### PR TITLE
Add avatar picker

### DIFF
--- a/assets/default_avatars/list.json
+++ b/assets/default_avatars/list.json
@@ -1,0 +1,1 @@
+["av0.png","av1.png","av2.png","av3.png"]

--- a/balancer.css
+++ b/balancer.css
@@ -86,4 +86,22 @@ button:hover{background:var(--accent-dark);}button:disabled{background:var(--tex
   margin-top: 0.5rem;
 }
 
+.avatar-thumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+}
+.avatar-thumb {
+  width: 32px;
+  height: 32px;
+  object-fit: cover;
+  cursor: pointer;
+  border: 1px solid #444;
+  border-radius: 4px;
+}
+.avatar-thumb.selected {
+  border-color: var(--accent);
+}
+
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const players = await loadPlayers(leagueSel.value);
       initLobby(players);          // Рендер лоббі
-      initAvatarAdmin(players, leagueSel.value);    // Рендер аватарів
+      await initAvatarAdmin(players, leagueSel.value);    // Рендер аватарів
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
     } catch (err) {
       console.error('Помилка loadPlayers:', err);
@@ -37,9 +37,9 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // При зміні ліги — очищуємо поточне лоббі та ховаємо сценарій
-  leagueSel.addEventListener('change', () => {
+  leagueSel.addEventListener('change', async () => {
     initLobby([]);               // Порожнє лоббі
-    initAvatarAdmin([], leagueSel.value);
+    await initAvatarAdmin([], leagueSel.value);
     scenArea.classList.add('hidden');
   });
 });


### PR DESCRIPTION
## Summary
- fetch available default avatars from `assets/default_avatars/list.json`
- allow admins to select a thumbnail to apply a default avatar
- style avatar thumb list
- load avatar picker asynchronously in balance page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687cb77e9aa08321a16f115e85d97fff