### PR TITLE
Add mobile lobby card view and mobile-only controls

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -63,7 +63,7 @@
               <tbody id="lobby-list"></tbody>
             </table>
           </div>
-          <div class="lobby-cards"></div>
+          <div class="lobby-cards only-mobile"></div>
           <p class="text-muted">
             Гравців: <span id="lobby-count">0</span> |
             Сума: <span id="lobby-sum">0</span> |


### PR DESCRIPTION
## Summary
- Mirror lobby table data into mobile-friendly cards and update render logic
- Restrict duplicate clear button and lobby cards to mobile view

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx eslint scripts/lobby.js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689c760d58e88321ae0443c8e48080cf