### PR TITLE
Normalize league name when filtering gameday data

### DIFF
--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -116,6 +116,11 @@ import { getAvatarUrl, getPdfLinks } from "./api.js";
     return `${vpIcons(a)} - ${vpIcons(b)}`;
   }
 
+  function normalizeLeagueForFilter(v){
+    const s = String(v || '').toLowerCase();
+    return s === 'sundaygames' ? 'sunday' : s;
+  }
+
   async function loadData(){
     if(!dateInput.value) return; // require date
     const rURL = rankingURLs[leagueSel.value];
@@ -152,7 +157,9 @@ import { getAvatarUrl, getPdfLinks } from "./api.js";
       rankMap[name] = +r.Points || 0;
     });
 
-    const allGames = games.filter(g=>g.League===leagueSel.value);
+    const allGames = games.filter(
+      g => normalizeLeagueForFilter(g.League) === leagueSel.value
+    );
     allGames.sort((a,b)=>{
       const tDiff = new Date(a.Timestamp) - new Date(b.Timestamp);
       if(tDiff) return tDiff;


### PR DESCRIPTION
## Summary
- ensure league names 'SundayGames' are treated as 'sunday' when filtering gameday data

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `npm run lint` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689c54d3f0648321a9e184202e7c028c