### PR TITLE
Add getGenders API hook

### DIFF
--- a/gas/doPost.gs
+++ b/gas/doPost.gs
@@ -1,0 +1,34 @@
+function doPost(e){
+  var payload = {};
+  try {
+    payload = JSON.parse(e.postData.contents || '{}');
+  } catch(err) {
+    return ContentService.createTextOutput('Invalid payload');
+  }
+
+  if (payload.action === 'getGenders') {
+    var ss = SpreadsheetApp.getActive();
+    var out = {};
+    ['kids','sundaygames'].forEach(function(name){
+      var sheet = ss.getSheetByName(name);
+      if(!sheet) return;
+      var headers = sheet.getRange(1,1,1,sheet.getLastColumn()).getValues()[0];
+      var nickCol = headers.indexOf('Nickname') + 1;
+      var genderCol = headers.indexOf('Gender') + 1;
+      if(nickCol && genderCol){
+        var values = sheet.getRange(2,1,sheet.getLastRow()-1,sheet.getLastColumn()).getValues();
+        values.forEach(function(row){
+          var nick = row[nickCol-1];
+          var gender = row[genderCol-1];
+          if(nick && gender){
+            out[nick.toString().trim()] = gender.toString().trim().toLowerCase();
+          }
+        });
+      }
+    });
+    return ContentService.createTextOutput(JSON.stringify(out))
+      .setMimeType(ContentService.MimeType.JSON);
+  }
+
+  return ContentService.createTextOutput('Unsupported');
+}

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,13 +1,16 @@
 // scripts/api.js
 
 const proxyUrl = 'https://laser-proxy.vartaclub.workers.dev';
-const gendersURL = `${proxyUrl}/genders`;
 const gendersFallback = 'assets/player_gender.json';
 
 export async function loadGenders(){
   let data = {};
   try{
-    const res = await fetch(gendersURL);
+    const res = await fetch(proxyUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'getGenders' })
+    });
     if(!res.ok) throw new Error('HTTP '+res.status);
     data = await res.json();
   }catch(err){
@@ -119,12 +122,12 @@ export async function uploadAvatar(nick, file){
   });
 }
 
-export async function saveGender(nick, gender, updateSheet = false){
+export async function saveGender(nick, gender, league = ''){
   try{
-    const res = await fetch(`${proxyUrl}/genders/${encodeURIComponent(nick)}`, {
+    const res = await fetch(proxyUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ gender, updateSheet })
+      body: JSON.stringify({ action: 'setGender', nick, gender, league })
     });
     if(!res.ok) throw new Error('HTTP '+res.status);
   }catch(err){

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -3,8 +3,9 @@ import { uploadAvatar, getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL, sav
 
 let pending = {};
 let genderChanges = {};
-
-export function initAvatarAdmin(players){
+let currentLeague = '';
+export function initAvatarAdmin(players, league=''){
+  currentLeague = league;
   const section = document.getElementById('avatar-admin');
   if(!section) return;
   const listEl = document.getElementById('avatar-list');
@@ -32,7 +33,7 @@ export function initAvatarAdmin(players){
   saveGenderBtn.onclick = async () => {
     const genderEntries = Object.entries(genderChanges);
     for(const [nick,gender] of genderEntries){
-      await saveGender(nick, gender, true);
+      await saveGender(nick, gender, currentLeague);
       const img = listEl.querySelector(`img[data-nick="${nick}"]`);
       if(img) img.dataset.gender = gender;
     }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnLoad   = document.getElementById('btn-load');
   const leagueSel = document.getElementById('league');
   const scenArea  = document.getElementById('scenario-area');
-  initAvatarAdmin([]);
+  initAvatarAdmin([], leagueSel ? leagueSel.value : '');
 
   if (!btnLoad || !leagueSel) {
     console.error('Не знайдено #btn-load або #league у DOM');
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const players = await loadPlayers(leagueSel.value);
       initLobby(players);          // Рендер лоббі
-      initAvatarAdmin(players);    // Рендер аватарів
+      initAvatarAdmin(players, leagueSel.value);    // Рендер аватарів
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
     } catch (err) {
       console.error('Помилка loadPlayers:', err);
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // При зміні ліги — очищуємо поточне лоббі та ховаємо сценарій
   leagueSel.addEventListener('change', () => {
     initLobby([]);               // Порожнє лоббі
-    initAvatarAdmin([]);
+    initAvatarAdmin([], leagueSel.value);
     scenArea.classList.add('hidden');
   });
 });


### PR DESCRIPTION
## Summary
- add GAS script with `getGenders` action
- request all genders via POST in `loadGenders`
- save genders through the same endpoint
- pass selected league to avatar admin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687aa9e4a2ac8321b507619694b2085c