### PR TITLE
Use remote avatar URLs with session caching

### DIFF
--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,10 +1,7 @@
 import { getAvatarUrl, getPdfLinks } from "./api.js";
 (function(){
   const AVATAR_TTL = 6 * 60 * 60 * 1000;
-  const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
-  function getLocalAvatarUrl(nick){
-    return `/avatars/${encodeURIComponent(nick)}`;
-  }
+  const DEFAULT_AVATAR_URL = "assets/default_avatars/av0.png";
 
   async function fetchAvatar(nick){
     const key = `avatar:${nick}`;
@@ -27,16 +24,13 @@ import { getAvatarUrl, getPdfLinks } from "./api.js";
     img.dataset.nick = nick;
     const info = await fetchAvatar(nick);
     if(info && info.url){
-      img.src = info.url;
+      img.src = `${info.url}?t=${Date.now()}`;
     }else{
       img.src = DEFAULT_AVATAR_URL;
     }
-    img.onerror=()=>{
-      img.onerror=()=>{
-        img.onerror=()=>{img.src='https://via.placeholder.com/40';};
-        img.src=DEFAULT_AVATAR_URL;
-      };
-      img.src=getLocalAvatarUrl(nick);
+    img.onerror = () => {
+      img.onerror = null;
+      img.src = DEFAULT_AVATAR_URL;
     };
   }
 

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,9 +1,6 @@
 import { getAvatarUrl } from "./api.js";
 
-const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
-function getLocalAvatarUrl(nick) {
-  return `/avatars/${encodeURIComponent(nick)}`;
-}
+const DEFAULT_AVATAR_URL = "assets/default_avatars/av0.png";
 
 const AVATAR_TTL = 6 * 60 * 60 * 1000;
 
@@ -28,18 +25,13 @@ async function setAvatar(img, nick) {
   img.dataset.nick = nick;
   const info = await fetchAvatar(nick);
   if (info && info.url) {
-    img.src = info.url;
+    img.src = `${info.url}?t=${Date.now()}`;
   } else {
     img.src = DEFAULT_AVATAR_URL;
   }
   img.onerror = () => {
-    img.onerror = () => {
-      img.onerror = () => {
-        img.src = "https://via.placeholder.com/40";
-      };
-      img.src = DEFAULT_AVATAR_URL;
-    };
-    img.src = getLocalAvatarUrl(nick);
+    img.onerror = null;
+    img.src = DEFAULT_AVATAR_URL;
   };
 }
 


### PR DESCRIPTION
## Summary
- Load avatars via `getAvatarUrl` and cache results in `sessionStorage` for 6h
- Remove local avatar fallbacks and default to existing `assets/default_avatars/av0.png`
- Bust browser cache with `?t=Date.now()` for fetched avatars only

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check scripts/ranking.js`
- `node --check scripts/gameday.js`
- `node --check scripts/profile.js`
- `node --check scripts/avatarAdmin.js`


------
https://chatgpt.com/codex/tasks/task_e_689a3b4c94b48321b54b09dd0e463458