### PR TITLE
Use text/plain for postJson requests

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -254,7 +254,7 @@ export async function fetchPlayerGames(nick, league = '') {
 async function postJson(payload) {
   const res = await fetch(API_URL, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'text/plain;charset=utf-8' },
     body: JSON.stringify(payload)
   });
   const text = await res.text();


### PR DESCRIPTION
## Summary
- adjust API request headers so postJson sends text/plain JSON payloads

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899e9fd1a708321919752f584252beb