### PR TITLE
Improve player selector layout

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -28,16 +28,16 @@
     <!-- 1. Вибір гравців -->
     <section class="blc-accordion" id="sec-player-picker">
       <h2 class="blc-acc-head">Вибір гравців</h2>
-      <div class="blc-acc-body">
+      <div class="blc-acc-body scroll-pane">
         <section id="select-area" class="card hidden">
-          <div class="search-wrapper">
+          <div class="blc-row">
             <input type="text" id="player-search" placeholder="🔍 Пошук гравця..." autocomplete="off">
+            <div class="sort-controls">
+              <button id="btn-sort-name">А–Я</button>
+              <button id="btn-sort-pts">За балами ↓</button>
+            </div>
           </div>
-          <div class="sort-controls">
-            <button id="btn-sort-name">А–Я</button>
-            <button id="btn-sort-pts">За балами ↓</button>
-          </div>
-          <ul id="select-list" class="list scroll-pane"></ul>
+          <ul id="select-list" class="list"></ul>
           <div class="actions">
             <button id="btn-add-selected">Додати у лоббі</button>
             <button id="btn-clear-selected">Очистити вибір</button>

--- a/balancer.css
+++ b/balancer.css
@@ -19,8 +19,10 @@ body{background:var(--bg);color:var(--text);font-family:sans-serif;line-height:1
 .card{background:var(--card-bg);padding:1rem;border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.5);}
 .hidden{display:none;}
 .sort-controls, .actions{display:flex;gap:0.5rem;flex-wrap:wrap;margin-top:0.5rem;}
+.sort-controls{margin-top:0;}
 .list{list-style:none;max-height:200px;overflow-y:auto;}
 .list li{display:flex;justify-content:space-between;padding:0.5rem 0;border-bottom:1px solid #2e2e2e;}
+#select-list li{width:100%;padding:8px 12px;cursor:pointer;}
 .table{width:100%;border-collapse:collapse;}
 .table th, .table td{padding:0.5rem;border:1px solid #2e2e2e;text-align:left;}
 .text-muted{color:var(--text-muted);font-size:0.9rem;}


### PR DESCRIPTION
## Summary
- allow vertical scrolling of player selector accordion body
- align search and sorting controls in a responsive row
- expand selector list items with padding and pointer cursor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c74b9ad888321ac7bc2742de78979