### PR TITLE
Add avatar API endpoints and integrate uploads

### DIFF
--- a/avatar-worker.js
+++ b/avatar-worker.js
@@ -1,0 +1,41 @@
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const m = url.pathname.match(/^\/avatars\/(.+)$/);
+    if (!m) {
+      return new Response('Not found', { status: 404 });
+    }
+
+    const nick = decodeURIComponent(m[1]);
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+        },
+      });
+    }
+
+    if (request.method === 'GET') {
+      const { value, metadata } = await env.AVATARS.getWithMetadata(nick, {
+        type: 'arrayBuffer',
+      });
+      if (!value) {
+        return new Response('Not found', { status: 404, headers: { 'Access-Control-Allow-Origin': '*' } });
+      }
+      const ct = (metadata && metadata.contentType) || 'application/octet-stream';
+      return new Response(value, {
+        headers: { 'Content-Type': ct, 'Access-Control-Allow-Origin': '*' },
+      });
+    }
+
+    if (request.method === 'POST') {
+      const ct = request.headers.get('content-type') || 'application/octet-stream';
+      const buf = await request.arrayBuffer();
+      await env.AVATARS.put(nick, buf, { metadata: { contentType: ct } });
+      return new Response('OK', { headers: { 'Access-Control-Allow-Origin': '*' } });
+    }
+
+    return new Response('Method not allowed', { status: 405, headers: { 'Access-Control-Allow-Origin': '*' } });
+  },
+};

--- a/gameday.html
+++ b/gameday.html
@@ -162,6 +162,6 @@
     </section>
     </div>
   </div>
-  <script src="scripts/gameday.js"></script>
+  <script type="module" src="scripts/gameday.js"></script>
 </body>
 </html>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -48,3 +48,17 @@ export async function saveDetailedStats(matchId, statsArray) {
   });
   return res.text();
 }
+
+const avatarBase = `${proxyUrl}/avatars`;
+
+export function getAvatarURL(nick){
+  return `${avatarBase}/${encodeURIComponent(nick)}?t=${Date.now()}`;
+}
+
+export async function uploadAvatar(nick, file){
+  await fetch(`${avatarBase}/${encodeURIComponent(nick)}`, {
+    method: 'POST',
+    headers: { 'Content-Type': file.type || 'application/octet-stream' },
+    body: file,
+  });
+}

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,3 +1,4 @@
+import { uploadAvatar, getAvatarURL } from "./api.js";
 (function(){
   function isAdminMode(){
     return localStorage.getItem('admin') === 'true';
@@ -193,7 +194,8 @@
       const tdAvatar=document.createElement('td');
       const img=document.createElement('img');
       img.className='avatar-img';
-      img.src=localStorage.getItem('avatar:'+p.nick)||'https://via.placeholder.com/40';
+      img.src=getAvatarURL(p.nick);
+      img.onerror=()=>{img.src='https://via.placeholder.com/40';};
       tdAvatar.appendChild(img);
       if(isAdminMode()){
         const input=document.createElement('input');
@@ -202,12 +204,10 @@
         input.addEventListener('change',e=>{
           const file=e.target.files[0];
           if(!file) return;
-          const reader=new FileReader();
-          reader.onload=ev=>{
-            localStorage.setItem('avatar:'+p.nick,ev.target.result);
-            img.src=ev.target.result;
-          };
-          reader.readAsDataURL(file);
+          img.src=URL.createObjectURL(file);
+          uploadAvatar(p.nick,file).then(()=>{
+            img.src=getAvatarURL(p.nick);
+          });
         });
         tdAvatar.appendChild(input);
       }

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,3 +1,4 @@
+import { uploadAvatar, getAvatarURL } from "./api.js";
 export async function loadData(rankingURL, gamesURL){
   const [rText, gText] = await Promise.all([
     fetch(rankingURL).then(r=>r.text()),
@@ -83,11 +84,11 @@ export function renderTable(list, tbodyEl){
     const cls=getRankClass(p.points);
     tr.className=cls+(i>=10?' hidden':'');
 
-    const avatar=localStorage.getItem('avatar:'+p.nickname)||'https://via.placeholder.com/40';
     const tdAvatar=document.createElement('td');
     const img=document.createElement('img');
     img.className='avatar-img';
-    img.src=avatar;
+    img.src=getAvatarURL(p.nickname);
+    img.onerror=()=>{img.src='https://via.placeholder.com/40';};
     tdAvatar.appendChild(img);
     if(isAdminMode()){
       const input=document.createElement('input');
@@ -96,12 +97,10 @@ export function renderTable(list, tbodyEl){
       input.addEventListener('change',e=>{
         const file=e.target.files[0];
         if(!file) return;
-        const reader=new FileReader();
-        reader.onload=ev=>{
-          localStorage.setItem('avatar:'+p.nickname,ev.target.result);
-          img.src=ev.target.result;
-        };
-        reader.readAsDataURL(file);
+        img.src=URL.createObjectURL(file);
+        uploadAvatar(p.nickname,file).then(()=>{
+          img.src=getAvatarURL(p.nickname);
+        });
       });
       tdAvatar.appendChild(input);
     }


### PR DESCRIPTION
## Summary
- add `avatar-worker.js` with GET/POST avatar endpoints
- expose `getAvatarURL` and `uploadAvatar` in `scripts/api.js`
- fetch/upload avatars from ranking and gameday views
- run `gameday.js` as module to support imports

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e7aa79ef48321a5e68fc5a0b56ce3