### PR TITLE
Add avatar upload endpoint and refresh handling

### DIFF
--- a/avatar-worker.js
+++ b/avatar-worker.js
@@ -1,8 +1,10 @@
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
-    const m = url.pathname.match(/^\/avatars\/(.+)$/);
-    if (!m) {
+    const avatarMatch = url.pathname.match(/^\/avatars\/(.+)$/);
+    const uploadMatch = url.pathname.match(/^\/upload-avatar\/(.+)$/);
+
+    if (!avatarMatch && !uploadMatch) {
       return new Response('Not found', {
         status: 404,
         headers: {
@@ -12,7 +14,8 @@ export default {
       });
     }
 
-    const nick = decodeURIComponent(m[1]);
+    const nick = decodeURIComponent(avatarMatch ? avatarMatch[1] : uploadMatch[1]);
+
     if (request.method === 'OPTIONS') {
       return new Response(null, {
         headers: {
@@ -23,7 +26,7 @@ export default {
       });
     }
 
-    if (request.method === 'GET') {
+    if (avatarMatch && request.method === 'GET') {
       const { value, metadata } = await env.AVATARS.getWithMetadata(nick, {
         type: 'arrayBuffer',
       });
@@ -46,7 +49,7 @@ export default {
       });
     }
 
-    if (request.method === 'POST') {
+    if (uploadMatch && request.method === 'POST') {
       const ct = request.headers.get('content-type') || 'application/octet-stream';
       const buf = await request.arrayBuffer();
       await env.AVATARS.put(nick, buf, { metadata: { contentType: ct } });

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -74,25 +74,24 @@ export async function saveDetailedStats(matchId, statsArray) {
   return res.text();
 }
 
-const avatarBase = `${proxyUrl}/avatars`;
-const customAvatarUploadBase = `${proxyUrl}/custom_avatars`;
-const customAvatarBase = 'assets/custom_avatars';
+const avatarBase = '/avatars';
+const avatarUploadBase = '/upload-avatar';
 const defaultAvatarBase = 'assets/default_avatars';
 
 export function getAvatarURL(nick){
-  return `${customAvatarBase}/${encodeURIComponent(nick)}.png?t=${Date.now()}`;
-}
-
-export function getProxyAvatarURL(nick){
   return `${avatarBase}/${encodeURIComponent(nick)}?t=${Date.now()}`;
 }
 
+export function getProxyAvatarURL(nick){
+  return getAvatarURL(nick);
+}
+
 export function getDefaultAvatarURL(){
-  return 'assets/default_avatars/av0.png';
+  return `${defaultAvatarBase}/av0.png`;
 }
 
 export async function uploadAvatar(nick, file){
-  const res = await fetch(`${customAvatarUploadBase}/${encodeURIComponent(nick)}`, {
+  const res = await fetch(`${avatarUploadBase}/${encodeURIComponent(nick)}`, {
     method: 'POST',
     headers: { 'Content-Type': file.type || 'application/octet-stream' },
     body: file

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -115,3 +115,13 @@ async function init(){
 }
 
 document.addEventListener('DOMContentLoaded', init);
+
+window.addEventListener('storage', e => {
+  if(e.key === 'avatarRefresh'){
+    const params = new URLSearchParams(location.search);
+    const nick = params.get('nick');
+    if(nick){
+      document.getElementById('avatar').src = getAvatarURL(nick);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- extend avatar worker to serve `/avatars/{nick}` and accept uploads at `/upload-avatar/{nick}`
- update API client to use new `/upload-avatar` endpoint and fetch avatars from worker
- refresh profile avatars across tabs when `avatarRefresh` storage event fires

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fcd733c5883218dc82f58201c486d