### PR TITLE
Handle saveResult errors

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -86,7 +86,11 @@ export async function saveResult(data) {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body
   });
-  return res.text();
+  const text = await res.text();
+  if(!res.ok){
+    throw new Error(text || ('HTTP '+res.status));
+  }
+  return text;
 }
 
 

--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -146,7 +146,8 @@ document.addEventListener('DOMContentLoaded', () => {
       btnClear.click();
     } catch (err) {
       console.error('Помилка під час збереження:', err);
-      alert('Не вдалося зберегти гру: ' + err.message);
+      const msg = err && err.message ? err.message : String(err);
+      alert('Не вдалося зберегти гру:\n' + msg);
     }
   });
 


### PR DESCRIPTION
## Summary
- throw an Error from `saveResult` when backend response is not OK
- show the returned error text when saving a match fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687caf72d51083218d132f1fb6277c4b