### PR TITLE
Adjust team total layout

### DIFF
--- a/gameday.html
+++ b/gameday.html
@@ -93,19 +93,17 @@
     .nick-D { color: lime; }
     .team-label {
       position:relative;
-      display:inline-block;
+      display:flex;
+      align-items:center;
       background:rgba(0,0,0,0.6);
       padding:0.25rem 1.5rem 0.25rem 0.5rem;
       border-radius:4px;
     }
     .team-total {
-      position:absolute;
-      right:0.25rem;
-      top:50%;
-      transform:translateY(-50%);
       background:rgba(255,255,255,0.15);
       padding:0 0.25rem;
       border-radius:3px;
+      margin-left:auto;
     }
     .team-win {
       border:2px solid lime;


### PR DESCRIPTION
## Summary
- style `.team-label` as flex container
- remove absolute positioning from `.team-total` and align totals to the right

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a7a4f7130832198efa12c1c69174e