### PR TITLE
Filter PDF files when listing PDF links

### DIFF
--- a/gas/doPost.gs
+++ b/gas/doPost.gs
@@ -476,14 +476,18 @@ function listPdfLinks_(league, ymd) {
   if (!df.hasNext()) return {};
   const dayFolder = df.next();
 
-  const files = dayFolder.getFilesByType(MimeType.PDF);
+  const allFiles = dayFolder.getFiles();
+  const pdfFiles = [];
+  while (allFiles.hasNext()) {
+    const f = allFiles.next();
+    if (f.getMimeType() === MimeType.PDF) pdfFiles.push(f);
+  }
   const map = {};
-  while (files.hasNext()) {
-    const f = files.next();
+  pdfFiles.forEach(f => {
     const name = f.getName();
     const matchId = name.replace(/\.pdf$/i, '');
     map[matchId] = publicFileUrl_(f.getId());
-  }
+  });
   return map;
 }
 


### PR DESCRIPTION
## Summary
- Adjust Drive PDF link listing to gather all files and filter by `MimeType.PDF`.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689a30ec13c083218a75434285420389