### PR TITLE
Add avatar support

### DIFF
--- a/gameday.html
+++ b/gameday.html
@@ -92,6 +92,7 @@
     tbody tr:nth-child(odd){ background:rgba(255,255,255,0.05); }
     .up   { color:lime; }
     .down { color:red; }
+    .avatar-img { width:40px; height:40px; object-fit:cover; }
     .nick-S { color: magenta; }
     .nick-A { color: red; }
     .nick-B { color: yellow; }
@@ -145,7 +146,7 @@
       <h2>Поточні гравці</h2>
       <div class="table-container">
         <table>
-          <thead><tr><th>Позиція (попередня)</th><th>Нік</th><th>Бали</th><th>Перемоги</th><th>Ігор</th><th>Зміна</th></tr></thead>
+          <thead><tr><th>Позиція (попередня)</th><th>Аватар</th><th>Нік</th><th>Бали</th><th>Перемоги</th><th>Ігор</th><th>Зміна</th></tr></thead>
           <tbody id="players"></tbody>
         </table>
       </div>

--- a/index.html
+++ b/index.html
@@ -104,6 +104,7 @@
     th, td { padding: 0.5rem; border: 1px solid #444; text-align: center; }
     tbody tr:nth-child(odd) { background: rgba(255,255,255,0.05); }
     tbody tr:hover { background: rgba(255,255,255,0.1); }
+    .avatar-img { width: 40px; height: 40px; object-fit: cover; }
     /* Show-more Button */
     .show-more {
       display: block;
@@ -154,7 +155,7 @@
     <div class="table-container">
       <table>
         <thead><tr>
-          <th>Місце</th><th>Нікнейм</th><th>Ранг</th><th>Бали</th>
+          <th>Місце</th><th>Аватар</th><th>Нікнейм</th><th>Ранг</th><th>Бали</th>
           <th>Ігор</th><th>Перемог</th><th>Поразок</th><th>% Win</th><th>MVP</th>
         </tr></thead>
         <tbody id="ranking"></tbody>

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -187,6 +187,12 @@
       const rank=document.createElement('td');
       rank.textContent=`${p.currRank} (${p.prevRank})`;
 
+      const tdAvatar=document.createElement('td');
+      const img=document.createElement('img');
+      img.className='avatar-img';
+      img.src=localStorage.getItem('avatar:'+p.nick)||'https://via.placeholder.com/40';
+      tdAvatar.appendChild(img);
+
       const nick=document.createElement('td');
       nick.className=nClass;
       nick.textContent=p.nick;
@@ -204,7 +210,7 @@
       delta.className=cls;
       delta.textContent=`${arrow} ${(p.delta>0?'+':'')+p.delta}`;
 
-      [rank,nick,pts,wins,games,delta].forEach(td=>tr.appendChild(td));
+      [rank,tdAvatar,nick,pts,wins,games,delta].forEach(td=>tr.appendChild(td));
       playersTb.appendChild(tr);
     });
 

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -79,13 +79,35 @@ export function renderTable(list, tbodyEl){
     const cls=getRankClass(p.points);
     tr.className=cls+(i>=10?' hidden':'');
 
-    const cells=[i+1,p.nickname,cls.replace('rank-',''),p.points,p.games,p.wins,p.losses,p.winRate+'%',p.mvp];
-    cells.forEach((val,idx)=>{
+    const avatar=localStorage.getItem('avatar:'+p.nickname)||'https://via.placeholder.com/40';
+    const tdAvatar=document.createElement('td');
+    const img=document.createElement('img');
+    img.className='avatar-img';
+    img.src=avatar;
+    const input=document.createElement('input');
+    input.type='file';
+    input.accept='image/*';
+    input.addEventListener('change',e=>{
+      const file=e.target.files[0];
+      if(!file) return;
+      const reader=new FileReader();
+      reader.onload=ev=>{
+        localStorage.setItem('avatar:'+p.nickname,ev.target.result);
+        img.src=ev.target.result;
+      };
+      reader.readAsDataURL(file);
+    });
+    tdAvatar.appendChild(img);
+    tdAvatar.appendChild(input);
+
+    const vals=[i+1,p.nickname,cls.replace('rank-',''),p.points,p.games,p.wins,p.losses,p.winRate+'%',p.mvp];
+    vals.forEach((val,idx)=>{
       const td=document.createElement('td');
       if(idx===1) td.className=cls.replace('rank-','nick-');
       td.textContent=val;
       tr.appendChild(td);
     });
+    tr.insertBefore(tdAvatar,tr.children[1]);
     tbodyEl.appendChild(tr);
   });
 }

--- a/sunday.html
+++ b/sunday.html
@@ -80,6 +80,7 @@
     th, td { padding: 0.5rem; border: 1px solid #444; text-align: center; }
     tbody tr:nth-child(odd) { background: rgba(255,255,255,0.05); }
     tbody tr:hover { background: rgba(255,255,255,0.1); }
+    .avatar-img { width: 40px; height: 40px; object-fit: cover; }
     /* Кнопка */
     .show-more {
       display: block; margin: 1rem auto; padding: 0.75rem 1.5rem;
@@ -126,6 +127,7 @@
         <thead>
           <tr>
             <th>Місце</th>
+            <th>Аватар</th>
             <th>Нікнейм</th>
             <th>Ранг</th>
             <th>Бали</th>


### PR DESCRIPTION
## Summary
- add avatar column to ranking and gameday tables
- let users upload avatar images stored in localStorage
- display stored avatars in listings

## Testing
- `node -e "new Function(require('fs').readFileSync('scripts/ranking.js','utf8'));"` *(fails: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_686c1f7fab708321b8f8a67614f08265