### PR TITLE
Add avatar management admin section

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -100,6 +100,12 @@
         <button id="btn-clear-arena">Скинути арену</button>
       </div>
     </section>
+
+    <!-- 7. Адміністрування аватарів -->
+    <section id="avatar-admin" class="card hidden">
+      <h2>Керування аватарами</h2>
+      <ul id="avatar-list" class="list"></ul>
+    </section>
   </main>
 
   <!-- PDF.js -->
@@ -118,6 +124,7 @@
   <script type="module" src="scripts/teams.js"></script>
   <script type="module" src="scripts/scenario.js"></script>
   <script type="module" src="scripts/arena.js"></script>
+  <script type="module" src="scripts/avatarAdmin.js"></script>
   <script type="module" src="scripts/main.js"></script>
 </body>
 </html>

--- a/balancer.css
+++ b/balancer.css
@@ -62,4 +62,24 @@ button:hover{background:var(--accent-dark);}button:disabled{background:var(--tex
   flex-shrink: 0;
 }
 
+/* Avatar admin */
+#avatar-list {
+  list-style: none;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 0;
+}
+#avatar-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid #2e2e2e;
+}
+.avatar-img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+}
+
 

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,0 +1,53 @@
+// scripts/avatarAdmin.js
+import { uploadAvatar, getAvatarURL } from './api.js';
+
+function isAdminMode(){
+  return localStorage.getItem('admin') === 'true';
+}
+
+export function initAvatarAdmin(players){
+  const section = document.getElementById('avatar-admin');
+  if(!section) return;
+  if(!isAdminMode()){
+    section.classList.add('hidden');
+    return;
+  }
+  section.classList.remove('hidden');
+  const listEl = document.getElementById('avatar-list');
+  if(!listEl) return;
+  listEl.innerHTML = '';
+  players.forEach(p => {
+    const li = document.createElement('li');
+    const img = document.createElement('img');
+    img.className = 'avatar-img';
+    img.dataset.nick = p.nick;
+    img.src = getAvatarURL(p.nick);
+    img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.addEventListener('change', e => {
+      const file = e.target.files[0];
+      if(!file) return;
+      img.src = URL.createObjectURL(file);
+      uploadAvatar(p.nick, file).then(() => {
+        img.src = getAvatarURL(p.nick);
+        localStorage.setItem('avatarRefresh', Date.now().toString());
+      });
+    });
+    li.appendChild(img);
+    const span = document.createElement('span');
+    span.textContent = p.nick;
+    li.appendChild(span);
+    li.appendChild(input);
+    listEl.appendChild(li);
+  });
+}
+
+window.addEventListener('storage', e => {
+  if(e.key === 'avatarRefresh'){
+    document.querySelectorAll('#avatar-list img.avatar-img[data-nick]').forEach(img => {
+      img.src = getAvatarURL(img.dataset.nick);
+    });
+  }
+});

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -3,6 +3,12 @@ import { uploadAvatar, getAvatarURL } from "./api.js";
   function isAdminMode(){
     return localStorage.getItem('admin') === 'true';
   }
+
+  function refreshAvatars(){
+    document.querySelectorAll('img.avatar-img[data-nick]').forEach(img=>{
+      img.src=getAvatarURL(img.dataset.nick);
+    });
+  }
   const rankingURLs = {
     kids: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv",
     sunday: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv"
@@ -32,6 +38,7 @@ import { uploadAvatar, getAvatarURL } from "./api.js";
   });
   window.addEventListener('storage', e => {
     if(e.key === 'gamedayRefresh') loadData();
+    if(e.key === 'avatarRefresh') refreshAvatars();
   });
   if(fullscreenBtn){
     fullscreenBtn.addEventListener('click', () => {
@@ -194,6 +201,7 @@ import { uploadAvatar, getAvatarURL } from "./api.js";
       const tdAvatar=document.createElement('td');
       const img=document.createElement('img');
       img.className='avatar-img';
+      img.dataset.nick=p.nick;
       img.src=getAvatarURL(p.nick);
       img.onerror=()=>{img.src='https://via.placeholder.com/40';};
       tdAvatar.appendChild(img);
@@ -207,6 +215,8 @@ import { uploadAvatar, getAvatarURL } from "./api.js";
           img.src=URL.createObjectURL(file);
           uploadAvatar(p.nick,file).then(()=>{
             img.src=getAvatarURL(p.nick);
+            localStorage.setItem('avatarRefresh', Date.now().toString());
+            refreshAvatars();
           });
         });
         tdAvatar.appendChild(input);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,11 +3,13 @@
 import { loadPlayers } from './api.js';
 import { initLobby }   from './lobby.js';
 import { initScenario } from './scenario.js';
+import { initAvatarAdmin } from './avatarAdmin.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const btnLoad   = document.getElementById('btn-load');
   const leagueSel = document.getElementById('league');
   const scenArea  = document.getElementById('scenario-area');
+  initAvatarAdmin([]);
 
   if (!btnLoad || !leagueSel) {
     console.error('Не знайдено #btn-load або #league у DOM');
@@ -23,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const players = await loadPlayers(leagueSel.value);
       initLobby(players);          // Рендер лоббі
+      initAvatarAdmin(players);    // Рендер аватарів
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
     } catch (err) {
       console.error('Помилка loadPlayers:', err);
@@ -36,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // При зміні ліги — очищуємо поточне лоббі та ховаємо сценарій
   leagueSel.addEventListener('change', () => {
     initLobby([]);               // Порожнє лоббі
+    initAvatarAdmin([]);
     scenArea.classList.add('hidden');
   });
 });

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -87,6 +87,7 @@ export function renderTable(list, tbodyEl){
     const tdAvatar=document.createElement('td');
     const img=document.createElement('img');
     img.className='avatar-img';
+    img.dataset.nick=p.nickname;
     img.src=getAvatarURL(p.nickname);
     img.onerror=()=>{img.src='https://via.placeholder.com/40';};
     tdAvatar.appendChild(img);
@@ -100,6 +101,8 @@ export function renderTable(list, tbodyEl){
         img.src=URL.createObjectURL(file);
         uploadAvatar(p.nickname,file).then(()=>{
           img.src=getAvatarURL(p.nickname);
+          localStorage.setItem('avatarRefresh', Date.now().toString());
+          refreshAvatars();
         });
       });
       tdAvatar.appendChild(input);
@@ -164,4 +167,16 @@ export function formatD(d){
 export function formatFull(d){
   if(!d) return '-';
   return ('0'+d.getDate()).slice(-2)+'.'+('0'+(d.getMonth()+1)).slice(-2)+'.'+d.getFullYear();
+}
+
+export function refreshAvatars(){
+  document.querySelectorAll('img.avatar-img[data-nick]').forEach(img=>{
+    img.src=getAvatarURL(img.dataset.nick);
+  });
+}
+
+if(typeof window!=='undefined'){
+  window.addEventListener('storage',e=>{
+    if(e.key==='avatarRefresh') refreshAvatars();
+  });
 }


### PR DESCRIPTION
## Summary
- add avatar administration section with player thumbnails and upload
- refresh avatars across ranking and gameday pages via storage events
- support avatar admin initialization in main script
- style avatar admin list

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686e7c383dd08321a7610fdb47da504b