### PR TITLE
Add neutral avatar fix and improve gender saving

### DIFF
--- a/gender-worker.js
+++ b/gender-worker.js
@@ -25,6 +25,7 @@ export default {
         headers: {
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type'
         },
       });
     }
@@ -32,7 +33,7 @@ export default {
     if(request.method === 'POST'){
       const { gender } = await request.json();
       await env.GENDERS.put(nick, gender);
-      return new Response('OK', { headers: { 'Access-Control-Allow-Origin': '*' } });
+      return new Response('OK', { headers: { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Headers': 'Content-Type' } });
     }
 
     if(request.method === 'GET'){

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -96,9 +96,13 @@ export function getProxyAvatarURL(nick){
 }
 
 export function getDefaultAvatarURL(gender){
-  return gender === 'female'
-    ? 'assets/default_avatars/av1.png'
-    : 'assets/default_avatars/av2.png';
+  if(gender === 'female'){
+    return 'assets/default_avatars/av1.png';
+  }
+  if(gender === 'male'){
+    return 'assets/default_avatars/av2.png';
+  }
+  return 'assets/default_avatars/av3.png';
 }
 
 export async function uploadAvatar(nick, file){
@@ -111,11 +115,12 @@ export async function uploadAvatar(nick, file){
 
 export async function saveGender(nick, gender){
   try{
-    await fetch(`${proxyUrl}/genders/${encodeURIComponent(nick)}`, {
+    const res = await fetch(`${proxyUrl}/genders/${encodeURIComponent(nick)}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ gender })
     });
+    if(!res.ok) throw new Error('HTTP '+res.status);
   }catch(err){
     const data = JSON.parse(localStorage.getItem('player_genders') || '{}');
     data[nick] = gender;

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -74,9 +74,13 @@ export function initAvatarAdmin(players){
     const optF = document.createElement('option');
     optF.value = 'female';
     optF.textContent = 'Female';
+    const optN = document.createElement('option');
+    optN.value = 'neutral';
+    optN.textContent = 'Neutral';
     genderSel.appendChild(optM);
     genderSel.appendChild(optF);
-    genderSel.value = p.gender || '';
+    genderSel.appendChild(optN);
+    genderSel.value = p.gender || 'neutral';
     genderSel.addEventListener('change', e => {
       genderChanges[p.nick] = e.target.value;
       saveGenderBtn.disabled = false;


### PR DESCRIPTION
## Summary
- use av3.png for neutral avatar image
- ensure gender saves correctly by checking response codes
- add CORS header handling in gender-worker
- remove unused neutral.png asset

## Testing
- `ls assets/default_avatars`


------
https://chatgpt.com/codex/tasks/task_e_687a96d0b64483219ef4dab77ecb2932