### PR TITLE
Add upload token and validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ The pages use ES modules, therefore they must be served via HTTP. Any static ser
 
 If the API proxy is unavailable, the balancer page will fetch player data directly from the published Google Sheets.
 
+## Avatar uploads
+
+The avatar upload worker requires an `UPLOAD_TOKEN` environment variable. Clients must send this token in the `X-Upload-Token` header when uploading images; the scripts expect it to be available as `window.UPLOAD_TOKEN`.
+

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -91,9 +91,11 @@ export function getDefaultAvatarURL(){
 }
 
 export async function uploadAvatar(nick, file){
+  const headers = { 'Content-Type': file.type || 'application/octet-stream' };
+  if (window.UPLOAD_TOKEN) headers['X-Upload-Token'] = window.UPLOAD_TOKEN;
   const res = await fetch(`${avatarUploadBase}/${encodeURIComponent(nick)}`, {
     method: 'POST',
-    headers: { 'Content-Type': file.type || 'application/octet-stream' },
+    headers,
     body: file
   });
   return res.ok;


### PR DESCRIPTION
## Summary
- validate avatar uploads to accept only images up to 1MB and check `X-Upload-Token`
- send upload token header from client
- document `UPLOAD_TOKEN` requirement for avatar uploads

## Testing
- `npm test` (fails: ENOENT package.json)
- `npx eslint avatar-worker.js scripts/api.js` (fails: ESLint couldn't find config)


------
https://chatgpt.com/codex/tasks/task_e_689343789fbc83219e35a9df4c975a9c