### PR TITLE
feat: add quick stats popover

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,197 +1,361 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="uk">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Молодша ліга | Лазертаг</title>
-  <!-- Піксельний шрифт -->
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <!-- PapaParse для CSV -->
-  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
-  <style>
-    /* Reset & Base */
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
-      font-family: 'Press Start 2P', monospace;
-      background: #111 url('assets/background_marathon.png') no-repeat center/cover;
-      color: #fff;
-      cursor: url('assets/cursor.png') 4 4, auto;
-    }
-    /* Navigation */
-    nav {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 0.5rem;
-      background: rgba(0,0,0,0.7);
-      padding: 0.5rem;
-    }
-    nav a {
-      color: #f39c12;
-      text-decoration: none;
-      font-size: 0.75rem;
-      padding: 0.25rem 0.5rem;
-      transition: color 0.2s, background 0.2s;
-      border-radius: 3px;
-    }
-    nav a:hover {
-      color: #000;
-      background: #ffd700;
-    }
-    nav a.active {
-      border-bottom: 2px solid #ffd700;
-    }
-    /* Container */
-    .container { max-width: 1200px; margin: 1rem auto; padding: 0 1rem; }
-    .season-info, .summary { text-align: center; margin-bottom: 1rem; }
-    .season-info { color: #f39c12; }
-    .rank-chart {
-      display: flex;
-      height: 1rem;
-      max-width: 400px;
-      margin: 0.5rem auto;
-      border: 1px solid #555;
-      border-radius: 4px;
-      overflow: hidden;
-      font-size: 0.6rem;
-      color: #000;
-    }
-    .rank-chart div {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .seg-S { background: magenta; }
-    .seg-A { background: red; }
-    .seg-B { background: yellow; }
-    .seg-C { background: cyan; }
-    .seg-D { background: lime; }
-    .summary { color: #ccc; font-size: 0.9rem; }
-    /* Search */
-    .search-box { text-align: center; margin-bottom: 1rem; }
-    .search-box input {
-      padding: 0.5rem;
-      width: 100%; max-width: 300px;
-      border: 2px solid #555;
-      background: rgba(0,0,0,0.5);
-      color: #fff;
-      border-radius: 4px;
-      font-size: 0.75rem;
-    }
-    /* Top MVP */
-    .top-mvp { display: flex; justify-content: center; gap: 1rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
-    .mvp-card {
-      background: rgba(243,156,18,0.2);
-      border: 2px solid #f39c12;
-      border-radius: 6px;
-      padding: 1rem;
-      min-width: 140px;
-      text-align: center;
-      animation: pulse 1.5s infinite;
-    }
-    @keyframes pulse { 0%,100% { box-shadow:0 0 8px rgba(243,156,18,.6); } 50% { box-shadow:0 0 16px rgba(243,156,18,1); } }
-    /* Table */
-    .table-container { overflow-x: auto; margin-bottom: 1rem; }
-    table { width: 100%; border-collapse: collapse; min-width: 600px; font-size: 0.75rem; }
-    thead th {
-      position: sticky; top: 0;
-      background: #222;
-      color: #f39c12;
-      padding: 0.75rem;
-      border-bottom: 2px solid #555;
-      z-index: 1;
-    }
-    th, td { padding: 0.5rem; border: 1px solid #444; text-align: center; }
-    tbody tr:nth-child(odd) { background: rgba(255,255,255,0.05); }
-    tbody tr:hover { background: rgba(255,255,255,0.1); }
-    .avatar-img { width: 40px; height: 40px; object-fit: cover; }
-    /* Show-more Button */
-    .show-more {
-      display: block;
-      margin: 1rem auto;
-      padding: 0.75rem 1.5rem;
-      background: #222;
-      color: #f39c12;
-      border: 2px solid #f39c12;
-      border-radius: 4px;
-      font-family: 'Press Start 2P', monospace;
-      font-size: 0.75rem;
-      text-transform: uppercase;
-      box-shadow: 0 0 8px #f39c12;
-      cursor: url('assets/cursor.png') 4 4, auto;
-      transition: transform 0.2s;
-    }
-    .show-more:hover { transform: scale(1.05); }
-    /* Rank highlight */
-    .rank-S td { border-left: 4px solid magenta; }
-    .rank-A td { border-left: 4px solid red; }
-    .rank-B td { border-left: 4px solid yellow; }
-    .rank-C td { border-left: 4px solid cyan; }
-    .rank-D td { border-left: 4px solid lime; }
-    /* Nickname color */
-    .nick-S { color: magenta; }
-    .nick-A { color: red; }
-    .nick-B { color: yellow; }
-    .nick-C { color: cyan; }
-    .nick-D { color: lime; }
-    .hidden { display: none; }
-    .modal { position: fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.8); display:flex; align-items:center; justify-content:center; z-index:1000; }
-    .modal.hidden { display:none; }
-    .modal-content { background:#222; padding:1rem; border-radius:4px; max-height:90%; overflow:auto; }
-    #stats-close { float:right; background:#444; border:none; color:#fff; cursor:pointer; padding:0.25rem 0.5rem; }
-    @media(max-width:600px) { table { min-width:480px; } .mvp-card { min-width:45%; } }
-  </style>
-</head>
-<body>
-  <nav>
-    <a href="index.html" class="active">Молодша Ліга</a>
-    <a href="sunday.html">Старша Ліга</a>
-    <a href="gameday.html">Ігровий день</a>
-    <a href="rules.html">Правила</a>
-    <a href="about.html">Про клуб</a>
-  </nav>
-  <div class="container">
-    <div id="season-info" class="season-info"></div>
-    <div class="summary" id="summary"></div>
-    <div id="rank-chart" class="rank-chart"></div>
-    <div class="search-box"><input type="text" id="search" placeholder="Пошук нікнейму…"/></div>
-    <div class="top-mvp" id="top-mvp"></div>
-    <div class="table-container">
-      <table>
-        <thead><tr>
-          <th>Місце</th><th>Аватар</th><th>Нікнейм</th><th>Ранг</th><th>Бали</th>
-          <th>Ігор</th><th>% Win</th><th>MVP</th>
-        </tr></thead>
-        <tbody id="ranking"></tbody>
-      </table>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Молодша ліга | Лазертаг</title>
+    <!-- Піксельний шрифт -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
+      rel="stylesheet"
+    />
+    <!-- PapaParse для CSV -->
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+    <style>
+      /* Reset & Base */
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: "Press Start 2P", monospace;
+        background: #111 url("assets/background_marathon.png") no-repeat
+          center/cover;
+        color: #fff;
+        cursor:
+          url("assets/cursor.png") 4 4,
+          auto;
+      }
+      /* Navigation */
+      nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.5rem;
+        background: rgba(0, 0, 0, 0.7);
+        padding: 0.5rem;
+      }
+      nav a {
+        color: #f39c12;
+        text-decoration: none;
+        font-size: 0.75rem;
+        padding: 0.25rem 0.5rem;
+        transition:
+          color 0.2s,
+          background 0.2s;
+        border-radius: 3px;
+      }
+      nav a:hover {
+        color: #000;
+        background: #ffd700;
+      }
+      nav a.active {
+        border-bottom: 2px solid #ffd700;
+      }
+      /* Container */
+      .container {
+        max-width: 1200px;
+        margin: 1rem auto;
+        padding: 0 1rem;
+      }
+      .season-info,
+      .summary {
+        text-align: center;
+        margin-bottom: 1rem;
+      }
+      .season-info {
+        color: #f39c12;
+      }
+      .rank-chart {
+        display: flex;
+        height: 1rem;
+        max-width: 400px;
+        margin: 0.5rem auto;
+        border: 1px solid #555;
+        border-radius: 4px;
+        overflow: hidden;
+        font-size: 0.6rem;
+        color: #000;
+      }
+      .rank-chart div {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .seg-S {
+        background: magenta;
+      }
+      .seg-A {
+        background: red;
+      }
+      .seg-B {
+        background: yellow;
+      }
+      .seg-C {
+        background: cyan;
+      }
+      .seg-D {
+        background: lime;
+      }
+      .summary {
+        color: #ccc;
+        font-size: 0.9rem;
+      }
+      /* Search */
+      .search-box {
+        text-align: center;
+        margin-bottom: 1rem;
+      }
+      .search-box input {
+        padding: 0.5rem;
+        width: 100%;
+        max-width: 300px;
+        border: 2px solid #555;
+        background: rgba(0, 0, 0, 0.5);
+        color: #fff;
+        border-radius: 4px;
+        font-size: 0.75rem;
+      }
+      /* Top MVP */
+      .top-mvp {
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin-bottom: 1.5rem;
+      }
+      .mvp-card {
+        background: rgba(243, 156, 18, 0.2);
+        border: 2px solid #f39c12;
+        border-radius: 6px;
+        padding: 1rem;
+        min-width: 140px;
+        text-align: center;
+        animation: pulse 1.5s infinite;
+      }
+      @keyframes pulse {
+        0%,
+        100% {
+          box-shadow: 0 0 8px rgba(243, 156, 18, 0.6);
+        }
+        50% {
+          box-shadow: 0 0 16px rgba(243, 156, 18, 1);
+        }
+      }
+      /* Table */
+      .table-container {
+        overflow-x: auto;
+        margin-bottom: 1rem;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        min-width: 600px;
+        font-size: 0.75rem;
+      }
+      thead th {
+        position: sticky;
+        top: 0;
+        background: #222;
+        color: #f39c12;
+        padding: 0.75rem;
+        border-bottom: 2px solid #555;
+        z-index: 1;
+      }
+      th,
+      td {
+        padding: 0.5rem;
+        border: 1px solid #444;
+        text-align: center;
+      }
+      tbody tr:nth-child(odd) {
+        background: rgba(255, 255, 255, 0.05);
+      }
+      tbody tr:hover {
+        background: rgba(255, 255, 255, 0.1);
+      }
+      .avatar-img {
+        width: 40px;
+        height: 40px;
+        object-fit: cover;
+      }
+      /* Show-more Button */
+      .show-more {
+        display: block;
+        margin: 1rem auto;
+        padding: 0.75rem 1.5rem;
+        background: #222;
+        color: #f39c12;
+        border: 2px solid #f39c12;
+        border-radius: 4px;
+        font-family: "Press Start 2P", monospace;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        box-shadow: 0 0 8px #f39c12;
+        cursor:
+          url("assets/cursor.png") 4 4,
+          auto;
+        transition: transform 0.2s;
+      }
+      .show-more:hover {
+        transform: scale(1.05);
+      }
+      /* Rank highlight */
+      .rank-S td {
+        border-left: 4px solid magenta;
+      }
+      .rank-A td {
+        border-left: 4px solid red;
+      }
+      .rank-B td {
+        border-left: 4px solid yellow;
+      }
+      .rank-C td {
+        border-left: 4px solid cyan;
+      }
+      .rank-D td {
+        border-left: 4px solid lime;
+      }
+      /* Nickname color */
+      .nick-S {
+        color: magenta;
+      }
+      .nick-A {
+        color: red;
+      }
+      .nick-B {
+        color: yellow;
+      }
+      .nick-C {
+        color: cyan;
+      }
+      .nick-D {
+        color: lime;
+      }
+      .hidden {
+        display: none;
+      }
+      .modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.8);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+      }
+      .modal.hidden {
+        display: none;
+      }
+      .modal-content {
+        background: #222;
+        padding: 1rem;
+        border-radius: 4px;
+        max-height: 90%;
+        overflow: auto;
+      }
+      #stats-close {
+        float: right;
+        background: #444;
+        border: none;
+        color: #fff;
+        cursor: pointer;
+        padding: 0.25rem 0.5rem;
+      }
+      @media (max-width: 600px) {
+        table {
+          min-width: 480px;
+        }
+        .mvp-card {
+          min-width: 45%;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <a href="index.html" class="active">Молодша Ліга</a>
+      <a href="sunday.html">Старша Ліга</a>
+      <a href="gameday.html">Ігровий день</a>
+      <a href="rules.html">Правила</a>
+      <a href="about.html">Про клуб</a>
+    </nav>
+    <div class="container">
+      <div id="season-info" class="season-info"></div>
+      <div class="summary" id="summary"></div>
+      <div id="rank-chart" class="rank-chart"></div>
+      <div class="search-box">
+        <input type="text" id="search" placeholder="Пошук нікнейму…" />
+      </div>
+      <div class="top-mvp" id="top-mvp"></div>
+      <div class="table-container">
+        <table>
+          <thead>
+            <tr>
+              <th>Місце</th>
+              <th>Аватар</th>
+              <th>Нікнейм</th>
+              <th>Ранг</th>
+              <th>Бали</th>
+              <th>Ігор</th>
+              <th>% Win</th>
+              <th>MVP</th>
+            </tr>
+          </thead>
+          <tbody id="ranking"></tbody>
+        </table>
+      </div>
+      <button class="show-more" id="toggle">Всі гравці</button>
     </div>
-    <button class="show-more" id="toggle">Всі гравці</button>
-  </div>
-  <div id="stats-modal" class="modal hidden">
-    <div class="modal-content">
-      <button id="stats-close">✕</button>
-      <div id="stats-body"></div>
+    <div id="stats-modal" class="modal hidden">
+      <div class="modal-content">
+        <button id="stats-close">✕</button>
+        <div id="stats-body"></div>
+      </div>
     </div>
-  </div>
-  <script type="module">
-  import {loadData,computeStats,renderTopMVP,renderChart,renderTable,initSearch,initToggle,formatD,formatFull} from './scripts/ranking.js';
-  const rankingURL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv";
-  const gamesURL   = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv";
-  const alias = {"Zavodchanyn":"Romario","Mariko":"Gidora","Timabuilding":"Бойбуд"};
-  const league = 'kids';
-  async function init(){
-    const {rank,games} = await loadData(rankingURL,gamesURL);
-    const {players,totalGames,totalRounds,minDate,maxDate} = computeStats(rank,games,{alias,league});
-    document.getElementById('summary').textContent = `Ігор: ${totalGames} (${totalRounds} раундів). Період: ${formatD(minDate)}–${formatD(maxDate)}`;
-    document.getElementById('season-info').textContent = `Перший сезон — старт ${formatFull(minDate)}`;
-    renderTopMVP(players, document.getElementById('top-mvp'));
-    renderChart(players, document.getElementById('rank-chart'));
-    renderTable(players, document.getElementById('ranking'));
-    initSearch(document.getElementById('search'), '#ranking tr');
-    initToggle(document.getElementById('toggle'), '#ranking tr');
-  }
-  document.addEventListener('DOMContentLoaded', init);
-</script>
-<script type="module" src="scripts/playerStats.js"></script>
-</body>
+    <script type="module">
+      import {
+        loadData,
+        computeStats,
+        renderTopMVP,
+        renderChart,
+        renderTable,
+        initSearch,
+        initToggle,
+        formatD,
+        formatFull,
+      } from "./scripts/ranking.js";
+      const rankingURL =
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv";
+      const gamesURL =
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv";
+      const alias = {
+        Zavodchanyn: "Romario",
+        Mariko: "Gidora",
+        Timabuilding: "Бойбуд",
+      };
+      const league = "kids";
+      async function init() {
+        const { rank, games } = await loadData(rankingURL, gamesURL);
+        const { players, totalGames, totalRounds, minDate, maxDate } =
+          computeStats(rank, games, { alias, league });
+        document.getElementById("summary").textContent =
+          `Ігор: ${totalGames} (${totalRounds} раундів). Період: ${formatD(minDate)}–${formatD(maxDate)}`;
+        document.getElementById("season-info").textContent =
+          `Перший сезон — старт ${formatFull(minDate)}`;
+        renderTopMVP(players, document.getElementById("top-mvp"));
+        renderChart(players, document.getElementById("rank-chart"));
+        renderTable(players, document.getElementById("ranking"));
+        initSearch(document.getElementById("search"), "#ranking tr");
+        initToggle(document.getElementById("toggle"), "#ranking tr");
+      }
+      document.addEventListener("DOMContentLoaded", init);
+    </script>
+    <script type="module" src="scripts/playerStats.js"></script>
+    <script type="module" src="scripts/quickStats.js"></script>
+  </body>
 </html>

--- a/scripts/quickStats.js
+++ b/scripts/quickStats.js
@@ -1,0 +1,177 @@
+// Quick stats popover
+const STYLE_ID = "quick-stats-style";
+if (!document.getElementById(STYLE_ID)) {
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+  #quick-stats{position:absolute;min-width:200px;background:#222;color:#fff;border:2px solid #f39c12;border-radius:4px;padding:0.5rem;font-size:0.75rem;z-index:10000;}
+  #quick-stats.bottom{left:0;right:0;bottom:0;top:auto;width:auto;margin:0;position:fixed;}
+  #quick-stats h4{margin-bottom:0.5rem;}
+  #quick-stats ul{list-style:none;padding:0;margin:0;}
+  #quick-stats li{margin:0.25rem 0;}
+  #quick-stats button{margin-top:0.5rem;padding:0.25rem 0.5rem;background:#444;border:1px solid #f39c12;color:#f39c12;font-family:inherit;cursor:pointer;}
+  .qs-loading{display:flex;gap:4px;justify-content:center;}
+  .qs-loading div{width:6px;height:6px;background:#f39c12;animation:qs-blink 1s infinite;}
+  .qs-loading div:nth-child(2){animation-delay:0.2s;}
+  .qs-loading div:nth-child(3){animation-delay:0.4s;}
+  @keyframes qs-blink{0%,80%,100%{opacity:0;}40%{opacity:1;}}
+  `;
+  document.head.appendChild(style);
+}
+
+const GAMES_URL =
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv";
+
+export async function showQuickStats(nick, evt) {
+  const existing = document.getElementById("quick-stats");
+  if (existing) existing.remove();
+  const el = document.createElement("div");
+  el.id = "quick-stats";
+  el.innerHTML =
+    '<div class="qs-loading"><div></div><div></div><div></div></div>';
+  if (window.matchMedia("(pointer:coarse)").matches) {
+    el.classList.add("bottom");
+  } else {
+    el.style.left = evt.clientX + 10 + "px";
+    el.style.top = evt.clientY + 10 + "px";
+  }
+  document.body.appendChild(el);
+  const close = () => {
+    el.remove();
+    document.removeEventListener("keydown", onKey);
+    document.removeEventListener("click", onDoc, true);
+  };
+  const onKey = (e) => {
+    if (e.key === "Escape") close();
+  };
+  const onDoc = (e) => {
+    if (!el.contains(e.target)) close();
+  };
+  setTimeout(() => document.addEventListener("click", onDoc, true));
+  document.addEventListener("keydown", onKey);
+
+  const render = (data) => {
+    if (!data) {
+      el.innerHTML = "<p>N/A</p>";
+      return;
+    }
+    const val = (v) =>
+      v === undefined || v === null || Number.isNaN(v) || v === "N/A"
+        ? "N/A"
+        : v;
+    el.innerHTML = `<h4>${nick}</h4>
+    <ul>
+      <li>Matches: ${val(data.matches)}</li>
+      <li>Rounds: ${val(data.rounds)}</li>
+      <li>Wins/Losses: ${val(data.wins)}/${val(data.losses)}</li>
+      <li>K/D: ${val(data.kd)}</li>
+      <li>Top teammates: ${data.teammates.length ? data.teammates.join(", ") : "N/A"}</li>
+    </ul>
+    <button id="qs-open">Profile</button>`;
+    document.getElementById("qs-open").addEventListener("click", () => {
+      window.location.href = `profile.html?nick=${encodeURIComponent(nick)}`;
+    });
+  };
+
+  const key = `quickStats:${nick}`;
+  try {
+    const cached = localStorage.getItem(key);
+    if (cached) {
+      const obj = JSON.parse(cached);
+      if (Date.now() - obj.ts < 6 * 60 * 60 * 1000) {
+        render(obj.data);
+        return;
+      }
+    }
+  } catch (e) {
+    /* ignore */
+  }
+
+  try {
+    const txt = await fetch(GAMES_URL).then((r) => r.text());
+    const rows = Papa.parse(txt, { header: true, skipEmptyLines: true }).data;
+    const data = computeStats(rows, nick);
+    render(data);
+    try {
+      localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data }));
+    } catch (e) {
+      /* ignore */
+    }
+  } catch (err) {
+    render(null);
+  }
+}
+
+function computeStats(rows, nick) {
+  let matches = 0;
+  let rounds = 0;
+  let wins = 0;
+  let losses = 0;
+  let kills = 0;
+  let deaths = 0;
+  let valid = true;
+  const mates = {};
+  rows.forEach((g) => {
+    const t1 = (g.Team1 || "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const t2 = (g.Team2 || "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    let team, opp;
+    if (t1.includes(nick)) {
+      team = t1;
+      opp = t2;
+    } else if (t2.includes(nick)) {
+      team = t2;
+      opp = t1;
+    } else return;
+    matches++;
+    team.forEach((n) => {
+      if (n !== nick) mates[n] = (mates[n] || 0) + 1;
+    });
+    const s1 = parseInt(g.Score1, 10);
+    const s2 = parseInt(g.Score2, 10);
+    if (!isNaN(s1) && !isNaN(s2)) {
+      rounds += s1 + s2;
+      if (team === t1) {
+        kills += s1;
+        deaths += s2;
+      } else {
+        kills += s2;
+        deaths += s1;
+      }
+    } else {
+      valid = false;
+    }
+    const winner = g.Winner;
+    if (winner === "team1" || winner === "team2") {
+      const pt = team === t1 ? "team1" : "team2";
+      if (winner === pt) wins++;
+      else losses++;
+    } else {
+      valid = false;
+    }
+  });
+  const kd =
+    !valid || deaths === 0
+      ? valid && kills > 0 && deaths === 0
+        ? "Inf"
+        : "N/A"
+      : (kills / deaths).toFixed(2);
+  return {
+    matches: valid ? matches : "N/A",
+    rounds: valid ? rounds : "N/A",
+    wins: valid ? wins : "N/A",
+    losses: valid ? losses : "N/A",
+    kd,
+    teammates: Object.entries(mates)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([n, c]) => `${n} (${c})`),
+  };
+}
+
+window.showQuickStats = showQuickStats;

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,134 +1,157 @@
 import { getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL } from "./api.js";
-export async function loadData(rankingURL, gamesURL){
+export async function loadData(rankingURL, gamesURL) {
   const [rText, gText] = await Promise.all([
-    fetch(rankingURL).then(r=>r.text()),
-    fetch(gamesURL).then(r=>r.text())
+    fetch(rankingURL).then((r) => r.text()),
+    fetch(gamesURL).then((r) => r.text()),
   ]);
-  const rank = Papa.parse(rText,{header:true,skipEmptyLines:true}).data;
-  const games = Papa.parse(gText,{header:true,skipEmptyLines:true}).data;
-  return {rank, games};
+  const rank = Papa.parse(rText, { header: true, skipEmptyLines: true }).data;
+  const games = Papa.parse(gText, { header: true, skipEmptyLines: true }).data;
+  return { rank, games };
 }
 
-export function computeStats(rank, games, {alias={}, league}={}){
-  const stats={};
-  let totalRounds=0;
-  const filtered = league? games.filter(g=>g.League===league): games;
-  filtered.forEach(g=>{
-    const t1=g.Team1.split(',').map(n=>alias[n.trim()]||n.trim());
-    const t2=g.Team2.split(',').map(n=>alias[n.trim()]||n.trim());
-    const winKey=g.Winner;
-    const winT=winKey==='team1'?t1:winKey==='team2'?t2:[];
-    t1.concat(t2).forEach(n=>{stats[n]=stats[n]||{games:0,wins:0,mvp:0};stats[n].games++;});
-    winT.forEach(n=>stats[n].wins++);
-    const m=alias[g.MVP]||g.MVP;
-    if(stats[m]) stats[m].mvp++;
-    let s1=parseInt(g.Score1,10); let s2=parseInt(g.Score2,10);
-    if(isNaN(s1)||isNaN(s2)){
-      const mScore=(g.Series||g.series||'').match(/(\d+)\D+(\d+)/);
-      if(mScore){ s1=parseInt(mScore[1],10); s2=parseInt(mScore[2],10); }
+export function computeStats(rank, games, { alias = {}, league } = {}) {
+  const stats = {};
+  let totalRounds = 0;
+  const filtered = league ? games.filter((g) => g.League === league) : games;
+  filtered.forEach((g) => {
+    const t1 = g.Team1.split(",").map((n) => alias[n.trim()] || n.trim());
+    const t2 = g.Team2.split(",").map((n) => alias[n.trim()] || n.trim());
+    const winKey = g.Winner;
+    const winT = winKey === "team1" ? t1 : winKey === "team2" ? t2 : [];
+    t1.concat(t2).forEach((n) => {
+      stats[n] = stats[n] || { games: 0, wins: 0, mvp: 0 };
+      stats[n].games++;
+    });
+    winT.forEach((n) => stats[n].wins++);
+    const m = alias[g.MVP] || g.MVP;
+    if (stats[m]) stats[m].mvp++;
+    let s1 = parseInt(g.Score1, 10);
+    let s2 = parseInt(g.Score2, 10);
+    if (isNaN(s1) || isNaN(s2)) {
+      const mScore = (g.Series || g.series || "").match(/(\d+)\D+(\d+)/);
+      if (mScore) {
+        s1 = parseInt(mScore[1], 10);
+        s2 = parseInt(mScore[2], 10);
+      }
     }
-    if(!isNaN(s1)&&!isNaN(s2)) totalRounds+=s1+s2;
+    if (!isNaN(s1) && !isNaN(s2)) totalRounds += s1 + s2;
   });
-  const totalGames=filtered.length;
-  const dates=filtered.map(g=>new Date(g.Timestamp)).filter(d=>!isNaN(d));
-  const minDate=dates.length?dates.reduce((a,b)=>a<b?a:b):null;
-  const maxDate=dates.length?dates.reduce((a,b)=>a>b?a:b):null;
-  const players=rank.map(r=>{
-    const nick=alias[r.Nickname]||r.Nickname;
-    const p={nickname:nick,points:+r.Points||0,
-             games:stats[nick]?.games||0,
-             wins: stats[nick]?.wins||0,
-             mvp:  stats[nick]?.mvp||0};
-    p.losses=p.games-p.wins;
-    p.winRate=p.games?((p.wins/p.games*100).toFixed(2)):'0';
-    return p;
-  }).sort((a,b)=>b.points-a.points);
-  return {players,totalGames,totalRounds,minDate,maxDate};
+  const totalGames = filtered.length;
+  const dates = filtered
+    .map((g) => new Date(g.Timestamp))
+    .filter((d) => !isNaN(d));
+  const minDate = dates.length ? dates.reduce((a, b) => (a < b ? a : b)) : null;
+  const maxDate = dates.length ? dates.reduce((a, b) => (a > b ? a : b)) : null;
+  const players = rank
+    .map((r) => {
+      const nick = alias[r.Nickname] || r.Nickname;
+      const p = {
+        nickname: nick,
+        points: +r.Points || 0,
+        games: stats[nick]?.games || 0,
+        wins: stats[nick]?.wins || 0,
+        mvp: stats[nick]?.mvp || 0,
+      };
+      p.losses = p.games - p.wins;
+      p.winRate = p.games ? ((p.wins / p.games) * 100).toFixed(2) : "0";
+      return p;
+    })
+    .sort((a, b) => b.points - a.points);
+  return { players, totalGames, totalRounds, minDate, maxDate };
 }
 
-export function getRankClass(points){
-  if(points>=1200) return 'rank-S';
-  if(points>=800 ) return 'rank-A';
-  if(points>=500 ) return 'rank-B';
-  if(points>=200 ) return 'rank-C';
-  return 'rank-D';
+export function getRankClass(points) {
+  if (points >= 1200) return "rank-S";
+  if (points >= 800) return "rank-A";
+  if (points >= 500) return "rank-B";
+  if (points >= 200) return "rank-C";
+  return "rank-D";
 }
 
-
-export function renderChart(list, chartEl){
-  const counts={S:0,A:0,B:0,C:0,D:0};
-  list.forEach(p=>{
-    const r=getRankClass(p.points).replace('rank-','');
-    counts[r]=(counts[r]||0)+1;
+export function renderChart(list, chartEl) {
+  const counts = { S: 0, A: 0, B: 0, C: 0, D: 0 };
+  list.forEach((p) => {
+    const r = getRankClass(p.points).replace("rank-", "");
+    counts[r] = (counts[r] || 0) + 1;
   });
-  const total=list.length||1;
-  chartEl.innerHTML='';
-  ['S','A','B','C','D'].forEach(r=>{
-    const pct=Math.round(counts[r]/total*100);
-    if(!pct) return;
-    const div=document.createElement('div');
-    div.className='seg-'+r;
-    div.style.width=pct+'%';
-    div.textContent=pct+'%';
+  const total = list.length || 1;
+  chartEl.innerHTML = "";
+  ["S", "A", "B", "C", "D"].forEach((r) => {
+    const pct = Math.round((counts[r] / total) * 100);
+    if (!pct) return;
+    const div = document.createElement("div");
+    div.className = "seg-" + r;
+    div.style.width = pct + "%";
+    div.textContent = pct + "%";
     chartEl.appendChild(div);
   });
 }
 
-export function renderTable(list, tbodyEl){
-  tbodyEl.innerHTML='';
-  list.forEach((p,i)=>{
-    const tr=document.createElement('tr');
-    const cls=getRankClass(p.points);
-    tr.className=cls+(i>=10?' hidden':'');
+export function renderTable(list, tbodyEl) {
+  tbodyEl.innerHTML = "";
+  list.forEach((p, i) => {
+    const tr = document.createElement("tr");
+    const cls = getRankClass(p.points);
+    tr.className = cls + (i >= 10 ? " hidden" : "");
 
-    const tdAvatar=document.createElement('td');
-    const img=document.createElement('img');
-    img.className='avatar-img';
-    img.alt=p.nickname;
-    img.dataset.nick=p.nickname;
-    img.src=getAvatarURL(p.nickname);
-    img.onerror=()=>{
-      img.onerror=()=>{
-        img.onerror=()=>{img.src='https://via.placeholder.com/40';};
-        img.src=getDefaultAvatarURL();
+    const tdAvatar = document.createElement("td");
+    const img = document.createElement("img");
+    img.className = "avatar-img";
+    img.alt = p.nickname;
+    img.dataset.nick = p.nickname;
+    img.src = getAvatarURL(p.nickname);
+    img.onerror = () => {
+      img.onerror = () => {
+        img.onerror = () => {
+          img.src = "https://via.placeholder.com/40";
+        };
+        img.src = getDefaultAvatarURL();
       };
-      img.src=getProxyAvatarURL(p.nickname);
+      img.src = getProxyAvatarURL(p.nickname);
     };
     tdAvatar.appendChild(img);
 
-    const vals=[i+1,p.nickname,cls.replace('rank-',''),p.points,p.games,p.winRate+'%',p.mvp];
-    vals.forEach((val,idx)=>{
-      const td=document.createElement('td');
-      if(idx===1){
-        td.className=cls.replace('rank-','nick-');
-        td.style.cursor='pointer';
-        td.addEventListener('click', () => {
-          const url = `profile.html?nick=${encodeURIComponent(p.nickname)}`;
-          window.location.href = url;
-        });
+    const vals = [
+      i + 1,
+      p.nickname,
+      cls.replace("rank-", ""),
+      p.points,
+      p.games,
+      p.winRate + "%",
+      p.mvp,
+    ];
+    vals.forEach((val, idx) => {
+      const td = document.createElement("td");
+      if (idx === 1) {
+        td.className = cls.replace("rank-", "nick-");
+        td.style.cursor = "pointer";
+        td.addEventListener("click", (e) => showQuickStats(p.nickname, e));
       }
-      td.textContent=val;
+      td.textContent = val;
       tr.appendChild(td);
     });
-    tr.insertBefore(tdAvatar,tr.children[1]);
+    tr.insertBefore(tdAvatar, tr.children[1]);
     tbodyEl.appendChild(tr);
   });
 }
 
-export function renderTopMVP(list, container){
-  const top=list.slice().sort((a,b)=>b.mvp-a.mvp).slice(0,3);
-  container.innerHTML='';
-  top.forEach(p=>{
-    const c=document.createElement('div');
-    c.className='mvp-card';
-    const crown=document.createElement('div');
-    crown.style.fontSize='2rem';
-    crown.textContent='\uD83D\uDC51';
-    const h=document.createElement('h3');
-    h.className=getRankClass(p.points).replace('rank-','nick-');
-    h.textContent=p.nickname;
-    const stat=document.createElement('div');
-    stat.textContent=p.mvp+' MVP';
+export function renderTopMVP(list, container) {
+  const top = list
+    .slice()
+    .sort((a, b) => b.mvp - a.mvp)
+    .slice(0, 3);
+  container.innerHTML = "";
+  top.forEach((p) => {
+    const c = document.createElement("div");
+    c.className = "mvp-card";
+    const crown = document.createElement("div");
+    crown.style.fontSize = "2rem";
+    crown.textContent = "\uD83D\uDC51";
+    const h = document.createElement("h3");
+    h.className = getRankClass(p.points).replace("rank-", "nick-");
+    h.textContent = p.nickname;
+    const stat = document.createElement("div");
+    stat.textContent = p.mvp + " MVP";
     c.appendChild(crown);
     c.appendChild(h);
     c.appendChild(stat);
@@ -136,49 +159,63 @@ export function renderTopMVP(list, container){
   });
 }
 
-export function initSearch(inputEl, rowSelector){
-  inputEl.addEventListener('input',e=>{
-    const q=e.target.value.toLowerCase();
-    document.querySelectorAll(rowSelector).forEach(tr=>{
-      tr.style.display=tr.textContent.toLowerCase().includes(q)?'':'none';
+export function initSearch(inputEl, rowSelector) {
+  inputEl.addEventListener("input", (e) => {
+    const q = e.target.value.toLowerCase();
+    document.querySelectorAll(rowSelector).forEach((tr) => {
+      tr.style.display = tr.textContent.toLowerCase().includes(q) ? "" : "none";
     });
   });
 }
 
-export function initToggle(btnEl, rowSelector){
-  btnEl.addEventListener('click',()=>{
-    const expanded=btnEl.textContent==='\u0412\u0441\u0456 \u0433\u0440\u0430\u0432\u0446\u0456';
-    document.querySelectorAll(rowSelector).forEach((tr,i)=>{
-      if(i>=10) tr.style.display=expanded?'table-row':'none';
+export function initToggle(btnEl, rowSelector) {
+  btnEl.addEventListener("click", () => {
+    const expanded =
+      btnEl.textContent ===
+      "\u0412\u0441\u0456 \u0433\u0440\u0430\u0432\u0446\u0456";
+    document.querySelectorAll(rowSelector).forEach((tr, i) => {
+      if (i >= 10) tr.style.display = expanded ? "table-row" : "none";
     });
-    btnEl.textContent=expanded?'\u0422\u043e\u043f-10':'\u0412\u0441\u0456 \u0433\u0440\u0430\u0432\u0446\u0456';
+    btnEl.textContent = expanded
+      ? "\u0422\u043e\u043f-10"
+      : "\u0412\u0441\u0456 \u0433\u0440\u0430\u0432\u0446\u0456";
   });
 }
 
-export function formatD(d){
-  return d?('0'+d.getDate()).slice(-2)+'.'+('0'+(d.getMonth()+1)).slice(-2):'-';
+export function formatD(d) {
+  return d
+    ? ("0" + d.getDate()).slice(-2) + "." + ("0" + (d.getMonth() + 1)).slice(-2)
+    : "-";
 }
 
-export function formatFull(d){
-  if(!d) return '-';
-  return ('0'+d.getDate()).slice(-2)+'.'+('0'+(d.getMonth()+1)).slice(-2)+'.'+d.getFullYear();
+export function formatFull(d) {
+  if (!d) return "-";
+  return (
+    ("0" + d.getDate()).slice(-2) +
+    "." +
+    ("0" + (d.getMonth() + 1)).slice(-2) +
+    "." +
+    d.getFullYear()
+  );
 }
 
-export function refreshAvatars(){
-  document.querySelectorAll('img.avatar-img[data-nick]').forEach(img=>{
-    img.src=getAvatarURL(img.dataset.nick);
-    img.onerror=()=>{
-      img.onerror=()=>{
-        img.onerror=()=>{img.src='https://via.placeholder.com/40';};
-        img.src=getDefaultAvatarURL();
+export function refreshAvatars() {
+  document.querySelectorAll("img.avatar-img[data-nick]").forEach((img) => {
+    img.src = getAvatarURL(img.dataset.nick);
+    img.onerror = () => {
+      img.onerror = () => {
+        img.onerror = () => {
+          img.src = "https://via.placeholder.com/40";
+        };
+        img.src = getDefaultAvatarURL();
       };
-      img.src=getProxyAvatarURL(img.dataset.nick);
+      img.src = getProxyAvatarURL(img.dataset.nick);
     };
   });
 }
 
-if(typeof window!=='undefined'){
-  window.addEventListener('storage',e=>{
-    if(e.key==='avatarRefresh') refreshAvatars();
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === "avatarRefresh") refreshAvatars();
   });
 }

--- a/sunday.html
+++ b/sunday.html
@@ -1,175 +1,363 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="uk">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Старша ліга | Лазертаг</title>
-  <!-- Піксельний шрифт -->
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <!-- PapaParse для CSV -->
-  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
-  <style>
-    /* Базові стилі */
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
-      font-family: 'Press Start 2P', monospace;
-      background: #111 url('assets/background_marathon.png') no-repeat center/cover;
-      color: #fff;
-      cursor: url('assets/cursor.png') 4 4, auto;
-    }
-    /* Навігація */
-    nav {
-      display: flex; flex-wrap: wrap; justify-content: center; gap: 1rem;
-      background: rgba(0,0,0,0.7); padding: 0.75rem;
-    }
-    nav a {
-      color: #f39c12; text-decoration: none; font-size: 0.75rem;
-      padding: 0.25rem 0.5rem; border-radius: 3px;
-      transition: color 0.2s, background 0.2s;
-    }
-    nav a.active,
-    nav a:hover {
-      color: #000; background: #ffd700;
-    }
-    /* Контейнер */
-    .container { max-width: 1200px; margin: 1rem auto; padding: 0 1rem; }
-    .season-info, .summary { text-align: center; margin-bottom: 1rem; }
-    .season-info { color: #f39c12; }
-    .rank-chart {
-      display: flex;
-      height: 1rem;
-      max-width: 400px;
-      margin: 0.5rem auto;
-      border: 1px solid #555;
-      border-radius: 4px;
-      overflow: hidden;
-      font-size: 0.6rem;
-      color: #000;
-    }
-    .rank-chart div { display:flex; align-items:center; justify-content:center; }
-    .seg-S { background: magenta; }
-    .seg-A { background: red; }
-    .seg-B { background: yellow; }
-    .seg-C { background: cyan; }
-    .seg-D { background: lime; }
-    .summary { color: #ccc; font-size: 0.9rem; }
-    /* Пошук */
-    .search-box { text-align: center; margin-bottom: 1rem; }
-    .search-box input {
-      padding: 0.5rem; width: 100%; max-width: 300px;
-      border: 2px solid #555; background: rgba(0,0,0,0.5);
-      color: #fff; border-radius: 4px; font-size: 0.75rem;
-    }
-    /* Top MVP */
-    .top-mvp { display: flex; justify-content: center; gap: 1rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
-    .mvp-card {
-      background: rgba(243,156,18,0.2);
-      border: 2px solid #f39c12; border-radius: 6px;
-      padding: 1rem; min-width: 140px; text-align: center;
-      font-family: 'Press Start 2P', monospace; color: #fff;
-    }
-    .mvp-card h3 { margin: 0.5rem 0; font-size: 0.8rem; }
-    .mvp-card .stats { font-size: 0.7rem; margin-top: 0.25rem; color: #ccc; }
-    /* Таблиця */
-    .table-container { overflow-x: auto; margin-bottom: 1rem; }
-    table { width: 100%; border-collapse: collapse; min-width: 600px; font-size: 0.75rem; }
-    thead th {
-      position: sticky; top: 0; background: #222; color: #f39c12;
-      padding: 0.75rem; border-bottom: 2px solid #555; z-index: 1;
-    }
-    th, td { padding: 0.5rem; border: 1px solid #444; text-align: center; }
-    tbody tr:nth-child(odd) { background: rgba(255,255,255,0.05); }
-    tbody tr:hover { background: rgba(255,255,255,0.1); }
-    .avatar-img { width: 40px; height: 40px; object-fit: cover; }
-    /* Кнопка */
-    .show-more {
-      display: block; margin: 1rem auto; padding: 0.75rem 1.5rem;
-      background: #222; color: #f39c12; border: 2px solid #f39c12; border-radius: 4px;
-      font-family: 'Press Start 2P', monospace; font-size: 0.75rem; text-transform: uppercase;
-      cursor: url('assets/cursor.png') 4 4, auto; transition: transform 0.2s;
-    }
-    .show-more:hover { transform: scale(1.05); }
-    /* Ранги */
-    .rank-S td { border-left: 4px solid magenta; }
-    .rank-A td { border-left: 4px solid red; }
-    .rank-B td { border-left: 4px solid yellow; }
-    .rank-C td { border-left: 4px solid cyan; }
-    .rank-D td { border-left: 4px solid lime; }
-    .nick-S { color: magenta; }
-    .nick-A { color: red; }
-    .nick-B { color: yellow; }
-    .nick-C { color: cyan; }
-    .nick-D { color: lime; }
-    .hidden { display: none; }
-    .modal { position: fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.8); display:flex; align-items:center; justify-content:center; z-index:1000; }
-    .modal.hidden { display:none; }
-    .modal-content { background:#222; padding:1rem; border-radius:4px; max-height:90%; overflow:auto; }
-    #stats-close { float:right; background:#444; border:none; color:#fff; cursor:pointer; padding:0.25rem 0.5rem; }
-    @media(max-width:600px) {
-      table { min-width: 480px; }
-      nav { gap: 0.5rem; padding: 0.5rem; }
-      nav a { font-size: 0.6rem; padding: 0.25rem; }
-    }
-  </style>
-</head>
-<body>
-  <nav>
-    <a href="index.html">Молодша Ліга</a>
-    <a href="sunday.html" class="active">Старша Ліга</a>
-    <a href="gameday.html">Ігровий день</a>
-    <a href="rules.html">Правила</a>
-    <a href="about.html">Про клуб</a>
-  </nav>
-  <div class="container">
-    <div id="season-info" class="season-info"></div>
-    <div class="summary" id="summary"></div>
-    <div id="rank-chart" class="rank-chart"></div>
-    <div class="search-box"><input type="text" id="search" placeholder="Пошук нікнейму…" /></div>
-    <div class="top-mvp" id="top-mvp"></div>
-    <div class="table-container">
-      <table>
-        <thead>
-          <tr>
-            <th>Місце</th>
-            <th>Аватар</th>
-            <th>Нікнейм</th>
-            <th>Ранг</th>
-            <th>Бали</th>
-            <th>Ігор</th>
-            <th>% Win</th>
-            <th>MVP</th>
-          </tr>
-        </thead>
-        <tbody id="ranking"></tbody>
-      </table>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Старша ліга | Лазертаг</title>
+    <!-- Піксельний шрифт -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
+      rel="stylesheet"
+    />
+    <!-- PapaParse для CSV -->
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+    <style>
+      /* Базові стилі */
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: "Press Start 2P", monospace;
+        background: #111 url("assets/background_marathon.png") no-repeat
+          center/cover;
+        color: #fff;
+        cursor:
+          url("assets/cursor.png") 4 4,
+          auto;
+      }
+      /* Навігація */
+      nav {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 1rem;
+        background: rgba(0, 0, 0, 0.7);
+        padding: 0.75rem;
+      }
+      nav a {
+        color: #f39c12;
+        text-decoration: none;
+        font-size: 0.75rem;
+        padding: 0.25rem 0.5rem;
+        border-radius: 3px;
+        transition:
+          color 0.2s,
+          background 0.2s;
+      }
+      nav a.active,
+      nav a:hover {
+        color: #000;
+        background: #ffd700;
+      }
+      /* Контейнер */
+      .container {
+        max-width: 1200px;
+        margin: 1rem auto;
+        padding: 0 1rem;
+      }
+      .season-info,
+      .summary {
+        text-align: center;
+        margin-bottom: 1rem;
+      }
+      .season-info {
+        color: #f39c12;
+      }
+      .rank-chart {
+        display: flex;
+        height: 1rem;
+        max-width: 400px;
+        margin: 0.5rem auto;
+        border: 1px solid #555;
+        border-radius: 4px;
+        overflow: hidden;
+        font-size: 0.6rem;
+        color: #000;
+      }
+      .rank-chart div {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .seg-S {
+        background: magenta;
+      }
+      .seg-A {
+        background: red;
+      }
+      .seg-B {
+        background: yellow;
+      }
+      .seg-C {
+        background: cyan;
+      }
+      .seg-D {
+        background: lime;
+      }
+      .summary {
+        color: #ccc;
+        font-size: 0.9rem;
+      }
+      /* Пошук */
+      .search-box {
+        text-align: center;
+        margin-bottom: 1rem;
+      }
+      .search-box input {
+        padding: 0.5rem;
+        width: 100%;
+        max-width: 300px;
+        border: 2px solid #555;
+        background: rgba(0, 0, 0, 0.5);
+        color: #fff;
+        border-radius: 4px;
+        font-size: 0.75rem;
+      }
+      /* Top MVP */
+      .top-mvp {
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin-bottom: 1.5rem;
+      }
+      .mvp-card {
+        background: rgba(243, 156, 18, 0.2);
+        border: 2px solid #f39c12;
+        border-radius: 6px;
+        padding: 1rem;
+        min-width: 140px;
+        text-align: center;
+        font-family: "Press Start 2P", monospace;
+        color: #fff;
+      }
+      .mvp-card h3 {
+        margin: 0.5rem 0;
+        font-size: 0.8rem;
+      }
+      .mvp-card .stats {
+        font-size: 0.7rem;
+        margin-top: 0.25rem;
+        color: #ccc;
+      }
+      /* Таблиця */
+      .table-container {
+        overflow-x: auto;
+        margin-bottom: 1rem;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        min-width: 600px;
+        font-size: 0.75rem;
+      }
+      thead th {
+        position: sticky;
+        top: 0;
+        background: #222;
+        color: #f39c12;
+        padding: 0.75rem;
+        border-bottom: 2px solid #555;
+        z-index: 1;
+      }
+      th,
+      td {
+        padding: 0.5rem;
+        border: 1px solid #444;
+        text-align: center;
+      }
+      tbody tr:nth-child(odd) {
+        background: rgba(255, 255, 255, 0.05);
+      }
+      tbody tr:hover {
+        background: rgba(255, 255, 255, 0.1);
+      }
+      .avatar-img {
+        width: 40px;
+        height: 40px;
+        object-fit: cover;
+      }
+      /* Кнопка */
+      .show-more {
+        display: block;
+        margin: 1rem auto;
+        padding: 0.75rem 1.5rem;
+        background: #222;
+        color: #f39c12;
+        border: 2px solid #f39c12;
+        border-radius: 4px;
+        font-family: "Press Start 2P", monospace;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        cursor:
+          url("assets/cursor.png") 4 4,
+          auto;
+        transition: transform 0.2s;
+      }
+      .show-more:hover {
+        transform: scale(1.05);
+      }
+      /* Ранги */
+      .rank-S td {
+        border-left: 4px solid magenta;
+      }
+      .rank-A td {
+        border-left: 4px solid red;
+      }
+      .rank-B td {
+        border-left: 4px solid yellow;
+      }
+      .rank-C td {
+        border-left: 4px solid cyan;
+      }
+      .rank-D td {
+        border-left: 4px solid lime;
+      }
+      .nick-S {
+        color: magenta;
+      }
+      .nick-A {
+        color: red;
+      }
+      .nick-B {
+        color: yellow;
+      }
+      .nick-C {
+        color: cyan;
+      }
+      .nick-D {
+        color: lime;
+      }
+      .hidden {
+        display: none;
+      }
+      .modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.8);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+      }
+      .modal.hidden {
+        display: none;
+      }
+      .modal-content {
+        background: #222;
+        padding: 1rem;
+        border-radius: 4px;
+        max-height: 90%;
+        overflow: auto;
+      }
+      #stats-close {
+        float: right;
+        background: #444;
+        border: none;
+        color: #fff;
+        cursor: pointer;
+        padding: 0.25rem 0.5rem;
+      }
+      @media (max-width: 600px) {
+        table {
+          min-width: 480px;
+        }
+        nav {
+          gap: 0.5rem;
+          padding: 0.5rem;
+        }
+        nav a {
+          font-size: 0.6rem;
+          padding: 0.25rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <a href="index.html">Молодша Ліга</a>
+      <a href="sunday.html" class="active">Старша Ліга</a>
+      <a href="gameday.html">Ігровий день</a>
+      <a href="rules.html">Правила</a>
+      <a href="about.html">Про клуб</a>
+    </nav>
+    <div class="container">
+      <div id="season-info" class="season-info"></div>
+      <div class="summary" id="summary"></div>
+      <div id="rank-chart" class="rank-chart"></div>
+      <div class="search-box">
+        <input type="text" id="search" placeholder="Пошук нікнейму…" />
+      </div>
+      <div class="top-mvp" id="top-mvp"></div>
+      <div class="table-container">
+        <table>
+          <thead>
+            <tr>
+              <th>Місце</th>
+              <th>Аватар</th>
+              <th>Нікнейм</th>
+              <th>Ранг</th>
+              <th>Бали</th>
+              <th>Ігор</th>
+              <th>% Win</th>
+              <th>MVP</th>
+            </tr>
+          </thead>
+          <tbody id="ranking"></tbody>
+        </table>
+      </div>
+      <button class="show-more" id="toggle">Всі гравці</button>
     </div>
-    <button class="show-more" id="toggle">Всі гравці</button>
-  </div>
-  <div id="stats-modal" class="modal hidden">
-    <div class="modal-content">
-      <button id="stats-close">✕</button>
-      <div id="stats-body"></div>
+    <div id="stats-modal" class="modal hidden">
+      <div class="modal-content">
+        <button id="stats-close">✕</button>
+        <div id="stats-body"></div>
+      </div>
     </div>
-  </div>
-<script type="module">
-  import {loadData,computeStats,renderTopMVP,renderChart,renderTable,initSearch,initToggle,formatD,formatFull} from './scripts/ranking.js';
-  const rankingURL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv";
-  const gamesURL   = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv";
-  const alias = {"Romario":"Zavodchanyn","Mariko":"Gidora","Timabuilding":"Бойбуд"};
-  const league = 'sunday';
-  async function init(){
-    const {rank,games} = await loadData(rankingURL,gamesURL);
-    const {players,totalGames,totalRounds,minDate,maxDate} = computeStats(rank,games,{alias,league});
-    document.getElementById('summary').textContent = `Ігор: ${totalGames} (${totalRounds} раундів). Період: ${formatD(minDate)}–${formatD(maxDate)}`;
-    document.getElementById('season-info').textContent = `Перший сезон — старт ${formatFull(minDate)}`;
-    renderTopMVP(players, document.getElementById('top-mvp'));
-    renderChart(players, document.getElementById('rank-chart'));
-    renderTable(players, document.getElementById('ranking'));
-    initSearch(document.getElementById('search'), '#ranking tr');
-    initToggle(document.getElementById('toggle'), '#ranking tr');
-  }
-  document.addEventListener('DOMContentLoaded', init);
-</script>
-<script type="module" src="scripts/playerStats.js"></script>
-</body>
+    <script type="module">
+      import {
+        loadData,
+        computeStats,
+        renderTopMVP,
+        renderChart,
+        renderTable,
+        initSearch,
+        initToggle,
+        formatD,
+        formatFull,
+      } from "./scripts/ranking.js";
+      const rankingURL =
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv";
+      const gamesURL =
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv";
+      const alias = {
+        Romario: "Zavodchanyn",
+        Mariko: "Gidora",
+        Timabuilding: "Бойбуд",
+      };
+      const league = "sunday";
+      async function init() {
+        const { rank, games } = await loadData(rankingURL, gamesURL);
+        const { players, totalGames, totalRounds, minDate, maxDate } =
+          computeStats(rank, games, { alias, league });
+        document.getElementById("summary").textContent =
+          `Ігор: ${totalGames} (${totalRounds} раундів). Період: ${formatD(minDate)}–${formatD(maxDate)}`;
+        document.getElementById("season-info").textContent =
+          `Перший сезон — старт ${formatFull(minDate)}`;
+        renderTopMVP(players, document.getElementById("top-mvp"));
+        renderChart(players, document.getElementById("rank-chart"));
+        renderTable(players, document.getElementById("ranking"));
+        initSearch(document.getElementById("search"), "#ranking tr");
+        initToggle(document.getElementById("toggle"), "#ranking tr");
+      }
+      document.addEventListener("DOMContentLoaded", init);
+    </script>
+    <script type="module" src="scripts/playerStats.js"></script>
+    <script type="module" src="scripts/quickStats.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add quick stats module with cached player stats popover
- wire ranking tables to open quick stats instead of profile
- load quick stats script on ranking pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx prettier -w scripts/quickStats.js scripts/ranking.js index.html sunday.html`
- `node --check scripts/quickStats.js`
- `node --check scripts/ranking.js`


------
https://chatgpt.com/codex/tasks/task_e_6893533972048321a08d12dd3d748c98