### PR TITLE
Handle missing avatar URLs gracefully

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -284,7 +284,9 @@ export async function getProfile(data) {
 export async function getAvatarUrl(nick) {
   const resp = await postJson({ action: 'getAvatarUrl', nick });
   if (resp.status && resp.status !== 'OK') throw new Error(resp.status);
-  if (!resp || !resp.url) throw new Error('Invalid avatar URL response');
+  if (!resp || !resp.url) {
+    return { url: null, updatedAt: null };
+  }
   return { url: resp.url, updatedAt: resp.updatedAt };
 }
 

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -26,7 +26,7 @@ import { getAvatarUrl, getPdfLinks } from "./api.js";
   async function setAvatar(img, nick){
     img.dataset.nick = nick;
     const info = await fetchAvatar(nick);
-    if(info){
+    if(info && info.url){
       img.src = `${info.url}?v=${info.updatedAt || 0}`;
     }else{
       img.src = getLocalAvatarUrl(nick);

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -27,7 +27,7 @@ async function fetchAvatar(nick) {
 async function setAvatar(img, nick) {
   img.dataset.nick = nick;
   const info = await fetchAvatar(nick);
-  if (info) {
+  if (info && info.url) {
     img.src = `${info.url}?v=${info.updatedAt || 0}`;
   } else {
     img.src = getLocalAvatarUrl(nick);


### PR DESCRIPTION
## Summary
- Avoid throwing when getAvatarUrl returns no URL; return null fields instead
- Guard avatar setters against missing avatar URLs in ranking and gameday scripts

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899ed2cc0208321a489e7129f25852d