### PR TITLE
Add avatar admin help text

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -104,9 +104,11 @@
     <!-- 7. Адміністрування аватарів -->
       <section id="avatar-admin" class="card">
         <h2>Керування аватарами</h2>
+        <p class="text-muted">Обери мініатюру для гравця, натисни «Зберегти аватари» та зображення оновиться автоматично.</p>
         <ul id="avatar-list" class="list"></ul>
         <div class="actions">
           <button id="save-avatars" disabled>Зберегти аватари</button>
+          <span id="avatar-status" class="text-muted hidden" style="align-self:center;">Аватари оновлено</span>
         </div>
       </section>
   </main>

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -23,10 +23,15 @@ export async function initAvatarAdmin(players, league=''){
   if(!section) return;
   const listEl = document.getElementById('avatar-list');
   const saveAvBtn = document.getElementById('save-avatars');
+  const statusEl = document.getElementById('avatar-status');
   if(!listEl || !saveAvBtn) return;
   pending = {};
   saveAvBtn.disabled = true;
   listEl.innerHTML = '';
+  if(statusEl){
+    statusEl.textContent = '';
+    statusEl.classList.add('hidden');
+  }
   await loadDefaultAvatars();
   saveAvBtn.onclick = async () => {
     const entries = Object.entries(pending);
@@ -44,6 +49,11 @@ export async function initAvatarAdmin(players, league=''){
     }
     pending = {};
     saveAvBtn.disabled = true;
+    if(statusEl){
+      statusEl.textContent = 'Аватари оновлено';
+      statusEl.classList.remove('hidden');
+      setTimeout(()=>statusEl.classList.add('hidden'), 2000);
+    }
   };
 
   players.forEach(p => {


### PR DESCRIPTION
## Summary
- document how to pick and save avatar thumbnails
- show a short status message once avatars are uploaded

## Testing
- `node --check scripts/avatarAdmin.js`

------
https://chatgpt.com/codex/tasks/task_e_687cc4677a708321a9aaa1f76a3a68a8