### PR TITLE
Enhance match table with team totals

### DIFF
--- a/gameday.html
+++ b/gameday.html
@@ -34,7 +34,7 @@
       color: #000;
       background: #ffd700;
     }
-    .container { max-width: 1200px; margin: 1rem auto; padding: 0 1rem; }
+    .container { max-width: 1400px; margin: 1rem auto; padding: 0 1rem; }
     .filters { display:flex; flex-wrap:wrap; gap:0.5rem; justify-content:center; margin-bottom:1rem; }
     select, input[type=date], .filters button {
       padding:0.5rem; font-size:1rem; border:2px solid #555;
@@ -48,6 +48,16 @@
     tbody tr:nth-child(odd){ background:rgba(255,255,255,0.05); }
     .up   { color:lime; }
     .down { color:red; }
+    .team-label {
+      display:inline-block;
+      background:rgba(0,0,0,0.6);
+      padding:0.25rem 0.5rem;
+      border-radius:4px;
+    }
+    .vs {
+      color:#ffd700;
+      font-size:1.1rem;
+    }
     @media (max-width: 600px) {
       nav { font-size:0.75rem; }
       table { font-size:0.75rem; }

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -78,6 +78,8 @@
 
       const team1Pts=[];
       const team2Pts=[];
+      const t1sum = t1.reduce((s,n)=>s+(players[n]?.pts||0),0);
+      const t2sum = t2.reduce((s,n)=>s+(players[n]?.pts||0),0);
       t1.forEach(n=>{
         players[n] = players[n]||{pts:0,delta:0};
         let d = partPoints(getRankLetter(players[n].pts));
@@ -97,6 +99,8 @@
       matchRows.push({
         team1: team1Pts.join(', '),
         team2: team2Pts.join(', '),
+        t1sum,
+        t2sum,
         score: (!isNaN(s1)&&!isNaN(s2))?`${s1}:${s2}`:'-',
         mvp
       });
@@ -118,7 +122,10 @@
     matchesTb.innerHTML='';
     matchRows.forEach(m=>{
       const tr=document.createElement('tr');
-      tr.innerHTML=`<td>${m.team1}</td><td>${m.score}</td><td>${m.team2}</td><td>${m.mvp}</td>`;
+      tr.innerHTML=`<td class="team-label">🛡️ ${m.team1} [${m.t1sum}]</td>`+
+        `<td><span class="vs">⚔️ ${m.score} ⚔️</span></td>`+
+        `<td class="team-label">🚀 ${m.team2} [${m.t2sum}]</td>`+
+        `<td>${m.mvp}</td>`;
       matchesTb.appendChild(tr);
     });
   }


### PR DESCRIPTION
## Summary
- compute each team's total points in `gameday.js`
- display teams with their totals and decorative icons
- highlight the versus section and style team labels
- widen the container for large displays

## Testing
- `node -e "require('./scripts/gameday.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686a570284808321854033e5b748f409