### PR TITLE
Add CORS headers to Cloudflare workers

### DIFF
--- a/avatar-worker.js
+++ b/avatar-worker.js
@@ -3,7 +3,13 @@ export default {
     const url = new URL(request.url);
     const m = url.pathname.match(/^\/avatars\/(.+)$/);
     if (!m) {
-      return new Response('Not found', { status: 404 });
+      return new Response('Not found', {
+        status: 404,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        },
+      });
     }
 
     const nick = decodeURIComponent(m[1]);
@@ -12,6 +18,7 @@ export default {
         headers: {
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type',
         },
       });
     }
@@ -21,11 +28,21 @@ export default {
         type: 'arrayBuffer',
       });
       if (!value) {
-        return new Response('Not found', { status: 404, headers: { 'Access-Control-Allow-Origin': '*' } });
+        return new Response('Not found', {
+          status: 404,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': 'Content-Type',
+          },
+        });
       }
       const ct = (metadata && metadata.contentType) || 'application/octet-stream';
       return new Response(value, {
-        headers: { 'Content-Type': ct, 'Access-Control-Allow-Origin': '*' },
+        headers: {
+          'Content-Type': ct,
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        },
       });
     }
 
@@ -33,9 +50,20 @@ export default {
       const ct = request.headers.get('content-type') || 'application/octet-stream';
       const buf = await request.arrayBuffer();
       await env.AVATARS.put(nick, buf, { metadata: { contentType: ct } });
-      return new Response('OK', { headers: { 'Access-Control-Allow-Origin': '*' } });
+      return new Response('OK', {
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        },
+      });
     }
 
-    return new Response('Method not allowed', { status: 405, headers: { 'Access-Control-Allow-Origin': '*' } });
+    return new Response('Method not allowed', {
+      status: 405,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      },
+    });
   },
 };

--- a/github-avatar-worker.js
+++ b/github-avatar-worker.js
@@ -3,20 +3,30 @@ export default {
     const url = new URL(request.url);
     const m = url.pathname.match(/^\/custom_avatars\/(.+)$/);
     if (!m) {
-      return new Response('Not found', { status: 404 });
+      return new Response('Not found', {
+        status: 404,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        },
+      });
     }
     if (request.method === 'OPTIONS') {
       return new Response(null, {
         headers: {
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Methods': 'POST,OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type',
         },
       });
     }
     if (request.method !== 'POST') {
       return new Response('Method not allowed', {
         status: 405,
-        headers: { 'Access-Control-Allow-Origin': '*' },
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        },
       });
     }
     const nick = decodeURIComponent(m[1]);
@@ -56,12 +66,18 @@ export default {
       const text = await putRes.text();
       return new Response(text, {
         status: 500,
-        headers: { 'Access-Control-Allow-Origin': '*' },
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        },
       });
     }
 
     return new Response('OK', {
-      headers: { 'Access-Control-Allow-Origin': '*' },
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      },
     });
   },
 };


### PR DESCRIPTION
## Summary
- include `Access-Control-Allow-Headers` in avatar-worker options handler
- return the header in all other avatar-worker responses
- add the same header to github-avatar-worker
- ensure every github-avatar-worker response contains CORS headers

## Testing
- `node --check avatar-worker.js`
- `node --check github-avatar-worker.js`
- `wrangler deploy avatar-worker.js` *(fails: login required)*
- `wrangler deploy github-avatar-worker.js` *(fails: login required)*

------
https://chatgpt.com/codex/tasks/task_e_687cb60aa35c8321abef8b3caea5d28d