### PR TITLE
Ensure avatars fall back to default when URL missing

### DIFF
--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -29,7 +29,7 @@ import { getAvatarUrl, getPdfLinks } from "./api.js";
     if(info && info.url){
       img.src = `${info.url}?v=${info.updatedAt || 0}`;
     }else{
-      img.src = getLocalAvatarUrl(nick);
+      img.src = DEFAULT_AVATAR_URL;
     }
     img.onerror=()=>{
       img.onerror=()=>{

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -30,7 +30,7 @@ async function setAvatar(img, nick) {
   if (info && info.url) {
     img.src = `${info.url}?v=${info.updatedAt || 0}`;
   } else {
-    img.src = getLocalAvatarUrl(nick);
+    img.src = DEFAULT_AVATAR_URL;
   }
   img.onerror = () => {
     img.onerror = () => {


### PR DESCRIPTION
## Summary
- Use default avatar when fetched info lacks a valid URL, for both ranking and gameday pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f02109d0832181207d67776dbdab