### PR TITLE
Add gender management in avatar admin

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -103,7 +103,7 @@
 
     <!-- 7. Адміністрування аватарів -->
       <section id="avatar-admin" class="card">
-        <h2>Керування аватарами</h2>
+        <h2>Керування аватарами та статтю</h2>
         <ul id="avatar-list" class="list"></ul>
         <div class="actions">
           <button id="save-avatars" disabled>Зберегти аватари</button>

--- a/gender-worker.js
+++ b/gender-worker.js
@@ -1,0 +1,48 @@
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if(url.pathname === '/genders' && request.method === 'GET'){
+      const list = await env.GENDERS.list();
+      const out = {};
+      for(const k of list.keys){
+        const v = await env.GENDERS.get(k.name);
+        out[k.name] = v;
+      }
+      return new Response(JSON.stringify(out), {
+        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+      });
+    }
+
+    const m = url.pathname.match(/^\/genders\/(.+)$/);
+    if(!m){
+      return new Response('Not found', { status: 404 });
+    }
+
+    const nick = decodeURIComponent(m[1]);
+    if(request.method === 'OPTIONS'){
+      return new Response(null, {
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+        },
+      });
+    }
+
+    if(request.method === 'POST'){
+      const { gender } = await request.json();
+      await env.GENDERS.put(nick, gender);
+      return new Response('OK', { headers: { 'Access-Control-Allow-Origin': '*' } });
+    }
+
+    if(request.method === 'GET'){
+      const gender = await env.GENDERS.get(nick);
+      if(!gender){
+        return new Response('Not found', { status: 404, headers: { 'Access-Control-Allow-Origin': '*' } });
+      }
+      return new Response(gender, { headers: { 'Content-Type': 'text/plain', 'Access-Control-Allow-Origin': '*' } });
+    }
+
+    return new Response('Method not allowed', { status: 405, headers: { 'Access-Control-Allow-Origin': '*' } });
+  },
+};

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,7 +1,8 @@
 // scripts/avatarAdmin.js
-import { uploadAvatar, getAvatarURL, getDefaultAvatarURL } from './api.js';
+import { uploadAvatar, getAvatarURL, getDefaultAvatarURL, saveGender } from './api.js';
 
 let pending = {};
+let genderChanges = {};
 
 export function initAvatarAdmin(players){
   const section = document.getElementById('avatar-admin');
@@ -10,18 +11,26 @@ export function initAvatarAdmin(players){
   const saveBtn = document.getElementById('save-avatars');
   if(!listEl || !saveBtn) return;
   pending = {};
+  genderChanges = {};
   saveBtn.disabled = true;
   listEl.innerHTML = '';
   saveBtn.onclick = async () => {
     const entries = Object.entries(pending);
+    const genderEntries = Object.entries(genderChanges);
     for(const [nick,obj] of entries){
       await uploadAvatar(nick, obj.file);
       obj.img.src = getAvatarURL(nick);
     }
-    if(entries.length){
+    for(const [nick,gender] of genderEntries){
+      await saveGender(nick, gender);
+      const img = listEl.querySelector(`img[data-nick="${nick}"]`);
+      if(img) img.dataset.gender = gender;
+    }
+    if(entries.length || genderEntries.length){
       localStorage.setItem('avatarRefresh', Date.now().toString());
     }
     pending = {};
+    genderChanges = {};
     saveBtn.disabled = true;
   };
   players.forEach(p => {
@@ -45,11 +54,28 @@ export function initAvatarAdmin(players){
       pending[p.nick] = { file, img };
       saveBtn.disabled = false;
     });
+
+    const genderSel = document.createElement('select');
+    const optM = document.createElement('option');
+    optM.value = 'male';
+    optM.textContent = 'Male';
+    const optF = document.createElement('option');
+    optF.value = 'female';
+    optF.textContent = 'Female';
+    genderSel.appendChild(optM);
+    genderSel.appendChild(optF);
+    genderSel.value = p.gender || '';
+    genderSel.addEventListener('change', e => {
+      genderChanges[p.nick] = e.target.value;
+      saveBtn.disabled = false;
+    });
+
     li.appendChild(img);
     const span = document.createElement('span');
     span.textContent = p.nick;
     li.appendChild(span);
     li.appendChild(input);
+    li.appendChild(genderSel);
     listEl.appendChild(li);
   });
 }


### PR DESCRIPTION
## Summary
- allow setting player gender in the avatar admin UI
- persist genders via new API functions
- update heading in avatar admin section
- provide Cloudflare worker for gender storage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a71c233a083218a9a8a1479a0ddd1