### PR TITLE
Refactor PDF link handling

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -295,7 +295,7 @@ export async function getPdfLinks(params) {
   if (payload.league) payload.league = normalizeLeague(payload.league);
   const resp = await postJson(payload);
   if (resp.status && resp.status !== 'OK') throw new Error(resp.status);
-  return resp;
+  return resp.links || {};
 }
 
 export function toBase64NoPrefix(file) {

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -54,8 +54,8 @@ async function renderGames(list, league) {
   for (const dt of dates) {
     if (!pdfCache[dt]) {
       try {
-        const resp = await getPdfLinks({ league, date: dt });
-        pdfCache[dt] = resp.links || {};
+        const links = await getPdfLinks({ league, date: dt });
+        pdfCache[dt] = links;
       } catch (err) {
         pdfCache[dt] = {};
       }


### PR DESCRIPTION
## Summary
- Ensure `getPdfLinks` returns only link map
- Simplify PDF link retrieval in profile view

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899ee27f8848321af685d89001e7d08