### PR TITLE
Add responsive mobile balance styles

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -24,7 +24,7 @@
     </div>
   </header>
 
-  <main class="container">
+  <main class="container blc-container">
     <!-- 1. Вибір гравців -->
     <section class="blc-accordion" id="sec-player-picker">
       <h2 class="blc-acc-head">Вибір гравців</h2>
@@ -37,7 +37,7 @@
             <button id="btn-sort-name">А–Я</button>
             <button id="btn-sort-pts">За балами ↓</button>
           </div>
-          <ul id="select-list" class="list"></ul>
+          <ul id="select-list" class="list scroll-pane"></ul>
           <div class="actions">
             <button id="btn-add-selected">Додати у лоббі</button>
             <button id="btn-clear-selected">Очистити вибір</button>
@@ -55,12 +55,15 @@
             <input type="text" id="addPlayerInput" placeholder="Нік гравця">
             <button id="addPlayerBtn">Add</button>
           </div>
-          <table class="table">
-            <thead>
-              <tr><th>Нік</th><th>Бали</th><th>Ранг</th><th>Абонемент</th><th>Ключ</th><th>→Команда / ✕</th></tr>
-            </thead>
-            <tbody id="lobby-list"></tbody>
-          </table>
+          <div class="lobby-table-wrap">
+            <table class="lobby-table table">
+              <thead>
+                <tr><th>Нік</th><th>Бали</th><th>Ранг</th><th>Абонемент</th><th>Ключ</th><th>→Команда / ✕</th></tr>
+              </thead>
+              <tbody id="lobby-list"></tbody>
+            </table>
+          </div>
+          <div class="lobby-cards"></div>
           <p class="text-muted">
             Гравців: <span id="lobby-count">0</span> |
             Сума: <span id="lobby-sum">0</span> |

--- a/styles/balance-mobile.css
+++ b/styles/balance-mobile.css
@@ -1,46 +1,90 @@
 /* Mobile-specific styles for balance page */
-.blc-top {
-  background: var(--surface, #1F1F1F);
-  padding: 0.5rem 1rem;
+
+/* Base layout */
+.blc-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
 }
-.blc-top.sticky {
+
+.sticky {
   position: sticky;
   top: 0;
   z-index: 100;
 }
+
 .blc-row {
   display: flex;
   align-items: center;
-  gap: 1rem;
-}
-.blc-actions {
-  display: flex;
-  gap: 0.5rem;
+  gap: 10px;
   flex-wrap: wrap;
 }
+
+.blc-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+button, select, input {
+  min-height: 42px;
+  font-size: 14px;
+  padding: 6px 12px;
+}
+
 .danger {
   background: var(--danger, #E53935);
 }
+
+/* Accordion behavior */
 .blc-accordion {
   border: 1px solid #2e2e2e;
   border-radius: 8px;
 }
+
 .blc-acc-head {
   font-size: 1.1rem;
-  padding: 0.5rem 1rem;
+  padding: 10px;
+  cursor: pointer;
 }
+
 .blc-acc-body {
-  padding: 0.5rem 1rem;
+  padding: 10px;
+}
+
+.blc-accordion:not(.open) .blc-acc-body {
   display: none;
 }
-.blc-accordion.open .blc-acc-body {
-  display: block;
+
+/* Scrollable player selector */
+.scroll-pane {
+  max-height: 60vh;
+  overflow: auto;
 }
-.only-mobile {
-  display: none;
+
+/* Lobby responsiveness */
+.lobby-table-wrap {overflow-x: auto;}
+.lobby-table thead th {position: sticky; top: 0;}
+.lobby-cards {display: none;}
+
+.only-mobile {display: none;}
+
+@media (max-width: 768px) {
+  .only-mobile {display: block;}
+  .lobby-table {display: none;}
+  .lobby-cards {display: grid; gap: 10px;}
+  .lobby-card {border: 1px solid #2a2a2a; border-radius: 10px; padding: 10px; background: #121212;}
+  .lobby-card .row {display: flex; justify-content: space-between; padding: 4px 0;}
+
+  /* Avatar admin mobile adjustments */
+  #avatar-list {display: grid; gap: 10px;}
+  #avatar-list .avatar-row {display: grid; grid-template-columns: 1fr auto; align-items: center;}
+  #save-avatars {width: 100%;}
 }
-@media (max-width: 600px) {
-  .only-mobile {
-    display: inline-block;
-  }
+
+/* Expand all sections on wider screens */
+@media (min-width: 769px) {
+  .blc-accordion .blc-acc-body {display: block !important;}
 }
+


### PR DESCRIPTION
## Summary
- Add mobile stylesheet with base layout, accordion, scrollable player selector, and responsive lobby/avatars
- Update balance page markup for scroll pane and lobby responsiveness

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx --yes stylelint styles/balance-mobile.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_689c727df8a88321a974b89dc3a2b229