### PR TITLE
feat: cache avatars and add match PDFs

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -291,7 +291,7 @@ export async function getProfile(data) {
 export async function getAvatarUrl(nick) {
   const data = await postJson({ action: 'getAvatarUrl', nick });
   if (!data || !data.url) throw new Error('Invalid avatar URL response');
-  return data.url;
+  return { url: data.url, updatedAt: data.updatedAt };
 }
 
 export async function getPdfLinks(params) {


### PR DESCRIPTION
## Summary
- cache avatar URLs in localStorage and version with updated timestamps
- refresh avatars across tabs via `avatarRefresh` storage events
- show PDF button for matches when available

## Testing
- `node --check scripts/api.js`
- `node --check scripts/ranking.js`
- `node --check scripts/gameday.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899c17d679c832199d461a7f1fd3adf