### PR TITLE
Refactor avatar handling and validate API responses

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -117,38 +117,17 @@ export async function saveDetailedStats(matchId, statsArray) {
 }
 
 // ---------------------- Аватарки ----------------------
-const avatarBase = '/avatars';
-const avatarUploadBase = '/upload-avatar';
-const defaultAvatarBase = 'assets/default_avatars';
-
-export function getAvatarURL(nick) {
-  return `${avatarBase}/${encodeURIComponent(nick)}?t=${Date.now()}`;
-}
-
-export function getProxyAvatarURL(nick) {
-  return getAvatarURL(nick);
-}
-
-export function getDefaultAvatarURL() {
-  return `${defaultAvatarBase}/av0.png`;
-}
-
-export async function uploadAvatar(nick, file) {
-  const avatar = await toBase64NoPrefix(file);
-  const payload = { action: 'uploadAvatar', nick, avatar, mime: file.type || 'image/png' };
-  const res = await fetch(API_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload)
+export async function uploadAvatar(nick, fileOrBlob) {
+  const data = await toBase64NoPrefix(fileOrBlob);
+  const resp = await postJson({
+    action: 'uploadAvatar',
+    nick,
+    mime: fileOrBlob.type || 'image/png',
+    data
   });
-  const text = await res.text();
-  if (!res.ok) throw new Error(text || ('HTTP ' + res.status));
-  try {
-    const data = JSON.parse(text);
-    return data.url || data.success || true;
-  } catch (_) {
-    return true;
-  }
+  if (resp.status && resp.status !== 'OK') throw new Error(resp.status);
+  if (!resp.url) throw new Error('No URL returned');
+  return resp.url;
 }
 
 // ---------------------- Реєстрація/статистика ----------------------
@@ -277,25 +256,34 @@ async function postJson(payload) {
 }
 
 export async function adminCreatePlayer(data) {
-  return postJson({ action: 'adminCreatePlayer', ...(data || {}) });
+  const resp = await postJson({ action: 'adminCreatePlayer', ...(data || {}) });
+  if (resp.status && resp.status !== 'OK') throw new Error(resp.status);
+  return resp;
 }
 
 export async function issueAccessKey(data) {
-  return postJson({ action: 'issueAccessKey', ...(data || {}) });
+  const resp = await postJson({ action: 'issueAccessKey', ...(data || {}) });
+  if (resp.status && resp.status !== 'OK') throw new Error(resp.status);
+  return resp;
 }
 
 export async function getProfile(data) {
-  return postJson({ action: 'getProfile', ...(data || {}) });
+  const resp = await postJson({ action: 'getProfile', ...(data || {}) });
+  if (resp.status && resp.status !== 'OK') throw new Error(resp.status);
+  return resp;
 }
 
 export async function getAvatarUrl(nick) {
-  const data = await postJson({ action: 'getAvatarUrl', nick });
-  if (!data || !data.url) throw new Error('Invalid avatar URL response');
-  return { url: data.url, updatedAt: data.updatedAt };
+  const resp = await postJson({ action: 'getAvatarUrl', nick });
+  if (resp.status && resp.status !== 'OK') throw new Error(resp.status);
+  if (!resp || !resp.url) throw new Error('Invalid avatar URL response');
+  return { url: resp.url, updatedAt: resp.updatedAt };
 }
 
 export async function getPdfLinks(params) {
-  return postJson({ action: 'getPdfLinks', ...(params || {}) });
+  const resp = await postJson({ action: 'getPdfLinks', ...(params || {}) });
+  if (resp.status && resp.status !== 'OK') throw new Error(resp.status);
+  return resp;
 }
 
 export function toBase64NoPrefix(file) {

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,5 +1,10 @@
 // scripts/avatarAdmin.js
-import { uploadAvatar, getAvatarURL, getProxyAvatarURL, getDefaultAvatarURL } from './api.js';
+import { uploadAvatar } from './api.js';
+
+const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
+function localAvatarUrl(nick){
+  return `/avatars/${encodeURIComponent(nick)}?t=${Date.now()}`;
+}
 
 let defaultAvatars = [];
 async function loadDefaultAvatars(path = 'assets/default_avatars/list.json'){
@@ -39,7 +44,7 @@ export async function initAvatarAdmin(players, league=''){
     for(const [nick,obj] of entries){
       const success = await uploadAvatar(nick, obj.file);
       if(!success) failed.push(nick);
-      obj.img.src = getAvatarURL(nick);
+      obj.img.src = localAvatarUrl(nick);
     }
     if(entries.length){
       localStorage.setItem('avatarRefresh', Date.now().toString());
@@ -62,13 +67,13 @@ export async function initAvatarAdmin(players, league=''){
     img.className = 'avatar-img';
     img.alt = p.nick;
     img.dataset.nick = p.nick;
-    img.src = getAvatarURL(p.nick);
+    img.src = localAvatarUrl(p.nick);
     img.onerror = () => {
       img.onerror = () => {
         img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
-        img.src = getDefaultAvatarURL();
+        img.src = DEFAULT_AVATAR_URL;
       };
-      img.src = getProxyAvatarURL(p.nick);
+      img.src = localAvatarUrl(p.nick);
     };
     const input = document.createElement('input');
     input.type = 'file';
@@ -116,13 +121,13 @@ export async function initAvatarAdmin(players, league=''){
 
 function refreshAvatars(){
   document.querySelectorAll('#avatar-list img.avatar-img[data-nick]').forEach(img => {
-    img.src = getAvatarURL(img.dataset.nick);
+    img.src = localAvatarUrl(img.dataset.nick);
     img.onerror = () => {
       img.onerror = () => {
         img.onerror = () => { img.src = 'https://via.placeholder.com/40'; };
-        img.src = getDefaultAvatarURL();
+        img.src = DEFAULT_AVATAR_URL;
       };
-      img.src = getProxyAvatarURL(img.dataset.nick);
+      img.src = localAvatarUrl(img.dataset.nick);
     };
   });
 }

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,6 +1,10 @@
-import { getAvatarUrl, getProxyAvatarURL, getDefaultAvatarURL, getPdfLinks } from "./api.js";
+import { getAvatarUrl, getPdfLinks } from "./api.js";
 (function(){
   const AVATAR_TTL = 6 * 60 * 60 * 1000;
+  const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
+  function getLocalAvatarUrl(nick){
+    return `/avatars/${encodeURIComponent(nick)}`;
+  }
 
   async function fetchAvatar(nick){
     const key = `avatar:${nick}`;
@@ -25,14 +29,14 @@ import { getAvatarUrl, getProxyAvatarURL, getDefaultAvatarURL, getPdfLinks } fro
     if(info){
       img.src = `${info.url}?v=${info.updatedAt || 0}`;
     }else{
-      img.src = getProxyAvatarURL(nick);
+      img.src = getLocalAvatarUrl(nick);
     }
     img.onerror=()=>{
       img.onerror=()=>{
         img.onerror=()=>{img.src='https://via.placeholder.com/40';};
-        img.src=getDefaultAvatarURL();
+        img.src=DEFAULT_AVATAR_URL;
       };
-      img.src=getProxyAvatarURL(nick);
+      img.src=getLocalAvatarUrl(nick);
     };
   }
 

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -53,7 +53,7 @@ async function renderGames(list, league) {
   for (const dt of dates) {
     if (!pdfCache[dt]) {
       try {
-        const resp = await getPdfLinks(league, dt);
+        const resp = await getPdfLinks({ league, date: dt });
         pdfCache[dt] = resp.links || {};
       } catch (err) {
         pdfCache[dt] = {};
@@ -120,19 +120,6 @@ function askKey(nick) {
   document.getElementById('profile').style.display = 'none';
 }
 
-async function fileToBase64(file) {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const res = reader.result || '';
-      const comma = res.indexOf(',');
-      resolve(comma === -1 ? res : res.slice(comma + 1));
-    };
-    reader.onerror = () => reject(new Error('Failed to read file'));
-    reader.readAsDataURL(file);
-  });
-}
-
 async function loadProfile(nick, key = '') {
   let data;
   try {
@@ -169,8 +156,7 @@ async function loadProfile(nick, key = '') {
     const file = fileInput.files[0];
     if (!file) return;
     try {
-      const avatar = await fileToBase64(file);
-      await uploadAvatar({ nick, avatar, mime: file.type });
+      await uploadAvatar(nick, file);
       document.getElementById('avatar').src = `${avatarUrl}?t=${Date.now()}`;
       localStorage.setItem('avatarRefresh', Date.now().toString());
     } catch (err) {

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,4 +1,9 @@
-import { getAvatarUrl, getProxyAvatarURL, getDefaultAvatarURL } from "./api.js";
+import { getAvatarUrl } from "./api.js";
+
+const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
+function getLocalAvatarUrl(nick) {
+  return `/avatars/${encodeURIComponent(nick)}`;
+}
 
 const AVATAR_TTL = 6 * 60 * 60 * 1000;
 
@@ -25,16 +30,16 @@ async function setAvatar(img, nick) {
   if (info) {
     img.src = `${info.url}?v=${info.updatedAt || 0}`;
   } else {
-    img.src = getProxyAvatarURL(nick);
+    img.src = getLocalAvatarUrl(nick);
   }
   img.onerror = () => {
     img.onerror = () => {
       img.onerror = () => {
         img.src = "https://via.placeholder.com/40";
       };
-      img.src = getDefaultAvatarURL();
+      img.src = DEFAULT_AVATAR_URL;
     };
-    img.src = getProxyAvatarURL(nick);
+    img.src = getLocalAvatarUrl(nick);
   };
 }
 


### PR DESCRIPTION
## Summary
- Refactor `uploadAvatar` to accept files directly and return uploaded URL
- Enforce status checks for JSON API calls
- Remove deprecated avatar URL helpers and update callers

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check scripts/api.js`
- `node --check scripts/profile.js`
- `node --check scripts/ranking.js`
- `node --check scripts/gameday.js`
- `node --check scripts/avatarAdmin.js`


------
https://chatgpt.com/codex/tasks/task_e_6899d77151f88321b0951410b6de455a