### PR TITLE
Sanitize DOM rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,12 +228,19 @@
       const top = pl.slice().sort((a,b)=>b.mvp-a.mvp).slice(0,3);
       const el = document.getElementById('top-mvp'); el.innerHTML='';
       top.forEach(p=>{
-        const c = document.createElement('div'); c.className='mvp-card';
-        c.innerHTML = `
-          <div style="font-size:2rem">👑</div>
-          <h3 class="${getRankClass(p.points).replace('rank-','nick-')}">${p.nickname}</h3>
-          <div>${p.mvp} MVP</div>
-        `;
+        const c = document.createElement('div');
+        c.className='mvp-card';
+        const crown=document.createElement('div');
+        crown.style.fontSize='2rem';
+        crown.textContent='👑';
+        const h=document.createElement('h3');
+        h.className=getRankClass(p.points).replace('rank-','nick-');
+        h.textContent=p.nickname;
+        const stat=document.createElement('div');
+        stat.textContent=p.mvp+' MVP';
+        c.appendChild(crown);
+        c.appendChild(h);
+        c.appendChild(stat);
         el.appendChild(c);
       });
     }
@@ -269,16 +276,44 @@
         const tr = document.createElement('tr');
         const cls= getRankClass(p.points);
         tr.className = cls + (i>=10? ' hidden':'');
-        tr.innerHTML =
-          `<td>${i+1}</td>`+
-          `<td class="${cls.replace('rank-','nick-')}">${p.nickname}</td>`+
-          `<td>${cls.replace('rank-','')}</td>`+
-          `<td>${p.points}</td>`+
-          `<td>${p.games||'-'}</td>`+
-          `<td>${p.wins||'-'}</td>`+
-          `<td>${p.losses||'-'}</td>`+
-          `<td>${p.winRate}%</td>`+
-          `<td>${p.mvp||'-'}</td>`;
+
+        const rankCell=document.createElement('td');
+        rankCell.textContent=i+1;
+
+        const nickCell=document.createElement('td');
+        nickCell.className=cls.replace('rank-','nick-');
+        nickCell.textContent=p.nickname;
+
+        const rCell=document.createElement('td');
+        rCell.textContent=cls.replace('rank-','');
+
+        const ptsCell=document.createElement('td');
+        ptsCell.textContent=p.points;
+
+        const gamesCell=document.createElement('td');
+        gamesCell.textContent=p.games||'-';
+
+        const winsCell=document.createElement('td');
+        winsCell.textContent=p.wins||'-';
+
+        const lossesCell=document.createElement('td');
+        lossesCell.textContent=p.losses||'-';
+
+        const winRateCell=document.createElement('td');
+        winRateCell.textContent=p.winRate+'%';
+
+        const mvpCell=document.createElement('td');
+        mvpCell.textContent=p.mvp||'-';
+
+        tr.appendChild(rankCell);
+        tr.appendChild(nickCell);
+        tr.appendChild(rCell);
+        tr.appendChild(ptsCell);
+        tr.appendChild(gamesCell);
+        tr.appendChild(winsCell);
+        tr.appendChild(lossesCell);
+        tr.appendChild(winRateCell);
+        tr.appendChild(mvpCell);
         tb.appendChild(tr);
       });
     }

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -120,8 +120,7 @@
         if(winner==='team1') d+=20;
         if(mvp===n) d+=10;
         players[n].delta += d;
-        const span=`<span class="nick-${getRankLetter(players[n].pts)}">${n}</span>`;
-        team1Pts.push(span+' ('+(d>0?'+':'')+d+')');
+        team1Pts.push({nick:n,rank:getRankLetter(players[n].pts),delta:d});
       });
       t2.forEach(n=>{
         players[n] = players[n]||{pts:0,delta:0,wins:0,games:0};
@@ -131,18 +130,17 @@
         if(winner==='team2') d+=20;
         if(mvp===n) d+=10;
         players[n].delta += d;
-        const span=`<span class="nick-${getRankLetter(players[n].pts)}">${n}</span>`;
-        team2Pts.push(span+' ('+(d>0?'+':'')+d+')');
+        team2Pts.push({nick:n,rank:getRankLetter(players[n].pts),delta:d});
       });
       matchRows.push({
-        team1: team1Pts.join(', '),
-        team2: team2Pts.join(', '),
+        team1: team1Pts,
+        team2: team2Pts,
         t1sum,
         t2sum,
         score1: s1,
         score2: s2,
         winner,
-        mvp: `<span class="nick-${getRankLetter(players[mvp]?.pts||0)}">${mvp}</span>`
+        mvp: {nick:mvp,rank:getRankLetter(players[mvp]?.pts||0)}
       });
     });
 
@@ -172,13 +170,28 @@
       const cls=p.delta>=0?'up':'down';
       const arrow=p.delta>0?'▲':p.delta<0?'▼':'';
       const nClass='nick-'+getRankLetter(p.pts);
-      tr.innerHTML=
-        `<td>${p.currRank} (${p.prevRank})</td>`+
-        `<td class="${nClass}">${p.nick}</td>`+
-        `<td>${p.pts}</td>`+
-        `<td>${p.wins}</td>`+
-        `<td>${p.games}</td>`+
-        `<td class="${cls}">${arrow} ${(p.delta>0?'+':'')+p.delta}</td>`;
+
+      const rank=document.createElement('td');
+      rank.textContent=`${p.currRank} (${p.prevRank})`;
+
+      const nick=document.createElement('td');
+      nick.className=nClass;
+      nick.textContent=p.nick;
+
+      const pts=document.createElement('td');
+      pts.textContent=p.pts;
+
+      const wins=document.createElement('td');
+      wins.textContent=p.wins;
+
+      const games=document.createElement('td');
+      games.textContent=p.games;
+
+      const delta=document.createElement('td');
+      delta.className=cls;
+      delta.textContent=`${arrow} ${(p.delta>0?'+':'')+p.delta}`;
+
+      [rank,nick,pts,wins,games,delta].forEach(td=>tr.appendChild(td));
       playersTb.appendChild(tr);
     });
 
@@ -188,10 +201,52 @@
       const cls1=m.winner==='team1'?'team-win':m.winner==='team2'?'team-loss':'';
       const cls2=m.winner==='team2'?'team-win':m.winner==='team1'?'team-loss':'';
       const score=formatScore(m.score1,m.score2);
-      tr.innerHTML=`<td class="team-label ${cls1}">🛡️ ${m.team1}<span class="team-total">[${m.t1sum}]</span></td>`+
-        `<td><span class="vs">${score}</span></td>`+
-        `<td class="team-label ${cls2}">🚀 ${m.team2}<span class="team-total">[${m.t2sum}]</span></td>`+
-        `<td>${m.mvp}</td>`;
+
+      const td1=document.createElement('td');
+      td1.className='team-label '+cls1;
+      td1.textContent='🛡️ ';
+      m.team1.forEach((p,i)=>{
+        const span=document.createElement('span');
+        span.className='nick-'+p.rank;
+        span.textContent=p.nick;
+        td1.appendChild(span);
+        td1.appendChild(document.createTextNode(` (${p.delta>0?'+':''}${p.delta})`));
+        if(i<m.team1.length-1) td1.appendChild(document.createTextNode(', '));
+      });
+      const total1=document.createElement('span');
+      total1.className='team-total';
+      total1.textContent='['+m.t1sum+']';
+      td1.appendChild(total1);
+
+      const tdScore=document.createElement('td');
+      const vs=document.createElement('span');
+      vs.className='vs';
+      vs.textContent=score;
+      tdScore.appendChild(vs);
+
+      const td2=document.createElement('td');
+      td2.className='team-label '+cls2;
+      td2.textContent='🚀 ';
+      m.team2.forEach((p,i)=>{
+        const span=document.createElement('span');
+        span.className='nick-'+p.rank;
+        span.textContent=p.nick;
+        td2.appendChild(span);
+        td2.appendChild(document.createTextNode(` (${p.delta>0?'+':''}${p.delta})`));
+        if(i<m.team2.length-1) td2.appendChild(document.createTextNode(', '));
+      });
+      const total2=document.createElement('span');
+      total2.className='team-total';
+      total2.textContent='['+m.t2sum+']';
+      td2.appendChild(total2);
+
+      const tdMvp=document.createElement('td');
+      const mvpSpan=document.createElement('span');
+      mvpSpan.className='nick-'+m.mvp.rank;
+      mvpSpan.textContent=m.mvp.nick;
+      tdMvp.appendChild(mvpSpan);
+
+      [td1,tdScore,td2,tdMvp].forEach(td=>tr.appendChild(td));
       matchesTb.appendChild(tr);
     });
   }

--- a/sunday.html
+++ b/sunday.html
@@ -226,11 +226,21 @@
         top.forEach(p => {
           const card = document.createElement('div');
           card.className = 'mvp-card';
-          card.innerHTML = `
-            <h3>${p.nickname}</h3>
-            <div class="stats">${p.games} ігор | ${p.wins}W - ${p.losses}L | ${p.winRate}%</div>
-            <div class="stats">${p.mvp} MVP</div>
-          `;
+
+          const h = document.createElement('h3');
+          h.textContent = p.nickname;
+
+          const info = document.createElement('div');
+          info.className = 'stats';
+          info.textContent = `${p.games} ігор | ${p.wins}W - ${p.losses}L | ${p.winRate}%`;
+
+          const mvp = document.createElement('div');
+          mvp.className = 'stats';
+          mvp.textContent = `${p.mvp} MVP`;
+
+          card.appendChild(h);
+          card.appendChild(info);
+          card.appendChild(mvp);
           el.appendChild(card);
         });
       }
@@ -270,17 +280,36 @@
           const tr = document.createElement('tr');
           const cls = getRankClass(p.points);
           tr.className = i >= 10 ? cls + ' hidden' : cls;
-          tr.innerHTML = `
-            <td>${i + 1}</td>
-            <td class="nick-${cls.split('-')[1]}">${p.nickname}</td>
-            <td>${cls.split('-')[1]}</td>
-            <td>${p.points}</td>
-            <td>${p.games}</td>
-            <td>${p.wins}</td>
-            <td>${p.losses}</td>
-            <td>${p.winRate}%</td>
-            <td>${p.mvp}</td>
-          `;
+
+          const idx = document.createElement('td');
+          idx.textContent = i + 1;
+
+          const nick = document.createElement('td');
+          nick.className = 'nick-' + cls.split('-')[1];
+          nick.textContent = p.nickname;
+
+          const rank = document.createElement('td');
+          rank.textContent = cls.split('-')[1];
+
+          const pts = document.createElement('td');
+          pts.textContent = p.points;
+
+          const games = document.createElement('td');
+          games.textContent = p.games;
+
+          const wins = document.createElement('td');
+          wins.textContent = p.wins;
+
+          const losses = document.createElement('td');
+          losses.textContent = p.losses;
+
+          const rate = document.createElement('td');
+          rate.textContent = p.winRate + '%';
+
+          const mvp = document.createElement('td');
+          mvp.textContent = p.mvp;
+
+          [idx,nick,rank,pts,games,wins,losses,rate,mvp].forEach(td=>tr.appendChild(td));
           tb.appendChild(tr);
         });
       }


### PR DESCRIPTION
## Summary
- avoid innerHTML string building in index and sunday pages
- create DOM nodes with textContent for player lists and MVP cards
- sanitize gameday.js table construction

## Testing
- `node - <<'EOF' ...` (compile index.html)
- `node - <<'EOF' ...` (compile sunday.html)
- `node -c scripts/gameday.js`
- `node /tmp/testproj/test.js`
- `node /tmp/testproj/test_gameday.js`


------
https://chatgpt.com/codex/tasks/task_e_686c123dd10c83218d9f05e3c5636373