### PR TITLE
Add abonement selection and update API

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -41,7 +41,7 @@
       <h2>Лоббі дня</h2>
       <table class="table">
         <thead>
-          <tr><th>Нік</th><th>Бали</th><th>Ранг</th><th>→Команда / ✕</th></tr>
+          <tr><th>Нік</th><th>Бали</th><th>Ранг</th><th>Абонемент</th><th>→Команда / ✕</th></tr>
         </thead>
         <tbody id="lobby-list"></tbody>
       </table>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -134,6 +134,17 @@ export async function requestAbonement(nick){
   return res.text();
 }
 
+export async function updateAbonement(nick, abonement){
+  const payload = {action:'updateAbonement', nick, abonement};
+  const res = await fetch(proxyUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if(!res.ok) throw new Error('HTTP '+res.status);
+  return res.text();
+}
+
 export async function fetchPlayerGames(nick, league=''){
   let res;
   try {

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -2,9 +2,11 @@
 
 import { initTeams, teams } from './teams.js';
 import { sortByName, sortByPtsDesc } from './sortUtils.js';
+import { updateAbonement } from './api.js';
 
 export let lobby = [];
 let players = [], filtered = [], selected = [], manualCount = 0;
+const ABONEMENT_TYPES = ['none', 'lite', 'full'];
 
 // Ініціалізує лоббі новим набором гравців
 export function initLobby(pl) {
@@ -97,6 +99,11 @@ function renderLobby() {
       <td>${p.pts}</td>
       <td>${p.rank}</td>
       <td>
+        <select class="abonement-select" data-i="${i}">
+          ${ABONEMENT_TYPES.map(t => `<option value="${t}">${t}</option>`).join('')}
+        </select>
+      </td>
+      <td>
         ${[...Array(manualCount)].map((_, k) =>
           `<button class="assign" data-i="${i}" data-team="${k+1}">→${k+1}</button>`
         ).join('')}
@@ -147,6 +154,26 @@ function renderLobby() {
       lobby.splice(idx, 1);
       renderLobby();
       renderSelect(filtered);
+    };
+  });
+
+  // Оновлення типу абонемента
+  tbody.querySelectorAll('.abonement-select').forEach(sel => {
+    const idx = +sel.dataset.i;
+    const player = lobby[idx];
+    sel.value = player.abonement || 'none';
+    sel.onchange = async () => {
+      const newType = sel.value;
+      try {
+        await updateAbonement(player.nick, newType);
+        player.abonement = newType;
+        const full = players.find(p => p.nick === player.nick);
+        if (full) full.abonement = newType;
+        alert('Абонемент оновлено');
+      } catch (err) {
+        sel.value = player.abonement || 'none';
+        alert('Помилка оновлення абонемента');
+      }
     };
   });
 }


### PR DESCRIPTION
## Summary
- add abonement column with selectable type in lobby table
- allow updating player abonement via API

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc5c650788321b70f449f2005edc0