### PR TITLE
Refactor avatar admin to use row-based uploads

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -110,7 +110,9 @@
       <section id="avatar-admin" class="card">
         <h2>Керування аватарами</h2>
         <p class="text-muted">Обери мініатюру для гравця, натисни «Зберегти аватари» та зображення оновиться автоматично.</p>
-        <ul id="avatar-list" class="list"></ul>
+        <table class="table avatar-table">
+          <tbody id="avatar-list"></tbody>
+        </table>
         <div class="actions">
           <button id="save-avatars" disabled>Зберегти аватари</button>
           <span id="avatar-status" class="text-muted hidden" style="align-self:center;">Аватари оновлено</span>

--- a/balancer.css
+++ b/balancer.css
@@ -63,18 +63,26 @@ button:hover{background:var(--accent-dark);}button:disabled{background:var(--tex
 }
 
 /* Avatar admin */
+.avatar-table {
+  width: 100%;
+  border-collapse: collapse;
+}
 #avatar-list {
-  list-style: none;
   max-height: 200px;
   overflow-y: auto;
+  display: block;
   padding: 0;
 }
-#avatar-list li {
+#avatar-list .avatar-row {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   padding: 0.25rem 0;
   border-bottom: 1px solid #2e2e2e;
+}
+#avatar-list .avatar-row td {
+  border: none;
+  padding: 0;
 }
 .avatar-img {
   width: 40px;


### PR DESCRIPTION
## Summary
- Replace avatar admin pending logic with row iteration over `.avatar-row` entries
- Upload selected files on "Save avatars" click, update previews, and trigger local refresh
- Switch avatar admin markup to table rows and adjust related styles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a4cb74810832188396ce1e89150a7