### PR TITLE
feat: improve avatar handling

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -118,13 +118,20 @@ export async function saveDetailedStats(matchId, statsArray) {
 
 // ---------------------- Аватарки ----------------------
 export async function uploadAvatar(nick, fileOrBlob) {
-  const data = await toBase64NoPrefix(fileOrBlob);
-  const resp = await postJson({
-    action: 'uploadAvatar',
-    nick,
-    mime: fileOrBlob.type || 'image/png',
-    data
+  const form = new FormData();
+  form.append('action', 'uploadAvatar');
+  form.append('nick', nick);
+  form.append('file', fileOrBlob, fileOrBlob.name || 'avatar.png');
+  const res = await fetch(proxyUrl, {
+    method: 'POST',
+    body: form
   });
+  let resp;
+  try {
+    resp = await res.json();
+  } catch {
+    throw new Error('Invalid avatar response');
+  }
   if (resp.status && resp.status !== 'OK') throw new Error(resp.status);
   if (!resp.url) throw new Error('No URL returned');
   return resp.url;


### PR DESCRIPTION
## Summary
- upload avatar files using FormData and return stored URL
- refresh profile avatars with new API fields and broadcast nick to other pages
- update admin avatar tools to use new upload flow and cache-busting query

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d8d68f5c8321ad2be7c754bd0ae4