### PR TITLE
Improve upload avatar feedback

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -117,11 +117,12 @@ export function getDefaultAvatarURL(gender){
 }
 
 export async function uploadAvatar(nick, file){
-  await fetch(`${customAvatarUploadBase}/${encodeURIComponent(nick)}`, {
+  const res = await fetch(`${customAvatarUploadBase}/${encodeURIComponent(nick)}`, {
     method: 'POST',
     headers: { 'Content-Type': file.type || 'application/octet-stream' },
-    body: file,
+    body: file
   });
+  return res.ok;
 }
 
 export async function saveGender(nick, gender, league = ''){

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -19,12 +19,17 @@ export function initAvatarAdmin(players, league=''){
   listEl.innerHTML = '';
   saveAvBtn.onclick = async () => {
     const entries = Object.entries(pending);
+    const failed = [];
     for(const [nick,obj] of entries){
-      await uploadAvatar(nick, obj.file);
+      const success = await uploadAvatar(nick, obj.file);
+      if(!success) failed.push(nick);
       obj.img.src = getAvatarURL(nick);
     }
     if(entries.length){
       localStorage.setItem('avatarRefresh', Date.now().toString());
+    }
+    if(failed.length){
+      alert('Failed to upload avatars for: '+failed.join(', '));
     }
     pending = {};
     saveAvBtn.disabled = true;


### PR DESCRIPTION
## Summary
- return a boolean from `uploadAvatar` to track if the HTTP request succeeded
- warn the admin when any avatar upload fails

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687aadadfb70832186ea49e16e09b3f6