### PR TITLE
Add game day page

### DIFF
--- a/about.html
+++ b/about.html
@@ -40,6 +40,7 @@
   <nav>
     <a href="index.html">М Ліга</a>
     <a href="sunday.html">С Ліга</a>
+    <a href="gameday.html">Ігровий день</a>
     <a href="rules.html">Правила</a>
     <a href="about.html" class="active">Про клуб</a>
   </nav>

--- a/gameday.html
+++ b/gameday.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ігровий день | Лазертаг</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Press Start 2P', monospace;
+      background: #111 url('assets/background_marathon.png') no-repeat center/cover;
+      color: #fff;
+      cursor: url('assets/cursor.png') 4 4, auto;
+    }
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 0.5rem;
+      background: rgba(0,0,0,0.7);
+      padding: 0.75rem;
+      font-size: 1rem;
+    }
+    nav a {
+      color: #f39c12;
+      text-decoration: none;
+      padding: 0.25rem 0.5rem;
+      transition: color 0.2s, background 0.2s;
+      border-radius: 3px;
+    }
+    nav a.active, nav a:hover {
+      color: #000;
+      background: #ffd700;
+    }
+    .container { max-width: 1200px; margin: 1rem auto; padding: 0 1rem; }
+    .filters { display:flex; flex-wrap:wrap; gap:0.5rem; justify-content:center; margin-bottom:1rem; }
+    select, input[type=date] {
+      padding:0.5rem; font-size:1rem; border:2px solid #555;
+      background:rgba(0,0,0,0.5); color:#fff; border-radius:4px;
+    }
+    table { width:100%; border-collapse:collapse; margin-bottom:1rem; font-size:0.9rem; }
+    th, td { border:1px solid #444; padding:0.5rem; text-align:center; }
+    thead th { background:#222; color:#f39c12; position:sticky; top:0; }
+    tbody tr:nth-child(odd){ background:rgba(255,255,255,0.05); }
+    .up   { color:lime; }
+    .down { color:red; }
+    @media (max-width: 600px) {
+      nav { font-size:0.75rem; }
+      table { font-size:0.75rem; }
+      select, input[type=date] { font-size:0.75rem; }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Молодша Ліга</a>
+    <a href="sunday.html">Старша Ліга</a>
+    <a href="gameday.html" class="active">Ігровий день</a>
+    <a href="rules.html">Правила</a>
+    <a href="about.html">Про клуб</a>
+  </nav>
+  <div class="container">
+    <div class="filters">
+      <select id="league">
+        <option value="kids">Молодша ліга</option>
+        <option value="sunday">Старша ліга</option>
+      </select>
+      <input type="date" id="date" />
+    </div>
+    <section>
+      <h2>Поточні гравці</h2>
+      <div class="table-container">
+        <table>
+          <thead><tr><th>Нік</th><th>Бали</th><th>Зміна</th></tr></thead>
+          <tbody id="players"></tbody>
+        </table>
+      </div>
+    </section>
+    <section>
+      <h2>Матчі сьогодні</h2>
+      <div class="table-container">
+        <table>
+          <thead><tr><th>Команда 1</th><th>Рахунок</th><th>Команда 2</th><th>MVP</th></tr></thead>
+          <tbody id="matches"></tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+  <script src="scripts/gameday.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
   <nav>
     <a href="index.html" class="active">Молодша Ліга</a>
     <a href="sunday.html">Старша Ліга</a>
+    <a href="gameday.html">Ігровий день</a>
     <a href="rules.html">Правила</a>
     <a href="about.html">Про клуб</a>
   </nav>

--- a/rules.html
+++ b/rules.html
@@ -94,6 +94,7 @@
   <nav>
     <a href="index.html">Молодша Ліга</a>
     <a href="sunday.html">Старша Ліга</a>
+    <a href="gameday.html">Ігровий день</a>
     <a href="rules.html" class="active">Правила</a>
     <a href="about.html">Про клуб</a>
   </nav>

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,0 +1,118 @@
+(function(){
+  const rankingURLs = {
+    kids: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv",
+    sunday: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv"
+  };
+  const gamesURL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv";
+
+  const alias = {
+    "Zavodchanyn": "Romario",
+    "Romario": "Zavodchanyn",
+    "Mariko": "Gidora",
+    "Timabuilding": "Бойбуд"
+  };
+
+  const leagueSel = document.getElementById('league');
+  const dateInput = document.getElementById('date');
+  const playersTb = document.getElementById('players');
+  const matchesTb = document.getElementById('matches');
+
+  leagueSel.addEventListener('change', loadData);
+  dateInput.addEventListener('change', loadData);
+  document.addEventListener('DOMContentLoaded', loadData);
+
+  function normName(n){ return alias[n] || n; }
+
+  function getRankLetter(pts){
+    if(pts>=1200) return 'S';
+    if(pts>=800 ) return 'A';
+    if(pts>=500 ) return 'B';
+    if(pts>=200 ) return 'C';
+    return 'D';
+  }
+  function partPoints(rank){
+    return {S:-15,A:-10,B:-5,C:0,D:5}[rank] || 0;
+  }
+
+  function parseDate(ts){
+    const d = new Date(ts);
+    if(isNaN(d)) return '';
+    return d.toISOString().slice(0,10);
+  }
+
+  async function loadData(){
+    if(!dateInput.value) return; // require date
+    const rURL = rankingURLs[leagueSel.value];
+    const [rText,gText] = await Promise.all([
+      fetch(rURL).then(r=>r.text()),
+      fetch(gamesURL).then(r=>r.text())
+    ]);
+    const ranking = Papa.parse(rText,{header:true,skipEmptyLines:true}).data;
+    const games   = Papa.parse(gText,{header:true,skipEmptyLines:true}).data;
+
+    const players = {};
+    ranking.forEach(r=>{
+      const name = normName(r.Nickname?.trim());
+      if(!name) return;
+      players[name] = {pts:+r.Points||0, delta:0};
+    });
+
+    const filtered = games.filter(g=>g.League===leagueSel.value)
+      .filter(g=>parseDate(g.Timestamp)===dateInput.value);
+
+    const matchRows = [];
+    filtered.forEach(g=>{
+      const t1 = g.Team1.split(',').map(s=>normName(s.trim()));
+      const t2 = g.Team2.split(',').map(s=>normName(s.trim()));
+      const winner = g.Winner;
+      const mvp = normName(g.MVP);
+      const s1 = parseInt(g.Score1,10);
+      const s2 = parseInt(g.Score2,10);
+
+      const team1Pts=[];
+      const team2Pts=[];
+      t1.forEach(n=>{
+        players[n] = players[n]||{pts:0,delta:0};
+        let d = partPoints(getRankLetter(players[n].pts));
+        if(winner==='team1') d+=20;
+        if(mvp===n) d+=10;
+        players[n].delta += d;
+        team1Pts.push(n+' ('+(d>0?'+':'')+d+')');
+      });
+      t2.forEach(n=>{
+        players[n] = players[n]||{pts:0,delta:0};
+        let d = partPoints(getRankLetter(players[n].pts));
+        if(winner==='team2') d+=20;
+        if(mvp===n) d+=10;
+        players[n].delta += d;
+        team2Pts.push(n+' ('+(d>0?'+':'')+d+')');
+      });
+      matchRows.push({
+        team1: team1Pts.join(', '),
+        team2: team2Pts.join(', '),
+        score: (!isNaN(s1)&&!isNaN(s2))?`${s1}:${s2}`:'-',
+        mvp
+      });
+    });
+
+    const list = Object.keys(players).filter(n=>players[n].delta!==0)
+      .map(n=>({nick:n,pts:players[n].pts,delta:players[n].delta}))
+      .sort((a,b)=>b.pts-a.pts);
+
+    playersTb.innerHTML='';
+    list.forEach(p=>{
+      const tr=document.createElement('tr');
+      const cls=p.delta>=0?'up':'down';
+      const arrow=p.delta>0?'▲':p.delta<0?'▼':'';
+      tr.innerHTML=`<td>${p.nick}</td><td>${p.pts}</td><td class="${cls}">${arrow} ${(p.delta>0?'+':'')+p.delta}</td>`;
+      playersTb.appendChild(tr);
+    });
+
+    matchesTb.innerHTML='';
+    matchRows.forEach(m=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${m.team1}</td><td>${m.score}</td><td>${m.team2}</td><td>${m.mvp}</td>`;
+      matchesTb.appendChild(tr);
+    });
+  }
+})();

--- a/sunday.html
+++ b/sunday.html
@@ -94,6 +94,7 @@
   <nav>
     <a href="index.html">Молодша Ліга</a>
     <a href="sunday.html" class="active">Старша Ліга</a>
+    <a href="gameday.html">Ігровий день</a>
     <a href="rules.html">Правила</a>
     <a href="about.html">Про клуб</a>
   </nav>


### PR DESCRIPTION
## Summary
- create `gameday.html` with retro style and responsive layout
- add script `scripts/gameday.js` to load rankings and games, filter by league and date, and render stats
- link `gameday.html` from navigation bars across the site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a4e07bfd08321987bfbe2cc85c5ed