### PR TITLE
Implement custom avatar uploading

### DIFF
--- a/github-avatar-worker.js
+++ b/github-avatar-worker.js
@@ -1,0 +1,68 @@
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const m = url.pathname.match(/^\/custom_avatars\/(.+)$/);
+    if (!m) {
+      return new Response('Not found', { status: 404 });
+    }
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'POST,OPTIONS',
+        },
+      });
+    }
+    if (request.method !== 'POST') {
+      return new Response('Method not allowed', {
+        status: 405,
+        headers: { 'Access-Control-Allow-Origin': '*' },
+      });
+    }
+    const nick = decodeURIComponent(m[1]);
+    const buf = await request.arrayBuffer();
+    const base64 = btoa(String.fromCharCode(...new Uint8Array(buf)));
+    const repo = env.GH_REPO;
+    const token = env.GH_TOKEN;
+    const path = `assets/custom_avatars/${nick}.png`;
+    const apiURL = `https://api.github.com/repos/${repo}/contents/${path}`;
+
+    let sha;
+    const getRes = await fetch(apiURL, {
+      headers: { Authorization: `token ${token}` },
+    });
+    if (getRes.ok) {
+      const data = await getRes.json();
+      sha = data.sha;
+    }
+
+    const body = {
+      message: `Upload avatar for ${nick}`,
+      content: base64,
+      encoding: 'base64',
+    };
+    if (sha) body.sha = sha;
+
+    const putRes = await fetch(apiURL, {
+      method: 'PUT',
+      headers: {
+        Authorization: `token ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!putRes.ok) {
+      const text = await putRes.text();
+      return new Response(text, {
+        status: 500,
+        headers: { 'Access-Control-Allow-Origin': '*' },
+      });
+    }
+
+    return new Response('OK', {
+      headers: { 'Access-Control-Allow-Origin': '*' },
+    });
+  },
+};
+

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -83,9 +83,15 @@ export async function saveDetailedStats(matchId, statsArray) {
 }
 
 const avatarBase = `${proxyUrl}/avatars`;
+const customAvatarUploadBase = `${proxyUrl}/custom_avatars`;
+const customAvatarBase = 'assets/custom_avatars';
 const defaultAvatarBase = 'assets/default_avatars';
 
 export function getAvatarURL(nick){
+  return `${customAvatarBase}/${encodeURIComponent(nick)}.png?t=${Date.now()}`;
+}
+
+export function getProxyAvatarURL(nick){
   return `${avatarBase}/${encodeURIComponent(nick)}?t=${Date.now()}`;
 }
 
@@ -96,7 +102,7 @@ export function getDefaultAvatarURL(gender){
 }
 
 export async function uploadAvatar(nick, file){
-  await fetch(`${avatarBase}/${encodeURIComponent(nick)}`, {
+  await fetch(`${customAvatarUploadBase}/${encodeURIComponent(nick)}`, {
     method: 'POST',
     headers: { 'Content-Type': file.type || 'application/octet-stream' },
     body: file,

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,5 +1,5 @@
 // scripts/avatarAdmin.js
-import { uploadAvatar, getAvatarURL, getDefaultAvatarURL, saveGender } from './api.js';
+import { uploadAvatar, getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL, saveGender } from './api.js';
 
 let pending = {};
 let genderChanges = {};
@@ -41,8 +41,11 @@ export function initAvatarAdmin(players){
     if(p.gender) img.dataset.gender = p.gender;
     img.src = getAvatarURL(p.nick);
     img.onerror = () => {
-      img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
-      img.src = getDefaultAvatarURL(p.gender);
+      img.onerror = () => {
+        img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
+        img.src = getDefaultAvatarURL(p.gender);
+      };
+      img.src = getProxyAvatarURL(p.nick);
     };
     const input = document.createElement('input');
     input.type = 'file';
@@ -85,8 +88,11 @@ window.addEventListener('storage', e => {
     document.querySelectorAll('#avatar-list img.avatar-img[data-nick]').forEach(img => {
       img.src = getAvatarURL(img.dataset.nick);
       img.onerror = () => {
-        img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
-        img.src = getDefaultAvatarURL(img.dataset.gender);
+        img.onerror = () => {
+          img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
+          img.src = getDefaultAvatarURL(img.dataset.gender);
+        };
+        img.src = getProxyAvatarURL(img.dataset.nick);
       };
     });
   }

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,9 +1,16 @@
-import { getAvatarURL, getDefaultAvatarURL } from "./api.js";
+import { getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL } from "./api.js";
 (function(){
 
   function refreshAvatars(){
     document.querySelectorAll('img.avatar-img[data-nick]').forEach(img=>{
       img.src=getAvatarURL(img.dataset.nick);
+      img.onerror=()=>{
+        img.onerror=()=>{
+          img.onerror=()=>{img.src='https://via.placeholder.com/40';};
+          img.src=getDefaultAvatarURL(img.dataset.gender);
+        };
+        img.src=getProxyAvatarURL(img.dataset.nick);
+      };
     });
   }
   const rankingURLs = {
@@ -202,8 +209,11 @@ import { getAvatarURL, getDefaultAvatarURL } from "./api.js";
       if(p.gender) img.dataset.gender=p.gender;
       img.src=getAvatarURL(p.nick);
       img.onerror=()=>{
-        img.onerror=()=>{img.src='https://via.placeholder.com/40';};
-        img.src=getDefaultAvatarURL(p.gender);
+        img.onerror=()=>{
+          img.onerror=()=>{img.src='https://via.placeholder.com/40';};
+          img.src=getDefaultAvatarURL(p.gender);
+        };
+        img.src=getProxyAvatarURL(p.nick);
       };
       tdAvatar.appendChild(img);
 

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,4 +1,4 @@
-import { getAvatarURL, getDefaultAvatarURL } from "./api.js";
+import { getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL } from "./api.js";
 export async function loadData(rankingURL, gamesURL){
   const [rText, gText] = await Promise.all([
     fetch(rankingURL).then(r=>r.text()),
@@ -88,8 +88,11 @@ export function renderTable(list, tbodyEl){
     if(p.gender) img.dataset.gender=p.gender;
     img.src=getAvatarURL(p.nickname);
     img.onerror=()=>{
-      img.onerror=()=>{img.src='https://via.placeholder.com/40';};
-      img.src=getDefaultAvatarURL(p.gender);
+      img.onerror=()=>{
+        img.onerror=()=>{img.src='https://via.placeholder.com/40';};
+        img.src=getDefaultAvatarURL(p.gender);
+      };
+      img.src=getProxyAvatarURL(p.nickname);
     };
     tdAvatar.appendChild(img);
 
@@ -157,6 +160,13 @@ export function formatFull(d){
 export function refreshAvatars(){
   document.querySelectorAll('img.avatar-img[data-nick]').forEach(img=>{
     img.src=getAvatarURL(img.dataset.nick);
+    img.onerror=()=>{
+      img.onerror=()=>{
+        img.onerror=()=>{img.src='https://via.placeholder.com/40';};
+        img.src=getDefaultAvatarURL(img.dataset.gender);
+      };
+      img.src=getProxyAvatarURL(img.dataset.nick);
+    };
   });
 }
 


### PR DESCRIPTION
## Summary
- add custom avatar upload worker that commits images to repo
- store avatars in `assets/custom_avatars`
- check custom avatar before proxy in `getAvatarURL`
- update avatar admin, ranking and gameday scripts to use new logic

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a7553a648832189911e62edf38c33