### PR TITLE
feat: add player creation modal and key issuing

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -11,6 +11,7 @@
     <div class="logo">🎮 Game Balancer</div>
     <nav class="nav" style="display:flex; align-items:center; justify-content:center; gap:1rem;">
       <button id="btn-load">Завантажити гравців</button>
+      <button id="btn-create-player">Створити гравця</button>
       <select id="league" style="margin-left:auto">
         <option value="kids">Молодша ліга</option>
         <option value="sunday">Старша ліга</option>
@@ -45,7 +46,7 @@
       </div>
       <table class="table">
         <thead>
-          <tr><th>Нік</th><th>Бали</th><th>Ранг</th><th>Абонемент</th><th>→Команда / ✕</th></tr>
+          <tr><th>Нік</th><th>Бали</th><th>Ранг</th><th>Абонемент</th><th>Ключ</th><th>→Команда / ✕</th></tr>
         </thead>
         <tbody id="lobby-list"></tbody>
       </table>
@@ -116,6 +117,42 @@
         </div>
       </section>
   </main>
+
+  <div id="create-player-modal" class="modal hidden">
+    <div class="modal-content">
+      <button id="create-player-close">✕</button>
+      <form id="create-player-form">
+        <label>Ліга:
+          <select name="league">
+            <option value="kids">Молодша ліга</option>
+            <option value="sunday">Старша ліга</option>
+          </select>
+        </label>
+        <label>Нік:
+          <input name="nick" required>
+        </label>
+        <label>Стать:
+          <select name="gender">
+            <option value="M">M</option>
+            <option value="F">F</option>
+          </select>
+        </label>
+        <label>Контакт:
+          <input name="contact">
+        </label>
+        <label>Досвід:
+          <input name="experience">
+        </label>
+        <label>Вік:
+          <input type="number" name="age">
+        </label>
+        <label>Стартові очки:
+          <input type="number" name="startPts" value="0">
+        </label>
+        <button type="submit">Створити</button>
+      </form>
+    </div>
+  </div>
 
   <!-- PDF.js -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>

--- a/balancer.css
+++ b/balancer.css
@@ -105,3 +105,31 @@ button:hover{background:var(--accent-dark);}button:disabled{background:var(--tex
 }
 
 
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modal.hidden {
+  display: none;
+}
+.modal-content {
+  background: #222;
+  padding: 1rem;
+  border-radius: 4px;
+  max-height: 90%;
+  overflow: auto;
+}
+.modal-content label {
+  display: block;
+  margin-top: 0.5rem;
+}
+
+


### PR DESCRIPTION
## Summary
- add Create Player modal to balance view
- import adminCreatePlayer & issueAccessKey and handle player creation without reload
- allow issuing access keys for lobby players

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b6706dbc832196b3c40833fb8b69