### PR TITLE
Handle errors when loading ranking data

### DIFF
--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -50,13 +50,25 @@ window.addEventListener("storage", (e) => {
   }
 });
 export async function loadData(rankingURL, gamesURL) {
-  const [rText, gText] = await Promise.all([
-    fetch(rankingURL).then((r) => r.text()),
-    fetch(gamesURL).then((r) => r.text()),
-  ]);
-  const rank = Papa.parse(rText, { header: true, skipEmptyLines: true }).data;
-  const games = Papa.parse(gText, { header: true, skipEmptyLines: true }).data;
-  return { rank, games };
+  try {
+    const [rText, gText] = await Promise.all([
+      fetch(rankingURL).then((r) => r.text()),
+      fetch(gamesURL).then((r) => r.text()),
+    ]);
+    const rank = Papa.parse(rText, { header: true, skipEmptyLines: true }).data;
+    const games = Papa.parse(gText, { header: true, skipEmptyLines: true }).data;
+    return { rank, games };
+  } catch (err) {
+    console.error("Failed to load or parse ranking data", err);
+    const msg = "Не вдалося завантажити дані рейтингу";
+    if (typeof alert === "function") alert(msg);
+    if (typeof document !== "undefined") {
+      const div = document.createElement("div");
+      div.textContent = msg;
+      document.body.appendChild(div);
+    }
+    return { rank: [], games: [] };
+  }
 }
 
 export function computeStats(rank, games, { alias = {}, league } = {}) {


### PR DESCRIPTION
## Summary
- wrap ranking data fetch in try/catch
- alert the user and log if loading/parsing fails and provide fallback data

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb2695fc48321a276ffa02cc80077