### PR TITLE
Update lobby after saving game

### DIFF
--- a/gas/doPost.gs
+++ b/gas/doPost.gs
@@ -143,6 +143,7 @@ function doPost(e) {
     }
 
     const winnerKey = params.winner;
+    const updatedPlayers = [];
     allPlayers.forEach(nick => {
       const cell = rankSheet.getRange(2, nickCol, rankSheet.getLastRow() - 1, 1)
         .createTextFinder(nick).matchEntireCell(true).findNext();
@@ -163,10 +164,16 @@ function doPost(e) {
       const updated = cur + delta;
       rankSheet.getRange(row, ptsCol).setValue(updated);
       logS.appendRow([now, params.league, nick, delta, updated]);
+
+      const rankLetter = updated < 200 ? 'D'
+                         : updated < 500 ? 'C'
+                         : updated < 800 ? 'B'
+                         : updated < 1200 ? 'A' : 'S';
+      updatedPlayers.push({nick: nick, points: updated, rank: rankLetter});
     });
 
-    return ContentService.createTextOutput('OK')
-      .setMimeType(ContentService.MimeType.TEXT)
+    return ContentService.createTextOutput(JSON.stringify({status:'OK', players: updatedPlayers}))
+      .setMimeType(ContentService.MimeType.JSON)
       .setHeader('Access-Control-Allow-Origin','*');
   }
   catch (err) {

--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -102,7 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // --- Зберегти гру ---
-  btnSave.addEventListener('click', async () => {
+  async function saveGame(){
     try {
       const vs = (arenaVS.textContent.match(/\d+/g) || []).map(Number);
       if (vs.length !== 2) throw new Error('Неправильний формат арени');
@@ -148,7 +148,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const msg = err && err.message ? err.message : String(err);
       alert('Не вдалося зберегти гру:\n' + msg);
     }
-  });
+  }
+  btnSave.addEventListener('click', saveGame);
 
   // --- Скинути арену ---
   btnClear.addEventListener('click', () => {

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -23,10 +23,15 @@ export function initLobby(pl) {
 
 export function updateLobbyState(updates){
   updates.forEach(u=>{
+    const norm = {nick:u.nick};
+    if(u.points!==undefined) norm.pts = u.points;
+    if(u.pts!==undefined)    norm.pts = u.pts;
+    if(u.rank!==undefined)   norm.rank = u.rank;
+
     const pAll = players.find(x=>x.nick===u.nick);
-    if(pAll) Object.assign(pAll, u);
+    if(pAll) Object.assign(pAll, norm);
     const pLobby = lobby.find(x=>x.nick===u.nick);
-    if(pLobby) Object.assign(pLobby, u);
+    if(pLobby) Object.assign(pLobby, norm);
   });
   renderLobby();
 }


### PR DESCRIPTION
## Summary
- request updated stats from backend and merge them into existing lobby
- map returned points/rank to current lobby players without reloading teams
- backend now responds with updated participant stats

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68936183f4e88321984318814e97c3b3