### PR TITLE
Use Apps Script proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Laser Tag Ranking
 
-This repository contains a small static web app used for managing and displaying laser tag rankings. The site is composed of several standalone HTML pages that load data from Google Sheets and from a simple Cloudflare Worker API.
+This repository contains a small static web app used for managing and displaying laser tag rankings. The site is composed of several standalone HTML pages that load data from Google Sheets and route API requests through a small Google Apps Script.
+
+All data submissions—saving match results, importing detailed stats, uploading avatars and storing gender preferences—are sent to this Apps Script which then updates the underlying spreadsheets and storage.
 
 The ranking spreadsheet is expected to contain a `Gender` column after the `Points` column. The app will read this value for each player when loading data.
 

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,6 +1,8 @@
 // scripts/api.js
 
-const proxyUrl = 'https://laser-proxy.vartaclub.workers.dev';
+// All API requests are routed through a Google Apps Script which acts as a
+// simple backend for storing results and serving assets.
+const proxyUrl = 'https://script.google.com/macros/s/AKfycbzLaserTagApi/exec';
 const gendersFallback = 'assets/player_gender.json';
 
 export async function loadGenders(){


### PR DESCRIPTION
## Summary
- route API calls through a Google Apps Script
- update README with Apps Script details

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687aac0298448321a95dbc55e6e7c6c0