### PR TITLE
Add admin mode for avatar uploads

### DIFF
--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,4 +1,7 @@
 (function(){
+  function isAdminMode(){
+    return localStorage.getItem('admin') === 'true';
+  }
   const rankingURLs = {
     kids: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv",
     sunday: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv"
@@ -192,6 +195,22 @@
       img.className='avatar-img';
       img.src=localStorage.getItem('avatar:'+p.nick)||'https://via.placeholder.com/40';
       tdAvatar.appendChild(img);
+      if(isAdminMode()){
+        const input=document.createElement('input');
+        input.type='file';
+        input.accept='image/*';
+        input.addEventListener('change',e=>{
+          const file=e.target.files[0];
+          if(!file) return;
+          const reader=new FileReader();
+          reader.onload=ev=>{
+            localStorage.setItem('avatar:'+p.nick,ev.target.result);
+            img.src=ev.target.result;
+          };
+          reader.readAsDataURL(file);
+        });
+        tdAvatar.appendChild(input);
+      }
 
       const nick=document.createElement('td');
       nick.className=nClass;

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -53,6 +53,10 @@ export function getRankClass(points){
   return 'rank-D';
 }
 
+export function isAdminMode(){
+  return localStorage.getItem('admin') === 'true';
+}
+
 export function renderChart(list, chartEl){
   const counts={S:0,A:0,B:0,C:0,D:0};
   list.forEach(p=>{
@@ -84,21 +88,23 @@ export function renderTable(list, tbodyEl){
     const img=document.createElement('img');
     img.className='avatar-img';
     img.src=avatar;
-    const input=document.createElement('input');
-    input.type='file';
-    input.accept='image/*';
-    input.addEventListener('change',e=>{
-      const file=e.target.files[0];
-      if(!file) return;
-      const reader=new FileReader();
-      reader.onload=ev=>{
-        localStorage.setItem('avatar:'+p.nickname,ev.target.result);
-        img.src=ev.target.result;
-      };
-      reader.readAsDataURL(file);
-    });
     tdAvatar.appendChild(img);
-    tdAvatar.appendChild(input);
+    if(isAdminMode()){
+      const input=document.createElement('input');
+      input.type='file';
+      input.accept='image/*';
+      input.addEventListener('change',e=>{
+        const file=e.target.files[0];
+        if(!file) return;
+        const reader=new FileReader();
+        reader.onload=ev=>{
+          localStorage.setItem('avatar:'+p.nickname,ev.target.result);
+          img.src=ev.target.result;
+        };
+        reader.readAsDataURL(file);
+      });
+      tdAvatar.appendChild(input);
+    }
 
     const vals=[i+1,p.nickname,cls.replace('rank-',''),p.points,p.games,p.wins,p.losses,p.winRate+'%',p.mvp];
     vals.forEach((val,idx)=>{


### PR DESCRIPTION
## Summary
- introduce `isAdminMode` helper
- only show avatar upload inputs when admin mode is enabled

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686c26bfdd4883219bcd7781dae233c6