### PR TITLE
feat: add player adder

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -39,6 +39,10 @@
     <!-- 2. Лоббі дня -->
     <section id="lobby-area" class="card">
       <h2>Лоббі дня</h2>
+      <div class="add-player">
+        <input type="text" id="addPlayerInput" placeholder="Нік гравця">
+        <button id="addPlayerBtn">Add</button>
+      </div>
       <table class="table">
         <thead>
           <tr><th>Нік</th><th>Бали</th><th>Ранг</th><th>Абонемент</th><th>→Команда / ✕</th></tr>

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -2,11 +2,18 @@
 
 import { initTeams, teams } from './teams.js';
 import { sortByName, sortByPtsDesc } from './sortUtils.js';
-import { updateAbonement } from './api.js';
+import { updateAbonement, fetchPlayerData } from './api.js';
 
 export let lobby = [];
 let players = [], filtered = [], selected = [], manualCount = 0;
 const ABONEMENT_TYPES = ['none', 'lite', 'full'];
+
+async function addPlayer(nick){
+  if(!nick) return;
+  const res = await fetchPlayerData(nick);
+  lobby.push({...res, team:null});
+  renderLobby();
+}
 
 // Ініціалізує лоббі новим набором гравців
 export function initLobby(pl) {
@@ -97,6 +104,14 @@ document.addEventListener('DOMContentLoaded', () => {
     selected = [];
     renderSelect(filtered);
   };
+
+  const addPlayerInput = document.getElementById('addPlayerInput');
+  const addPlayerBtn = document.getElementById('addPlayerBtn');
+  if(addPlayerInput && addPlayerBtn){
+    addPlayerBtn.addEventListener('click', () => {
+      addPlayer(addPlayerInput.value.trim());
+    });
+  }
 });
 
 // Встановлюємо кількість команд для ручного режиму


### PR DESCRIPTION
## Summary
- allow manual player entry in lobby page
- support adding players through API and render immediately

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689363537ed88321814f7e7abe041ee8