### PR TITLE
Optimize mobile league tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
     @keyframes pulse { 0%,100% { box-shadow:0 0 8px rgba(243,156,18,.6); } 50% { box-shadow:0 0 16px rgba(243,156,18,1); } }
     /* Table */
     .table-container { overflow-x: auto; margin-bottom: 1rem; }
-    table { width: 100%; border-collapse: collapse; min-width: 800px; font-size: 0.75rem; }
+    table { width: 100%; border-collapse: collapse; min-width: 600px; font-size: 0.75rem; }
     thead th {
       position: sticky; top: 0;
       background: #222;
@@ -135,7 +135,7 @@
     .nick-C { color: cyan; }
     .nick-D { color: lime; }
     .hidden { display: none; }
-    @media(max-width:600px) { table { min-width:600px; } .mvp-card { min-width:45%; } }
+    @media(max-width:600px) { table { min-width:480px; } .mvp-card { min-width:45%; } }
   </style>
 </head>
 <body>
@@ -156,7 +156,7 @@
       <table>
         <thead><tr>
           <th>Місце</th><th>Аватар</th><th>Нікнейм</th><th>Ранг</th><th>Бали</th>
-          <th>Ігор</th><th>Перемог</th><th>Поразок</th><th>% Win</th><th>MVP</th>
+          <th>Ігор</th><th>% Win</th><th>MVP</th>
         </tr></thead>
         <tbody id="ranking"></tbody>
       </table>

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -92,7 +92,7 @@ export function renderTable(list, tbodyEl){
     };
     tdAvatar.appendChild(img);
 
-    const vals=[i+1,p.nickname,cls.replace('rank-',''),p.points,p.games,p.wins,p.losses,p.winRate+'%',p.mvp];
+    const vals=[i+1,p.nickname,cls.replace('rank-',''),p.points,p.games,p.winRate+'%',p.mvp];
     vals.forEach((val,idx)=>{
       const td=document.createElement('td');
       if(idx===1) td.className=cls.replace('rank-','nick-');

--- a/sunday.html
+++ b/sunday.html
@@ -72,7 +72,7 @@
     .mvp-card .stats { font-size: 0.7rem; margin-top: 0.25rem; color: #ccc; }
     /* Таблиця */
     .table-container { overflow-x: auto; margin-bottom: 1rem; }
-    table { width: 100%; border-collapse: collapse; min-width: 800px; font-size: 0.75rem; }
+    table { width: 100%; border-collapse: collapse; min-width: 600px; font-size: 0.75rem; }
     thead th {
       position: sticky; top: 0; background: #222; color: #f39c12;
       padding: 0.75rem; border-bottom: 2px solid #555; z-index: 1;
@@ -102,7 +102,7 @@
     .nick-D { color: lime; }
     .hidden { display: none; }
     @media(max-width:600px) {
-      table { min-width: 100%; }
+      table { min-width: 480px; }
       nav { gap: 0.5rem; padding: 0.5rem; }
       nav a { font-size: 0.6rem; padding: 0.25rem; }
     }
@@ -132,8 +132,6 @@
             <th>Ранг</th>
             <th>Бали</th>
             <th>Ігор</th>
-            <th>Перемог</th>
-            <th>Поразок</th>
             <th>% Win</th>
             <th>MVP</th>
           </tr>


### PR DESCRIPTION
## Summary
- trim ranking tables for kids and adult leagues
- narrow table widths for mobile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686fce8674948321930eb28050388502