### PR TITLE
Handle denied profile responses

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -275,7 +275,9 @@ export async function getProfile(data) {
   const payload = { action: 'getProfile', ...(data || {}) };
   if (payload.league) payload.league = normalizeLeague(payload.league);
   const resp = await postJson(payload);
-  if (resp.status && resp.status !== 'OK') throw new Error(resp.status);
+  if (resp.status && resp.status !== 'OK' && resp.status !== 'DENIED') {
+    throw new Error(resp.status);
+  }
   return resp;
 }
 

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -126,12 +126,12 @@ async function loadProfile(nick, key = '') {
   let data;
   try {
     data = await getProfile({ nick, key });
+    if (data.status === 'DENIED') {
+      askKey(nick);
+      return;
+    }
   } catch (err) {
     showError('Помилка завантаження профілю');
-    return;
-  }
-  if (data.status === 'DENIED') {
-    askKey(nick);
     return;
   }
   const profile = data.profile || {};


### PR DESCRIPTION
## Summary
- Allow `getProfile` to return a `DENIED` status without throwing
- Prompt for a key when profile fetch is denied

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899ec115de083218c696157d0e72036