### PR TITLE
Add gender column support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains a small static web app used for managing and displaying laser tag rankings. The site is composed of several standalone HTML pages that load data from Google Sheets and from a simple Cloudflare Worker API.
 
+The ranking spreadsheet is expected to contain a `Gender` column after the `Points` column. The app will read this value for each player when loading data.
+
 ## Running the site locally
 
 The pages use ES modules, therefore they must be served via HTTP. Any static server will work, for example:

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -50,8 +50,14 @@ export async function loadPlayers(league) {
                  : pts < 800  ? 'B'
                  : pts < 1200 ? 'A'
                  :              'S';
-      const g = genders[nick];
-      const gender = g === 'm' ? 'male' : g === 'f' ? 'female' : g;
+
+      let gender = cols[3]?.trim().toLowerCase();
+      if (gender === 'm') gender = 'male';
+      else if (gender === 'f') gender = 'female';
+      if (!gender) {
+        gender = genders[nick];
+      }
+
       return { nick, pts, rank, gender };
     });
 }
@@ -113,12 +119,12 @@ export async function uploadAvatar(nick, file){
   });
 }
 
-export async function saveGender(nick, gender){
+export async function saveGender(nick, gender, updateSheet = false){
   try{
     const res = await fetch(`${proxyUrl}/genders/${encodeURIComponent(nick)}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ gender })
+      body: JSON.stringify({ gender, updateSheet })
     });
     if(!res.ok) throw new Error('HTTP '+res.status);
   }catch(err){

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -32,7 +32,7 @@ export function initAvatarAdmin(players){
   saveGenderBtn.onclick = async () => {
     const genderEntries = Object.entries(genderChanges);
     for(const [nick,gender] of genderEntries){
-      await saveGender(nick, gender);
+      await saveGender(nick, gender, true);
       const img = listEl.querySelector(`img[data-nick="${nick}"]`);
       if(img) img.dataset.gender = gender;
     }


### PR DESCRIPTION
## Summary
- add mention of Gender column to README
- parse gender column in `loadPlayers`
- add ability to sync gender to spreadsheet when calling `saveGender`
- call new option from avatar admin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687a9fa298c88321976fe3daab5409ee