### PR TITLE
refactor: use gasPost and simplify API wrappers

### DIFF
--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -14,8 +14,8 @@ import { getAvatarUrl, getPdfLinks } from "./api.js";
       if(cached && now - cached.time < AVATAR_TTL) return cached;
     }catch{}
     try{
-      const data = await getAvatarUrl(nick);
-      const info = { url:data.url, updatedAt:data.updatedAt, time:now };
+      const url = await getAvatarUrl(nick);
+      const info = { url, time:now };
       sessionStorage.setItem(key, JSON.stringify(info));
       return info;
     }catch{
@@ -27,7 +27,7 @@ import { getAvatarUrl, getPdfLinks } from "./api.js";
     img.dataset.nick = nick;
     const info = await fetchAvatar(nick);
     if(info && info.url){
-      img.src = `${info.url}?v=${info.updatedAt || 0}`;
+      img.src = info.url;
     }else{
       img.src = DEFAULT_AVATAR_URL;
     }

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -140,12 +140,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const data=Object.fromEntries(fd.entries());
       data.points=parseInt(data.points,10)||0;
       try{
-        const resp=await adminCreatePlayer(data);
-        if(resp.status==='DUPLICATE'){
+        const status=await adminCreatePlayer(data);
+        if(status==='DUPLICATE'){
           alert('Такий нік вже існує');
           return;
         }
-        if(resp.status==='OK'){
+        if(status==='OK'){
           const pts=data.points;
           const rank=pts<200?'D':pts<500?'C':pts<800?'B':pts<1200?'A':'S';
           const newPlayer={nick:data.nick,pts,rank,abonement:'none'};
@@ -266,8 +266,7 @@ function renderLobby() {
       const idx=+btn.dataset.i;
       const player=lobby[idx];
       try{
-        const data=await issueAccessKey({nick:player.nick,league:document.getElementById('league')?.value});
-        const key=data.key||data.accessKey||data;
+        const key=await issueAccessKey({nick:player.nick,league:document.getElementById('league')?.value});
         alert(`Ключ: ${key}`);
         navigator.clipboard?.writeText(String(key)).catch(()=>{});
       }catch(err){

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -15,8 +15,8 @@ async function fetchAvatar(nick) {
     if (cached && now - cached.time < AVATAR_TTL) return cached;
   } catch {}
   try {
-    const data = await getAvatarUrl(nick);
-    const info = { url: data.url, updatedAt: data.updatedAt, time: now };
+    const url = await getAvatarUrl(nick);
+    const info = { url, time: now };
     sessionStorage.setItem(key, JSON.stringify(info));
     return info;
   } catch {
@@ -28,7 +28,7 @@ async function setAvatar(img, nick) {
   img.dataset.nick = nick;
   const info = await fetchAvatar(nick);
   if (info && info.url) {
-    img.src = `${info.url}?v=${info.updatedAt || 0}`;
+    img.src = info.url;
   } else {
     img.src = DEFAULT_AVATAR_URL;
   }


### PR DESCRIPTION
## Summary
- send JSON to GAS via new `gasPost` helper
- simplify wrapper return values and drop legacy proxy URL usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a3842b9688321b00a7bab96c8fbcb