### PR TITLE
Include timestamps in avatar refresh events

### DIFF
--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -45,7 +45,7 @@ export async function initAvatarAdmin(players, league=''){
       try{
         const url = await uploadAvatar(nick, obj.file);
         obj.img.src = `${url}?v=${Date.now()}`;
-        localStorage.setItem('avatarRefresh', nick);
+        localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
       }catch{
         failed.push(nick);
       }
@@ -135,5 +135,8 @@ function refreshAvatars(nick){
 }
 
 window.addEventListener('storage', e => {
-  if(e.key === 'avatarRefresh') refreshAvatars(e.newValue);
+  if(e.key === 'avatarRefresh') {
+    const [nick] = (e.newValue || '').split(':');
+    refreshAvatars(nick);
+  }
 });

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -74,7 +74,7 @@ import { getAvatarUrl, getPdfLinks } from "./api.js";
   window.addEventListener('storage', e => {
     if(e.key === 'gamedayRefresh') loadData();
     if(e.key === 'avatarRefresh') {
-      const nick = e.newValue;
+      const [nick] = (e.newValue || '').split(':');
       if(nick) sessionStorage.removeItem(`avatar:${nick}`);
       refreshAvatars(nick);
     }

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -162,7 +162,7 @@ async function loadProfile(nick, key = '') {
       const url = await uploadAvatar(nick, file);
       avatarUrl = url;
       document.getElementById('avatar').src = `${url}?v=${Date.now()}`;
-      localStorage.setItem('avatarRefresh', nick);
+      localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
     } catch (err) {
       alert('Помилка завантаження');
     }
@@ -191,6 +191,9 @@ function refreshAvatar() {
 }
 
 window.addEventListener('storage', e => {
-  if (e.key === 'avatarRefresh' && e.newValue === currentNick) refreshAvatar();
+  if (e.key === 'avatarRefresh') {
+    const [nick] = (e.newValue || '').split(':');
+    if (nick === currentNick) refreshAvatar();
+  }
 });
 

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -52,7 +52,7 @@ function refreshAvatars(nick) {
 
 window.addEventListener("storage", (e) => {
   if (e.key === "avatarRefresh") {
-    const nick = e.newValue;
+    const [nick] = (e.newValue || "").split(":");
     if (nick) sessionStorage.removeItem(`avatar:${nick}`);
     refreshAvatars(nick);
   }


### PR DESCRIPTION
## Summary
- Append a timestamp when setting `avatarRefresh` so each update forces a new storage event
- Parse `avatarRefresh` values in listeners across profile, ranking, gameday, and avatar admin scripts

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899ef2d43d8832181c4780c6f8383f4