### PR TITLE
Add position tracking to gameday view

### DIFF
--- a/gameday.html
+++ b/gameday.html
@@ -48,6 +48,12 @@
     tbody tr:nth-child(odd){ background:rgba(255,255,255,0.05); }
     .up   { color:lime; }
     .down { color:red; }
+    /* Nickname colors */
+    .nick-S { color: magenta; }
+    .nick-A { color: red; }
+    .nick-B { color: yellow; }
+    .nick-C { color: cyan; }
+    .nick-D { color: lime; }
     @media (max-width: 600px) {
       nav { font-size:0.75rem; }
       table { font-size:0.75rem; }
@@ -76,7 +82,11 @@
       <h2>Поточні гравці</h2>
       <div class="table-container">
         <table>
-          <thead><tr><th>Нік</th><th>Бали</th><th>Зміна</th></tr></thead>
+          <thead>
+            <tr>
+              <th>Позиція (попередня)</th><th>Нік</th><th>Бали</th><th>Зміна</th>
+            </tr>
+          </thead>
           <tbody id="players"></tbody>
         </table>
       </div>

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -102,16 +102,32 @@
       });
     });
 
-    const list = Object.keys(players).filter(n=>players[n].delta!==0)
-      .map(n=>({nick:n,pts:players[n].pts,delta:players[n].delta}))
-      .sort((a,b)=>b.pts-a.pts);
+    const all = Object.keys(players).map(n=>({
+      nick:n,
+      pts:players[n].pts + players[n].delta,
+      delta:players[n].delta
+    }));
+
+    const sortedNew = [...all].sort((a,b)=>b.pts-a.pts);
+    const sortedOld = [...all].sort((a,b)=>(b.pts - b.delta)-(a.pts - a.delta));
+
+    const posMap = {}; sortedNew.forEach((p,i)=>{posMap[p.nick]=i+1;});
+    const prevMap = {}; sortedOld.forEach((p,i)=>{prevMap[p.nick]=i+1;});
+
+    const list = sortedNew.filter(p=>p.delta!==0);
 
     playersTb.innerHTML='';
     list.forEach(p=>{
       const tr=document.createElement('tr');
       const cls=p.delta>=0?'up':'down';
       const arrow=p.delta>0?'▲':p.delta<0?'▼':'';
-      tr.innerHTML=`<td>${p.nick}</td><td>${p.pts}</td><td class="${cls}">${arrow} ${(p.delta>0?'+':'')+p.delta}</td>`;
+      const now=posMap[p.nick];
+      const prev=prevMap[p.nick];
+      const rank=getRankLetter(p.pts);
+      tr.innerHTML=`<td>#${now} (#${prev})</td>`+
+        `<td class="nick-${rank}">${p.nick}</td>`+
+        `<td>${p.pts}</td>`+
+        `<td class="${cls}">${arrow} ${(p.delta>0?'+':'')+p.delta}</td>`;
       playersTb.appendChild(tr);
     });
 


### PR DESCRIPTION
## Summary
- colorize nicknames on gameday page
- show previous position next to current position
- compute rankings before and after the day's matches

## Testing
- `node --check scripts/gameday.js`


------
https://chatgpt.com/codex/tasks/task_e_686a56fd3abc8321aedc3fc0ba649a16