### PR TITLE
Enable league-based player loading

### DIFF
--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -9,8 +9,7 @@ export let lobby = [];
 let players = [], filtered = [], selected = [], manualCount = 0;
 const ABONEMENT_TYPES = ['none', 'lite', 'full'];
 
-const select = document.getElementById('league-select');
-export const uiLeague = String(select?.value || '').toLowerCase() === 'kids' ? 'kids' : 'sunday';
+let uiLeague = 'sunday';
 
 async function addPlayer(nick){
   if(!nick) return;
@@ -20,7 +19,8 @@ async function addPlayer(nick){
 }
 
 // Ініціалізує лоббі новим набором гравців
-export function initLobby(pl) {
+export function initLobby(pl, league = uiLeague) {
+  uiLeague = String(league || '').toLowerCase() === 'kids' ? 'kids' : 'sunday';
   players = pl;
   filtered = [...players];
   const saved = loadLobbyState(uiLeague);
@@ -168,7 +168,7 @@ export function clearLobby() {
   lobby.length = 0;
   Object.keys(teams).forEach(k => { teams[k].length = 0; });
 
-  localStorage.removeItem(getLobbyStorageKey());
+  localStorage.removeItem(getLobbyStorageKey(undefined, uiLeague));
 
   renderLobby();
   renderTeams();
@@ -272,7 +272,7 @@ function renderLobby() {
     };
   });
 
-  saveLobbyState({lobby, teams, manualCount});
+  saveLobbyState({lobby, teams, manualCount, league: uiLeague});
 }
 
 document.addEventListener('click', async e => {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,17 +1,17 @@
 // scripts/main.js
 
 import { loadPlayers } from './api.js';
-import { initLobby, uiLeague }   from './lobby.js';
+import { initLobby }   from './lobby.js';
 import { initScenario } from './scenario.js';
 import { initAvatarAdmin } from './avatarAdmin.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const btnLoad   = document.getElementById('btn-load');
-  const leagueSel = document.getElementById('league-select');
+  const selLeague = document.querySelector('#league-select') || document.querySelector('#league');
   const scenArea  = document.getElementById('scenario-area');
-  initAvatarAdmin([], uiLeague);
+  initAvatarAdmin([], selLeague?.value || '');
 
-  if (!btnLoad || !leagueSel) {
+  if (!btnLoad || !selLeague) {
     console.error('Не знайдено #btn-load або #league-select у DOM');
     return;
   }
@@ -23,9 +23,10 @@ document.addEventListener('DOMContentLoaded', () => {
     btnLoad.textContent = 'Завантаження...';
 
     try {
-      const players = await loadPlayers(uiLeague);
-      initLobby(players);          // Рендер лоббі
-      await initAvatarAdmin(players, uiLeague);    // Рендер аватарів
+      const csvLeague = window.uiLeagueToCsv(selLeague.value);
+      const players = await loadPlayers(csvLeague);
+      initLobby(players, csvLeague);          // Рендер лоббі
+      await initAvatarAdmin(players, selLeague.value);    // Рендер аватарів
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
     } catch (err) {
       console.error('Помилка loadPlayers:', err);
@@ -37,9 +38,10 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // При зміні ліги — очищуємо поточне лоббі та ховаємо сценарій
-  leagueSel.addEventListener('change', async () => {
-    initLobby([]);               // Порожнє лоббі
-    await initAvatarAdmin([], uiLeague);
+  selLeague.addEventListener('change', async () => {
+    const csvLeague = window.uiLeagueToCsv(selLeague.value);
+    initLobby([], csvLeague);               // Порожнє лоббі
+    await initAvatarAdmin([], selLeague.value);
     scenArea.classList.add('hidden');
   });
 });

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -1,12 +1,13 @@
 export function getLobbyStorageKey(date, league){
   const d = date || document.getElementById('date')?.value || new Date().toISOString().slice(0,10);
-  const l = league || document.getElementById('league')?.value || '';
+  const sel = document.querySelector('#league-select') || document.querySelector('#league');
+  const l = league || sel?.value || '';
   return `lobby::${d}::${l}`;
 }
 
-export function saveLobbyState({lobby, teams, manualCount}){
+export function saveLobbyState({lobby, teams, manualCount, league}){
   try{
-    const key = getLobbyStorageKey();
+    const key = getLobbyStorageKey(undefined, league);
     localStorage.setItem(key, JSON.stringify({lobby, teams, manualCount}));
   }catch(err){
     console.error('Failed to save lobby state', err);


### PR DESCRIPTION
## Summary
- Dynamically read selected league and map it for CSV loading
- Initialize lobby with league-specific state and persist per league
- Clear lobby and avatars when league changes

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm run lint` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c66b282f083218af8e7d2d515fa4e