### PR TITLE
Add alt text to avatar images

### DIFF
--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -60,6 +60,7 @@ export async function initAvatarAdmin(players, league=''){
     const li = document.createElement('li');
     const img = document.createElement('img');
     img.className = 'avatar-img';
+    img.alt = p.nick;
     img.dataset.nick = p.nick;
     img.src = getAvatarURL(p.nick);
     img.onerror = () => {
@@ -85,6 +86,7 @@ export async function initAvatarAdmin(players, league=''){
     defaultAvatars.forEach(src => {
       const t = document.createElement('img');
       t.className = 'avatar-thumb';
+      t.alt = 'avatar';
       t.src = src;
       t.addEventListener('click', async () => {
         thumbs.querySelectorAll('.avatar-thumb').forEach(el => el.classList.remove('selected'));

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -205,6 +205,7 @@ import { getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL } from "./api.js";
       const tdAvatar=document.createElement('td');
       const img=document.createElement('img');
       img.className='avatar-img';
+      img.alt=p.nick;
       img.dataset.nick=p.nick;
       img.src=getAvatarURL(p.nick);
       img.onerror=()=>{

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -84,6 +84,7 @@ export function renderTable(list, tbodyEl){
     const tdAvatar=document.createElement('td');
     const img=document.createElement('img');
     img.className='avatar-img';
+    img.alt=p.nickname;
     img.dataset.nick=p.nickname;
     img.src=getAvatarURL(p.nickname);
     img.onerror=()=>{


### PR DESCRIPTION
## Summary
- Add `alt` attributes to ranking avatars for better accessibility
- Include `alt` text on Game Day player avatars
- Set `alt` text on admin avatar images and default avatar thumbnails

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933cf98f5883219a0f18adab54c523