### PR TITLE
Ensure correct league is sent when saving game results

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -75,7 +75,9 @@ export async function fetchPlayerData(league) {
 // ---------------------- Збереження результату ----------------------
 export async function saveResult(data) {
   const payload = { ...(data || {}) };
-  if (payload.league) payload.league = normalizeLeague(payload.league);
+  if (payload.league && !['kids', 'sunday'].includes(payload.league)) {
+    payload.league = 'sunday';
+  }
   const body = new URLSearchParams(payload);
   const res = await fetch(PROXY_URL, {
     method: 'POST',

--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -117,8 +117,10 @@ document.addEventListener('DOMContentLoaded', () => {
                    : winsB > winsA ? 'team2'
                    : 'tie';
 
+      const leagueForGamesLog = leagueSel.value === 'kids' ? 'kids' : 'sunday';
+
       const data = {
-        league: leagueSel.value,
+        league: leagueForGamesLog,
         team1: teams[vs[0]].map(p => p.nick).join(', '),
         team2: teams[vs[1]].map(p => p.nick).join(', '),
         winner,


### PR DESCRIPTION
## Summary
- Send only `kids` or `sunday` leagues when saving arena results
- Default unknown leagues to `sunday` in `saveResult`

## Testing
- `npm test` (fails: no such file or directory)
- `npm run lint` (fails: no such file or directory)
- `node --check scripts/arena.js && node --check scripts/api.js`


------
https://chatgpt.com/codex/tasks/task_e_689c53ae43208321b0553a4b10c92094