### PR TITLE
Default gameday date on load

### DIFF
--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -22,7 +22,10 @@
   leagueSel.addEventListener('change', loadData);
   dateInput.addEventListener('change', loadData);
   if(loadBtn) loadBtn.addEventListener('click', loadData);
-  document.addEventListener('DOMContentLoaded', loadData);
+  document.addEventListener('DOMContentLoaded', () => {
+    dateInput.value = new Date().toISOString().slice(0,10);
+    loadData();
+  });
   window.addEventListener('storage', e => {
     if(e.key === 'gamedayRefresh') loadData();
   });


### PR DESCRIPTION
## Summary
- auto-set the gameday date input to today in `gameday.js`

## Testing
- `node -e "require('./scripts/gameday.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686c1e4f83a483219357a8b9d960c8ad