### PR TITLE
Improve gameday layout

### DIFF
--- a/gameday.html
+++ b/gameday.html
@@ -48,7 +48,21 @@
       color: #000;
       background: #ffd700;
     }
-    .container { max-width: 1400px; margin: 1rem auto; padding: 0 1rem; }
+    .container {
+      width: 100%;
+      max-width: 1920px;
+      margin: 1rem auto;
+      padding: 0 1rem;
+    }
+    .section-wrap {
+      display: grid;
+      gap: 1rem;
+    }
+    @media (min-width: 900px) {
+      .section-wrap {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
     .filters { display:flex; flex-wrap:wrap; gap:0.5rem; justify-content:center; margin-bottom:1rem; }
     select, input[type=date], .filters button {
       padding:0.5rem; font-size:1rem; border:2px solid #555;
@@ -56,8 +70,17 @@
       font-family: 'Press Start 2P', monospace;
       cursor:pointer;
     }
-    table { width:100%; border-collapse:collapse; margin-bottom:1rem; font-size:0.9rem; }
-    th, td { border:1px solid #444; padding:0.5rem; text-align:center; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 1rem;
+      font-size: 0.75rem;
+    }
+    th, td {
+      border: 1px solid #444;
+      padding: 0.4rem;
+      text-align: center;
+    }
     thead th { background:#222; color:#f39c12; position:sticky; top:0; }
     tbody tr:nth-child(odd){ background:rgba(255,255,255,0.05); }
     .up   { color:lime; }
@@ -102,6 +125,7 @@
       <input type="date" id="date" />
       <button id="loadBtn">Завантажити</button>
     </div>
+    <div class="section-wrap">
     <section>
       <h2>Поточні гравці</h2>
       <div class="table-container">
@@ -120,6 +144,7 @@
         </table>
       </div>
     </section>
+    </div>
   </div>
   <script src="scripts/gameday.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- make gameday container full width
- place "Поточні гравці" and "Матчі сьогодні" side by side with grid
- reduce table font and spacing so page fits a 1080p display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a65c64a1c832190c4801f7d77052e