### PR TITLE
Add gender data support

### DIFF
--- a/assets/player_gender.json
+++ b/assets/player_gender.json
@@ -1,0 +1,8 @@
+{
+  "Romario": "m",
+  "Zavodchanyn": "m",
+  "Mariko": "f",
+  "Gidora": "f",
+  "Timabuilding": "m",
+  "Бойбуд": "m"
+}

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,10 +1,25 @@
 // scripts/api.js
 
 const proxyUrl = 'https://laser-proxy.vartaclub.workers.dev';
+const gendersURL = 'assets/player_gender.json';
+
+export async function loadGenders(){
+  try{
+    const res = await fetch(gendersURL);
+    if(!res.ok) throw new Error('HTTP '+res.status);
+    return await res.json();
+  }catch(err){
+    console.error('Failed to load genders', err);
+    return {};
+  }
+}
 
 
 export async function loadPlayers(league) {
-  const res = await fetch(`${proxyUrl}?league=${league}&t=${Date.now()}`);
+  const [genders, res] = await Promise.all([
+    loadGenders(),
+    fetch(`${proxyUrl}?league=${league}&t=${Date.now()}`)
+  ]);
   const txt = await res.text();
   return txt
     .trim()
@@ -19,7 +34,7 @@ export async function loadPlayers(league) {
                  : pts < 800  ? 'B'
                  : pts < 1200 ? 'A'
                  :              'S';
-      return { nick, pts, rank };
+      return { nick, pts, rank, gender: genders[nick] };
     });
 }
 


### PR DESCRIPTION
## Summary
- provide `assets/player_gender.json` for gender lookup
- expose `loadGenders()` in `api.js`
- augment `loadPlayers()` to include gender info from the JSON file

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687a6de00870832194d9d2e6a2caf46b