### PR TITLE
Refactor balance controls and remove player modal

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -10,12 +10,15 @@
   <header class="header">
     <div class="logo">🎮 Game Balancer</div>
     <nav class="nav" style="display:flex; align-items:center; justify-content:center; gap:1rem;">
-      <button id="btn-load">Завантажити гравців</button>
-      <button id="btn-create-player">Створити гравця</button>
-      <select id="league" style="margin-left:auto">
+      <select id="league-select" style="margin-right:auto">
         <option value="kids">Молодша ліга</option>
         <option value="sunday">Старша ліга</option>
       </select>
+      <button id="btn-load">Завантажити гравців</button>
+      <input type="text" id="new-nick" placeholder="Нік">
+      <input type="number" id="new-age" placeholder="Вік" min="0">
+      <button id="btn-create-player">Створити гравця</button>
+      <button id="clear-lobby" type="button">Очистити лоббі</button>
     </nav>
   </header>
 
@@ -55,9 +58,6 @@
         Сума: <span id="lobby-sum">0</span> |
         Середній: <span id="lobby-avg">0</span>
       </p>
-      <div class="actions">
-        <button id="clear-lobby" type="button">Очистити лоббі</button>
-      </div>
     </section>
 
     <!-- 3. Сценарій -->
@@ -120,41 +120,6 @@
       </section>
   </main>
 
-  <div id="create-player-modal" class="modal hidden">
-    <div class="modal-content">
-      <button id="create-player-close">✕</button>
-      <form id="create-player-form">
-        <label>Ліга:
-          <select name="league">
-            <option value="kids">Молодша ліга</option>
-            <option value="sunday">Старша ліга</option>
-          </select>
-        </label>
-        <label>Нік:
-          <input name="nick" required>
-        </label>
-        <label>Стать:
-          <select name="gender">
-            <option value="M">M</option>
-            <option value="F">F</option>
-          </select>
-        </label>
-        <label>Контакт:
-          <input name="contact">
-        </label>
-        <label>Досвід:
-          <input name="experience">
-        </label>
-        <label>Вік:
-          <input type="number" name="age">
-        </label>
-        <label>Очки:
-          <input type="number" name="points" value="0">
-        </label>
-        <button type="submit">Створити</button>
-      </form>
-    </div>
-  </div>
 
   <!-- PDF.js -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -128,40 +128,30 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const createBtn = document.getElementById('btn-create-player');
-  const modal = document.getElementById('create-player-modal');
-  const closeModal = document.getElementById('create-player-close');
-  const form = document.getElementById('create-player-form');
-  if(createBtn && modal && closeModal && form){
-    const hide=()=>modal.classList.add('hidden');
-    createBtn.addEventListener('click',()=>modal.classList.remove('hidden'));
-    closeModal.addEventListener('click',hide);
-    modal.addEventListener('click',e=>{if(e.target===modal)hide();});
-    form.addEventListener('submit',async e=>{
-      e.preventDefault();
-      const fd=new FormData(form);
-      const data=Object.fromEntries(fd.entries());
-      data.points=parseInt(data.points,10)||0;
-      try{
-        const status=await adminCreatePlayer(data);
-        if(status==='DUPLICATE'){
+  const newNick = document.getElementById('new-nick');
+  const newAge  = document.getElementById('new-age');
+  if (createBtn && newNick && newAge) {
+    createBtn.addEventListener('click', async () => {
+      const nick = newNick.value.trim();
+      if (!nick) return;
+      const age = parseInt(newAge.value, 10) || 0;
+      try {
+        const status = await adminCreatePlayer({ league: uiLeague, nick, age });
+        if (status === 'DUPLICATE') {
           alert('Такий нік вже існує');
           return;
         }
-        if(status==='OK'){
-          const pts=data.points;
-          const rank=pts<200?'D':pts<500?'C':pts<800?'B':pts<1200?'A':'S';
-          const newPlayer={nick:data.nick,pts,rank,abonement:'none'};
-            if(data.league===uiLeague){
-              players.push(newPlayer);
-              filtered.push(newPlayer);
-              renderSelect(filtered);
-          }
-          form.reset();
-          hide();
-        }else{
+        if (status === 'OK') {
+          const newPlayer = { nick, pts: 0, rank: 'D', abonement: 'none' };
+          players.push(newPlayer);
+          filtered.push(newPlayer);
+          renderSelect(filtered);
+          newNick.value = '';
+          newAge.value = '';
+        } else {
           alert('Не вдалося створити гравця');
         }
-      }catch(err){
+      } catch (err) {
         alert('Не вдалося створити гравця');
       }
     });


### PR DESCRIPTION
## Summary
- Consolidate lobby controls in header with league selector, load button, inline player creation fields, and lobby clear button.
- Remove obsolete player creation modal and its script logic.
- Add inline player creation handler using new nick and age fields.

## Testing
- `npm test` (fails: Could not read package.json)
- `npm run lint` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689c5e63eacc8321a37dc3c5e65a577c