### PR TITLE
Add fullscreen toggle to gameday page

### DIFF
--- a/gameday.html
+++ b/gameday.html
@@ -30,7 +30,21 @@
       transition: color 0.2s, background 0.2s;
       border-radius: 3px;
     }
+    nav #fullscreen {
+      color: #f39c12;
+      background: none;
+      border: none;
+      font: inherit;
+      cursor: pointer;
+      padding: 0.25rem 0.5rem;
+      transition: color 0.2s, background 0.2s;
+      border-radius: 3px;
+    }
     nav a.active, nav a:hover {
+      color: #000;
+      background: #ffd700;
+    }
+    nav #fullscreen:hover {
       color: #000;
       background: #ffd700;
     }
@@ -77,6 +91,7 @@
     <a href="gameday.html" class="active">Ігровий день</a>
     <a href="rules.html">Правила</a>
     <a href="about.html">Про клуб</a>
+    <button id="fullscreen">⛶</button>
   </nav>
   <div class="container">
     <div class="filters">

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -17,11 +17,21 @@
   const loadBtn   = document.getElementById('loadBtn');
   const playersTb = document.getElementById('players');
   const matchesTb = document.getElementById('matches');
+  const fullscreenBtn = document.getElementById('fullscreen');
 
   leagueSel.addEventListener('change', loadData);
   dateInput.addEventListener('change', loadData);
   if(loadBtn) loadBtn.addEventListener('click', loadData);
   document.addEventListener('DOMContentLoaded', loadData);
+  if(fullscreenBtn){
+    fullscreenBtn.addEventListener('click', () => {
+      if(!document.fullscreenElement){
+        document.documentElement.requestFullscreen();
+      }else{
+        document.exitFullscreen();
+      }
+    });
+  }
 
   function normName(n){ return alias[n] || n; }
 


### PR DESCRIPTION
## Summary
- add fullscreen button to `gameday.html`
- style the new button like the navigation links
- toggle fullscreen mode in `scripts/gameday.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a649a6ab88321ad01389427459de8