### PR TITLE
Handle duplicate player creation

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -146,8 +146,8 @@
         <label>Вік:
           <input type="number" name="age">
         </label>
-        <label>Стартові очки:
-          <input type="number" name="startPts" value="0">
+        <label>Очки:
+          <input type="number" name="points" value="0">
         </label>
         <button type="submit">Створити</button>
       </form>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -264,7 +264,7 @@ async function postJson(payload) {
 
 export async function adminCreatePlayer(data) {
   const resp = await postJson({ action: 'adminCreatePlayer', ...(data || {}) });
-  if (resp.status && resp.status !== 'OK') throw new Error(resp.status);
+  if (resp.status && resp.status !== 'OK' && resp.status !== 'DUPLICATE') throw new Error(resp.status);
   return resp;
 }
 

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -138,20 +138,28 @@ document.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
       const fd=new FormData(form);
       const data=Object.fromEntries(fd.entries());
-      data.startPts=parseInt(data.startPts,10)||0;
+      data.points=parseInt(data.points,10)||0;
       try{
-        await adminCreatePlayer(data);
-        const pts=data.startPts;
-        const rank=pts<200?'D':pts<500?'C':pts<800?'B':pts<1200?'A':'S';
-        const newPlayer={nick:data.nick,pts,rank,abonement:'none'};
-        const currentLeague=document.getElementById('league')?.value;
-        if(data.league===currentLeague){
-          players.push(newPlayer);
-          filtered.push(newPlayer);
-          renderSelect(filtered);
+        const resp=await adminCreatePlayer(data);
+        if(resp.status==='DUPLICATE'){
+          alert('Такий нік вже існує');
+          return;
         }
-        form.reset();
-        hide();
+        if(resp.status==='OK'){
+          const pts=data.points;
+          const rank=pts<200?'D':pts<500?'C':pts<800?'B':pts<1200?'A':'S';
+          const newPlayer={nick:data.nick,pts,rank,abonement:'none'};
+          const currentLeague=document.getElementById('league')?.value;
+          if(data.league===currentLeague){
+            players.push(newPlayer);
+            filtered.push(newPlayer);
+            renderSelect(filtered);
+          }
+          form.reset();
+          hide();
+        }else{
+          alert('Не вдалося створити гравця');
+        }
       }catch(err){
         alert('Не вдалося створити гравця');
       }


### PR DESCRIPTION
## Summary
- Rename startPts to points in create-player modal and submission
- Handle DUPLICATE status from adminCreatePlayer, only adding new player on OK
- Allow adminCreatePlayer to return DUPLICATE without throwing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899dc8d387483219518744d521cbaa3