### PR TITLE
Compute profile rank on client and fetch games separately

### DIFF
--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,10 +1,19 @@
-import { getProfile, uploadAvatar, getPdfLinks } from './api.js';
+import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames } from './api.js';
 
 let gameLimit = 0;
 let gamesLeftEl = null;
 let avatarUrl = '';
 let currentNick = '';
 const pdfCache = {};
+
+function computeRank(points) {
+  const p = +points || 0;
+  if (p >= 1200) return 'S';
+  if (p >= 800) return 'A';
+  if (p >= 500) return 'B';
+  if (p >= 200) return 'C';
+  return 'D';
+}
 
 function showError(msg) {
   const container = document.getElementById('profile');
@@ -136,10 +145,11 @@ async function loadProfile(nick, key = '') {
   }
   const profile = data.profile || {};
   const league = data.league || profile.league || '';
-  const games = data.games || [];
+  const games = await fetchPlayerGames(nick, league);
   avatarUrl = data.avatarUrl || `/avatars/${encodeURIComponent(nick)}`;
   document.getElementById('avatar').src = `${avatarUrl}?v=${data.avatarUpdatedAt || Date.now()}`;
-  document.getElementById('rating').textContent = `Рейтинг: ${profile.points} (${profile.rank})`;
+  const rank = computeRank(profile.points);
+  document.getElementById('rating').textContent = `Рейтинг: ${profile.points} (${rank})`;
   const aboType = profile.abonement?.type || '';
   document.getElementById('abonement-type').textContent = `Абонемент: ${aboType}`;
 


### PR DESCRIPTION
## Summary
- derive rank from profile points on the client
- fetch player game history using fetchPlayerGames and supply to renderGames

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a272f16988321a26182bd1d384890