### PR TITLE
Improve error handling on gameday data fetch

### DIFF
--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -72,10 +72,21 @@
   async function loadData(){
     if(!dateInput.value) return; // require date
     const rURL = rankingURLs[leagueSel.value];
-    const [rText,gText] = await Promise.all([
-      fetch(rURL).then(r=>r.text()),
-      fetch(gamesURL).then(r=>r.text())
-    ]);
+    let rText, gText;
+    try{
+      [rText, gText] = await Promise.all([
+        fetch(rURL).then(r=>r.text()),
+        fetch(gamesURL).then(r=>r.text())
+      ]);
+    }catch(err){
+      playersTb.innerHTML = '';
+      matchesTb.innerHTML = '';
+      console.error('Failed to load gameday data', err);
+      if(typeof alert === 'function'){
+        alert('Failed to load gameday data. Please try again later.');
+      }
+      return;
+    }
     const ranking = Papa.parse(rText,{header:true,skipEmptyLines:true}).data;
     const games   = Papa.parse(gText,{header:true,skipEmptyLines:true}).data;
 


### PR DESCRIPTION
## Summary
- catch errors when loading gameday data
- clear tables and show an alert if the fetch fails

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a7e6571b0832182678fd8cf3dcb6f