### PR TITLE
Add gender management

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -107,6 +107,7 @@
         <ul id="avatar-list" class="list"></ul>
         <div class="actions">
           <button id="save-avatars" disabled>Зберегти аватари</button>
+          <button id="save-genders" disabled>Зберегти стать</button>
         </div>
       </section>
   </main>

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,4 +1,4 @@
-import { getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL } from "./api.js";
+import { getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL, loadGenders } from "./api.js";
 (function(){
 
   function refreshAvatars(){
@@ -11,6 +11,14 @@ import { getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL } from "./api.js";
         };
         img.src=getProxyAvatarURL(img.dataset.nick);
       };
+    });
+  }
+
+  async function refreshGenders(){
+    const genders = await loadGenders();
+    document.querySelectorAll('img.avatar-img[data-nick]').forEach(img=>{
+      const g = genders[img.dataset.nick];
+      if(g) img.dataset.gender = g;
     });
   }
   const rankingURLs = {
@@ -43,6 +51,7 @@ import { getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL } from "./api.js";
   window.addEventListener('storage', e => {
     if(e.key === 'gamedayRefresh') loadData();
     if(e.key === 'avatarRefresh') refreshAvatars();
+    if(e.key === 'genderRefresh') refreshGenders();
   });
   if(fullscreenBtn){
     fullscreenBtn.addEventListener('click', () => {

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,4 +1,4 @@
-import { getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL } from "./api.js";
+import { getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL, loadGenders } from "./api.js";
 export async function loadData(rankingURL, gamesURL){
   const [rText, gText] = await Promise.all([
     fetch(rankingURL).then(r=>r.text()),
@@ -170,8 +170,17 @@ export function refreshAvatars(){
   });
 }
 
+export async function refreshGenders(){
+  const genders = await loadGenders();
+  document.querySelectorAll('img.avatar-img[data-nick]').forEach(img=>{
+    const g = genders[img.dataset.nick];
+    if(g) img.dataset.gender = g;
+  });
+}
+
 if(typeof window!=='undefined'){
   window.addEventListener('storage',e=>{
     if(e.key==='avatarRefresh') refreshAvatars();
+    if(e.key==='genderRefresh') refreshGenders();
   });
 }


### PR DESCRIPTION
## Summary
- add a separate button for gender saving
- split avatar and gender saves in `avatarAdmin.js`
- refresh gender info via `genderRefresh` storage message
- update scoreboard and gameday views when gender data changes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a94982cdc8321a11c72d4810722b5