### PR TITLE
Redirect ranking nicknames to profile

### DIFF
--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -101,7 +101,10 @@ export function renderTable(list, tbodyEl){
       if(idx===1){
         td.className=cls.replace('rank-','nick-');
         td.style.cursor='pointer';
-        td.addEventListener('click',()=>{ if(window.loadStats) window.loadStats(p.nickname); });
+        td.addEventListener('click', () => {
+          const url = `profile.html?nick=${encodeURIComponent(p.nickname)}`;
+          window.location.href = url;
+        });
       }
       td.textContent=val;
       tr.appendChild(td);


### PR DESCRIPTION
## Summary
- Replace ranking table nickname click handler to redirect to profile page instead of invoking stats modal

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933bfb954883219afe30ba4403474d