### PR TITLE
Ensure avatar refresh listeners across pages

### DIFF
--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -114,17 +114,19 @@ export async function initAvatarAdmin(players, league=''){
   });
 }
 
-window.addEventListener('storage', e => {
-  if(e.key === 'avatarRefresh'){
-    document.querySelectorAll('#avatar-list img.avatar-img[data-nick]').forEach(img => {
-      img.src = getAvatarURL(img.dataset.nick);
+function refreshAvatars(){
+  document.querySelectorAll('#avatar-list img.avatar-img[data-nick]').forEach(img => {
+    img.src = getAvatarURL(img.dataset.nick);
+    img.onerror = () => {
       img.onerror = () => {
-        img.onerror = () => {
-          img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
-          img.src = getDefaultAvatarURL();
-        };
-        img.src = getProxyAvatarURL(img.dataset.nick);
+        img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
+        img.src = getDefaultAvatarURL();
       };
-    });
-  }
+      img.src = getProxyAvatarURL(img.dataset.nick);
+    };
+  });
+}
+
+window.addEventListener('storage', e => {
+  if(e.key === 'avatarRefresh') refreshAvatars();
 });

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -136,12 +136,14 @@ async function init(){
 
 document.addEventListener('DOMContentLoaded', init);
 
-window.addEventListener('storage', e => {
-  if(e.key === 'avatarRefresh'){
-    const params = new URLSearchParams(location.search);
-    const nick = params.get('nick');
-    if(nick){
-      document.getElementById('avatar').src = getAvatarURL(nick);
-    }
+function refreshAvatars(){
+  const params = new URLSearchParams(location.search);
+  const nick = params.get('nick');
+  if(nick){
+    document.getElementById('avatar').src = getAvatarURL(nick);
   }
+}
+
+window.addEventListener('storage', e => {
+  if(e.key === 'avatarRefresh') refreshAvatars();
 });


### PR DESCRIPTION
## Summary
- Confirm `gameday.js` listens for `avatarRefresh` events
- Refactor avatar admin page to use a shared `refreshAvatars` helper
- Add `refreshAvatars` helper to profile page for storage-driven updates

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/laser-tag-ranking/package.json')*
- `npm run lint` *(fails: ENOENT: no such file or directory, open '/workspace/laser-tag-ranking/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689346a9bab88321b7c1367adabfc16a