### PR TITLE
Refactor league selection logic

### DIFF
--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -9,6 +9,9 @@ export let lobby = [];
 let players = [], filtered = [], selected = [], manualCount = 0;
 const ABONEMENT_TYPES = ['none', 'lite', 'full'];
 
+const select = document.getElementById('league-select');
+export const uiLeague = String(select?.value || '').toLowerCase() === 'kids' ? 'kids' : 'sunday';
+
 async function addPlayer(nick){
   if(!nick) return;
   const res = await fetchPlayerData(nick);
@@ -20,8 +23,7 @@ async function addPlayer(nick){
 export function initLobby(pl) {
   players = pl;
   filtered = [...players];
-  const league = document.getElementById('league')?.value;
-  const saved = loadLobbyState(league);
+  const saved = loadLobbyState(uiLeague);
   lobby = saved?.lobby || [];
   manualCount = saved?.manualCount || 0;
   selected = [];
@@ -149,11 +151,10 @@ document.addEventListener('DOMContentLoaded', () => {
           const pts=data.points;
           const rank=pts<200?'D':pts<500?'C':pts<800?'B':pts<1200?'A':'S';
           const newPlayer={nick:data.nick,pts,rank,abonement:'none'};
-          const currentLeague=document.getElementById('league')?.value;
-          if(data.league===currentLeague){
-            players.push(newPlayer);
-            filtered.push(newPlayer);
-            renderSelect(filtered);
+            if(data.league===uiLeague){
+              players.push(newPlayer);
+              filtered.push(newPlayer);
+              renderSelect(filtered);
           }
           form.reset();
           hide();
@@ -293,7 +294,7 @@ document.addEventListener('click', async e => {
   if (!btn) return;
   const nick = btn.dataset.nick;
   try {
-    const key = await issueAccessKey({ nick, league: document.getElementById('league')?.value });
+    const key = await issueAccessKey({ nick, league: uiLeague });
     const cell = btn.closest('tr')?.querySelector('.access-key');
     if (cell) cell.textContent = key;
   } catch (err) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,18 +1,18 @@
 // scripts/main.js
 
 import { loadPlayers } from './api.js';
-import { initLobby }   from './lobby.js';
+import { initLobby, uiLeague }   from './lobby.js';
 import { initScenario } from './scenario.js';
 import { initAvatarAdmin } from './avatarAdmin.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const btnLoad   = document.getElementById('btn-load');
-  const leagueSel = document.getElementById('league');
+  const leagueSel = document.getElementById('league-select');
   const scenArea  = document.getElementById('scenario-area');
-  initAvatarAdmin([], leagueSel ? leagueSel.value : '');
+  initAvatarAdmin([], uiLeague);
 
   if (!btnLoad || !leagueSel) {
-    console.error('Не знайдено #btn-load або #league у DOM');
+    console.error('Не знайдено #btn-load або #league-select у DOM');
     return;
   }
 
@@ -23,9 +23,9 @@ document.addEventListener('DOMContentLoaded', () => {
     btnLoad.textContent = 'Завантаження...';
 
     try {
-      const players = await loadPlayers(leagueSel.value);
+      const players = await loadPlayers(uiLeague);
       initLobby(players);          // Рендер лоббі
-      await initAvatarAdmin(players, leagueSel.value);    // Рендер аватарів
+      await initAvatarAdmin(players, uiLeague);    // Рендер аватарів
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
     } catch (err) {
       console.error('Помилка loadPlayers:', err);
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // При зміні ліги — очищуємо поточне лоббі та ховаємо сценарій
   leagueSel.addEventListener('change', async () => {
     initLobby([]);               // Порожнє лоббі
-    await initAvatarAdmin([], leagueSel.value);
+    await initAvatarAdmin([], uiLeague);
     scenArea.classList.add('hidden');
   });
 });


### PR DESCRIPTION
## Summary
- derive a `uiLeague` constant from the `league-select` element
- apply `uiLeague` across lobby state, player creation, and access key issuance
- update main script to load players and avatars based on `uiLeague`

## Testing
- `node --check scripts/lobby.js`
- `node --check scripts/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c576b25a483218e9d61a8b251165f