### PR TITLE
Improve scenario and avatar admin responsiveness

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -85,7 +85,7 @@
             <option value="3">3 команди</option>
             <option value="4">4 команди</option>
           </select>
-          <div class="actions">
+          <div class="blc-actions">
             <button id="btn-auto">Авто-баланс</button>
             <button id="btn-manual">Ручне формування</button>
           </div>
@@ -127,8 +127,8 @@
     <!-- 7. Адміністрування аватарів -->
     <section class="blc-accordion" id="sec-avatar-admin">
       <h2 class="blc-acc-head">Керування аватарами</h2>
-      <div class="blc-acc-body">
-        <section id="avatar-admin" class="card">
+      <section id="avatar-admin" class="card">
+        <div class="blc-acc-body">
           <p class="text-muted">Обери мініатюру для гравця, натисни «Зберегти аватари» та зображення оновиться автоматично.</p>
           <table class="table avatar-table">
             <tbody id="avatar-list"></tbody>
@@ -137,8 +137,8 @@
             <button id="save-avatars" disabled>Зберегти аватари</button>
             <span id="avatar-status" class="text-muted hidden" style="align-self:center;">Аватари оновлено</span>
           </div>
-        </section>
-      </div>
+        </div>
+      </section>
     </section>
   </main>
 

--- a/styles/balance-mobile.css
+++ b/styles/balance-mobile.css
@@ -78,6 +78,7 @@ button, select, input {
   .lobby-card .row {display: flex; justify-content: space-between; padding: 4px 0;}
 
   /* Avatar admin mobile adjustments */
+  .avatar-table {display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px;}
   #avatar-list {display: grid; gap: 10px;}
   #avatar-list .avatar-row {display: grid; grid-template-columns: 1fr auto; align-items: center;}
   #save-avatars {width: 100%;}


### PR DESCRIPTION
## Summary
- Wrap scenario action buttons in `.blc-actions` for better mobile wrapping
- Nest avatar admin content inside `.blc-acc-body` and add mobile grid layout
- Ensure avatar save button spans full width on small screens

## Testing
- `npm test` *(fails: could not find package.json)*
- `npx eslint balance.html` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689c773fda2883219712e1bfe093e264