### PR TITLE
feat: update lobby state without reload

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -52,11 +52,11 @@ export async function saveResult(data) {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body
   });
-  const text = await res.text();
   if(!res.ok){
+    const text = await res.text();
     throw new Error(text || ('HTTP '+res.status));
   }
-  return text;
+  return res.json();
 }
 
 

--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -1,9 +1,8 @@
 // scripts/arena.js
 
-import { saveResult, loadPlayers, saveDetailedStats } from './api.js';
+import { saveResult, saveDetailedStats } from './api.js';
 import { parseGamePdf }                   from './pdfParser.js';
-import { initLobby }                      from './lobby.js';
-import { initScenario }                   from './scenario.js';
+import { updateLobbyState }               from './lobby.js';
 import { teams }                          from './teams.js';
 
 // Дочекаємося, поки DOM завантажиться
@@ -129,17 +128,17 @@ document.addEventListener('DOMContentLoaded', () => {
       };
 
       const res = await saveResult(data);
-      if (res.trim() !== 'OK') {
-        alert('Помилка збереження: ' + res);
+      if (res.status !== 'OK') {
+        alert('Помилка збереження: ' + (res.status || res));
         return;
       }
 
       // Зберігаємо matchId для подальшого імпорту PDF
-      window.lastMatchId = Date.now();
+      window.lastMatchId = res.matchId || Date.now();
 
-      const updated = await loadPlayers(leagueSel.value);
-      initLobby(updated);
-      initScenario();
+      if (Array.isArray(res.players)) {
+        updateLobbyState(res.players);
+      }
 
       alert('Гру успішно збережено та рейтинги оновлено');
       localStorage.setItem('gamedayRefresh', Date.now());

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -21,6 +21,16 @@ export function initLobby(pl) {
   renderLobby();
 }
 
+export function updateLobbyState(updates){
+  updates.forEach(u=>{
+    const pAll = players.find(x=>x.nick===u.nick);
+    if(pAll) Object.assign(pAll, u);
+    const pLobby = lobby.find(x=>x.nick===u.nick);
+    if(pLobby) Object.assign(pLobby, u);
+  });
+  renderLobby();
+}
+
 // Рендер списку доступних гравців
 function renderSelect(arr) {
   document.getElementById('select-area').classList.remove('hidden');


### PR DESCRIPTION
## Summary
- update lobby state in place after saving results
- parse JSON responses from saveResult

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `npm run lint` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68935eea8a8c8321abf69dedef6c9190