### PR TITLE
Add player profile page with avatar and game history

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Профіль гравця | Лазертаг</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+  <style>
+    *{box-sizing:border-box;margin:0;padding:0;}
+    body{
+      font-family:'Press Start 2P',monospace;
+      background:#111 url('assets/background_marathon.png') no-repeat center/cover;
+      color:#fff;
+    }
+    nav{display:flex;flex-wrap:wrap;justify-content:center;gap:0.5rem;background:rgba(0,0,0,0.7);padding:0.5rem;}
+    nav a{color:#f39c12;text-decoration:none;font-size:0.7rem;padding:0.25rem 0.5rem;border-radius:3px;}
+    nav a:hover{color:#000;background:#ffd700;}
+    .profile{max-width:480px;margin:1rem auto;padding:0 1rem;text-align:center;}
+    .avatar-wrap{width:120px;height:120px;margin:0 auto;}
+    .avatar-wrap img{width:100%;height:100%;object-fit:cover;border-radius:50%;border:2px solid #f39c12;}
+    button{cursor:pointer;border:none;padding:0.5rem 1rem;background:#222;color:#f39c12;border:2px solid #f39c12;border-radius:4px;font-family:'Press Start 2P',monospace;font-size:0.6rem;}
+    #request-abonement{display:none;margin-top:0.5rem;}
+    .filter{margin-top:1rem;}
+    .filter input{width:100%;padding:0.5rem;border:2px solid #555;background:rgba(0,0,0,0.5);color:#fff;border-radius:4px;font-size:0.7rem;}
+    table{width:100%;border-collapse:collapse;margin-top:1rem;font-size:0.7rem;}
+    th,td{border:1px solid #444;padding:0.5rem;text-align:center;}
+    @media(min-width:768px){.profile{max-width:600px;}}
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="index.html">Молодша Ліга</a>
+    <a href="sunday.html">Старша Ліга</a>
+    <a href="gameday.html">Ігровий день</a>
+    <a href="rules.html">Правила</a>
+    <a href="about.html">Про клуб</a>
+  </nav>
+  <div class="profile" id="profile">
+    <div class="avatar-wrap"><img id="avatar" alt="avatar"></div>
+    <button id="change-avatar" style="margin-top:0.5rem;">Змінити аватарку</button>
+    <input type="file" id="avatar-input" accept="image/*" style="display:none;">
+    <div id="rating" style="margin-top:1rem;"></div>
+    <div id="abonement-type" style="margin-top:0.5rem;"></div>
+    <button id="request-abonement">Запросити абонемент</button>
+    <div class="filter"><input type="date" id="date-filter"></div>
+    <table>
+      <thead><tr><th>Дата</th><th>ID</th><th>PDF</th></tr></thead>
+      <tbody id="games-body"></tbody>
+    </table>
+  </div>
+  <script type="module" src="scripts/profile.js"></script>
+</body>
+</html>

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,0 +1,99 @@
+import { loadPlayers, getAvatarURL, uploadAvatar, fetchPlayerGames } from './api.js';
+
+function showError(msg){
+  const container = document.getElementById('profile');
+  container.innerHTML = `<p style="color:#f39c12;text-align:center;">${msg}</p>`;
+}
+
+function renderGames(list, league, nick){
+  const tbody = document.getElementById('games-body');
+  const filterVal = document.getElementById('date-filter').value;
+  tbody.innerHTML = '';
+  list
+    .filter(g=>!filterVal || (g.Timestamp && g.Timestamp.startsWith(filterVal)))
+    .forEach(g=>{
+      const d = new Date(g.Timestamp);
+      const dateStr = isNaN(d)?'':d.toISOString().split('T')[0];
+      const id = g.ID || g.Id || g.GameID || g.game_id || g.gameId || '';
+      const tr=document.createElement('tr');
+      const tdD=document.createElement('td');
+      tdD.textContent=dateStr;
+      const tdId=document.createElement('td');
+      tdId.textContent=id;
+      const tdPdf=document.createElement('td');
+      const a=document.createElement('a');
+      a.textContent='PDF';
+      a.href=`/pdfs/${league}/${dateStr}/${id}.pdf`;
+      a.target='_blank';
+      tdPdf.appendChild(a);
+      tr.appendChild(tdD); tr.appendChild(tdId); tr.appendChild(tdPdf);
+      tbody.appendChild(tr);
+    });
+}
+
+async function init(){
+  const params = new URLSearchParams(location.search);
+  const nick = params.get('nick');
+  if(!nick){
+    showError('Нік не вказано');
+    return;
+  }
+  let player=null, league='';
+  for(const l of ['kids','sunday']){
+    try{
+      const players = await loadPlayers(l);
+      player = players.find(p=>p.nick===nick);
+      if(player){ league=l; break; }
+    }catch(err){/* ignore */}
+  }
+  if(!player){
+    showError('Гравця не знайдено');
+    return;
+  }
+  document.getElementById('avatar').src = getAvatarURL(nick);
+  document.getElementById('rating').textContent = `Рейтинг: ${player.pts} (${player.rank})`;
+  document.getElementById('abonement-type').textContent = `Абонемент: ${player.abonement_type}`;
+  const reqBtn = document.getElementById('request-abonement');
+  if(player.abonement_type === 'none'){
+    reqBtn.style.display='block';
+    reqBtn.addEventListener('click', async ()=>{
+      reqBtn.disabled=true;
+      try{
+        await fetch('https://script.google.com/macros/s/AKfycbzjdoEtN8HsBFRGyme184NIGsZuCPyCPPtHNXU_PnJhoDi3mUVT40XnwzR90KHDa9J8pg/exec',{
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({action:'abonement_request',nick})
+        });
+        reqBtn.textContent='Запит відправлено';
+      }catch(err){
+        reqBtn.disabled=false;
+        alert('Помилка запиту');
+      }
+    });
+  }
+  const fileInput = document.getElementById('avatar-input');
+  document.getElementById('change-avatar').addEventListener('click',()=>fileInput.click());
+  fileInput.addEventListener('change',async()=>{
+    const file=fileInput.files[0];
+    if(!file) return;
+    const ok = await uploadAvatar(nick,file);
+    if(ok){
+      document.getElementById('avatar').src = getAvatarURL(nick);
+      localStorage.setItem('avatarRefresh', Date.now());
+    } else {
+      alert('Помилка завантаження');
+    }
+  });
+
+  let games=[];
+  try{ games = await fetchPlayerGames(); }catch(err){ games=[]; }
+  const playerGames = games.filter(g=>{
+    if(g.League && g.League!==league) return false;
+    const teams=[g.Team1,g.Team2,g.Team3,g.Team4];
+    return teams.some(t=> (t||'').split(',').map(s=>s.trim()).includes(nick));
+  });
+  renderGames(playerGames, league, nick);
+  document.getElementById('date-filter').addEventListener('change',()=>renderGames(playerGames,league,nick));
+}
+
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- add mobile-friendly player profile page with avatar, rating and game history
- implement profile logic for avatar upload, abonement requests and game filtering
- extend API to expose abonement type and fetch games list

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fb9cb9f8083218d065ddfb868e15e