### PR TITLE
Add avatar admin button and remove admin mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Laser Tag Ranking
+
+This repository contains a small static web app used for managing and displaying laser tag rankings. The site is composed of several standalone HTML pages that load data from Google Sheets and from a simple Cloudflare Worker API.
+
+## Running the site locally
+
+The pages use ES modules, therefore they must be served via HTTP. Any static server will work, for example:
+
+```bash
+# from the repository root
+python3 -m http.server 8080
+```
+
+Then open `http://localhost:8080/index.html` in your browser. The other pages are accessible by replacing the file name in the address bar.
+
+### Available pages
+
+- **[`index.html`](index.html)** – ranking table for the Junior league.
+- **[`sunday.html`](sunday.html)** – ranking table for the Senior league.
+- **[`gameday.html`](gameday.html)** – daily matches and standings.
+- **[`balance.html`](balance.html)** – team balancer and arena helper.
+- **[`rules.html`](rules.html)** – club rules and scoring system.
+- **[`about.html`](about.html)** – small pixel arena demo.
+
+## Avatar management
+
+Avatar uploads are managed **only** through `balance.html`. The *Керування аватарами* section contains a file input next to each nickname and a **Зберегти аватари** button. Select the desired images, then click the button to upload them to the `/avatars/{nick}` API endpoint defined in `scripts/api.js`.
+
+If a player has no stored avatar the site will attempt to load a default image from `assets/default_avatars/{nick}.png` before falling back to a placeholder. Place any default avatars you want to use in that folder.
+
+### Server configuration
+
+The avatar API is implemented as a Cloudflare Worker found in [`avatar-worker.js`](avatar-worker.js). Deploy it with a KV namespace named `AVATARS` bound to the worker. A minimal `wrangler.toml` would look like:
+
+```toml
+name = "laser-proxy"
+main = "avatar-worker.js"
+compatibility_date = "2023-10-01"
+
+[[kv_namespaces]]
+binding = "AVATARS"
+id = "<namespace_id>"
+```
+
+Requests to `/avatars/<nick>` support `GET` for downloading and `POST` for uploading avatars. CORS headers are sent automatically so the pages can access the API from any origin.
+
+## Summary
+
+1. Start a static server in the repository root.
+2. Visit `index.html` or any other page listed above.
+3. Open `balance.html` to upload avatars or manage data.
+4. Ensure the Cloudflare Worker from `avatar-worker.js` is deployed if you need avatar uploads.

--- a/balance.html
+++ b/balance.html
@@ -102,10 +102,13 @@
     </section>
 
     <!-- 7. Адміністрування аватарів -->
-    <section id="avatar-admin" class="card hidden">
-      <h2>Керування аватарами</h2>
-      <ul id="avatar-list" class="list"></ul>
-    </section>
+      <section id="avatar-admin" class="card">
+        <h2>Керування аватарами</h2>
+        <ul id="avatar-list" class="list"></ul>
+        <div class="actions">
+          <button id="save-avatars" disabled>Зберегти аватари</button>
+        </div>
+      </section>
   </main>
 
   <!-- PDF.js -->

--- a/balancer.css
+++ b/balancer.css
@@ -82,4 +82,8 @@ button:hover{background:var(--accent-dark);}button:disabled{background:var(--tex
   object-fit: cover;
 }
 
+#save-avatars {
+  margin-top: 0.5rem;
+}
+
 

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -50,9 +50,14 @@ export async function saveDetailedStats(matchId, statsArray) {
 }
 
 const avatarBase = `${proxyUrl}/avatars`;
+const defaultAvatarBase = 'assets/default_avatars';
 
 export function getAvatarURL(nick){
   return `${avatarBase}/${encodeURIComponent(nick)}?t=${Date.now()}`;
+}
+
+export function getDefaultAvatarURL(nick){
+  return `${defaultAvatarBase}/${encodeURIComponent(nick)}.png`;
 }
 
 export async function uploadAvatar(nick, file){

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,28 +1,39 @@
 // scripts/avatarAdmin.js
-import { uploadAvatar, getAvatarURL } from './api.js';
+import { uploadAvatar, getAvatarURL, getDefaultAvatarURL } from './api.js';
 
-function isAdminMode(){
-  return localStorage.getItem('admin') === 'true';
-}
+let pending = {};
 
 export function initAvatarAdmin(players){
   const section = document.getElementById('avatar-admin');
   if(!section) return;
-  if(!isAdminMode()){
-    section.classList.add('hidden');
-    return;
-  }
-  section.classList.remove('hidden');
   const listEl = document.getElementById('avatar-list');
-  if(!listEl) return;
+  const saveBtn = document.getElementById('save-avatars');
+  if(!listEl || !saveBtn) return;
+  pending = {};
+  saveBtn.disabled = true;
   listEl.innerHTML = '';
+  saveBtn.onclick = async () => {
+    const entries = Object.entries(pending);
+    for(const [nick,obj] of entries){
+      await uploadAvatar(nick, obj.file);
+      obj.img.src = getAvatarURL(nick);
+    }
+    if(entries.length){
+      localStorage.setItem('avatarRefresh', Date.now().toString());
+    }
+    pending = {};
+    saveBtn.disabled = true;
+  };
   players.forEach(p => {
     const li = document.createElement('li');
     const img = document.createElement('img');
     img.className = 'avatar-img';
     img.dataset.nick = p.nick;
     img.src = getAvatarURL(p.nick);
-    img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
+    img.onerror = () => {
+      img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
+      img.src = getDefaultAvatarURL(p.nick);
+    };
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = 'image/*';
@@ -30,10 +41,8 @@ export function initAvatarAdmin(players){
       const file = e.target.files[0];
       if(!file) return;
       img.src = URL.createObjectURL(file);
-      uploadAvatar(p.nick, file).then(() => {
-        img.src = getAvatarURL(p.nick);
-        localStorage.setItem('avatarRefresh', Date.now().toString());
-      });
+      pending[p.nick] = { file, img };
+      saveBtn.disabled = false;
     });
     li.appendChild(img);
     const span = document.createElement('span');
@@ -48,6 +57,10 @@ window.addEventListener('storage', e => {
   if(e.key === 'avatarRefresh'){
     document.querySelectorAll('#avatar-list img.avatar-img[data-nick]').forEach(img => {
       img.src = getAvatarURL(img.dataset.nick);
+      img.onerror = () => {
+        img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
+        img.src = getDefaultAvatarURL(img.dataset.nick);
+      };
     });
   }
 });

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,8 +1,5 @@
-import { uploadAvatar, getAvatarURL } from "./api.js";
+import { getAvatarURL, getDefaultAvatarURL } from "./api.js";
 (function(){
-  function isAdminMode(){
-    return localStorage.getItem('admin') === 'true';
-  }
 
   function refreshAvatars(){
     document.querySelectorAll('img.avatar-img[data-nick]').forEach(img=>{
@@ -203,24 +200,11 @@ import { uploadAvatar, getAvatarURL } from "./api.js";
       img.className='avatar-img';
       img.dataset.nick=p.nick;
       img.src=getAvatarURL(p.nick);
-      img.onerror=()=>{img.src='https://via.placeholder.com/40';};
+      img.onerror=()=>{
+        img.onerror=()=>{img.src='https://via.placeholder.com/40';};
+        img.src=getDefaultAvatarURL(p.nick);
+      };
       tdAvatar.appendChild(img);
-      if(isAdminMode()){
-        const input=document.createElement('input');
-        input.type='file';
-        input.accept='image/*';
-        input.addEventListener('change',e=>{
-          const file=e.target.files[0];
-          if(!file) return;
-          img.src=URL.createObjectURL(file);
-          uploadAvatar(p.nick,file).then(()=>{
-            img.src=getAvatarURL(p.nick);
-            localStorage.setItem('avatarRefresh', Date.now().toString());
-            refreshAvatars();
-          });
-        });
-        tdAvatar.appendChild(input);
-      }
 
       const nick=document.createElement('td');
       nick.className=nClass;

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,4 +1,4 @@
-import { uploadAvatar, getAvatarURL } from "./api.js";
+import { getAvatarURL, getDefaultAvatarURL } from "./api.js";
 export async function loadData(rankingURL, gamesURL){
   const [rText, gText] = await Promise.all([
     fetch(rankingURL).then(r=>r.text()),
@@ -54,9 +54,6 @@ export function getRankClass(points){
   return 'rank-D';
 }
 
-export function isAdminMode(){
-  return localStorage.getItem('admin') === 'true';
-}
 
 export function renderChart(list, chartEl){
   const counts={S:0,A:0,B:0,C:0,D:0};
@@ -89,24 +86,11 @@ export function renderTable(list, tbodyEl){
     img.className='avatar-img';
     img.dataset.nick=p.nickname;
     img.src=getAvatarURL(p.nickname);
-    img.onerror=()=>{img.src='https://via.placeholder.com/40';};
+    img.onerror=()=>{
+      img.onerror=()=>{img.src='https://via.placeholder.com/40';};
+      img.src=getDefaultAvatarURL(p.nickname);
+    };
     tdAvatar.appendChild(img);
-    if(isAdminMode()){
-      const input=document.createElement('input');
-      input.type='file';
-      input.accept='image/*';
-      input.addEventListener('change',e=>{
-        const file=e.target.files[0];
-        if(!file) return;
-        img.src=URL.createObjectURL(file);
-        uploadAvatar(p.nickname,file).then(()=>{
-          img.src=getAvatarURL(p.nickname);
-          localStorage.setItem('avatarRefresh', Date.now().toString());
-          refreshAvatars();
-        });
-      });
-      tdAvatar.appendChild(input);
-    }
 
     const vals=[i+1,p.nickname,cls.replace('rank-',''),p.points,p.games,p.wins,p.losses,p.winRate+'%',p.mvp];
     vals.forEach((val,idx)=>{


### PR DESCRIPTION
## Summary
- allow avatar uploads without admin mode
- add Save Avatars button in balance page
- document avatar workflow in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e7e6fe3288321b2a0ee8a46dfc337