### PR TITLE
Refactor balance styles into single responsive sheet

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -11,28 +11,28 @@
   <header>
     <button id="ui-burger"></button>
   </header>
-  <div id="ui-panel">
+  <div id="ui-panel" class="bal__panel">
     <section class="bal__card">
-      <div class="blc-row">
+      <div class="bal__row">
         <select id="league">
           <option value="kids">Молодша ліга</option>
           <option value="sunday">Старша ліга</option>
         </select>
-        <div class="blc-actions">
+        <div class="bal__actions">
           <button id="btn-load">Завантажити гравців</button>
           <input type="text" id="new-nick" placeholder="Нік">
           <input type="number" id="new-age" placeholder="Вік" min="0">
           <button id="btn-create">Створити гравця</button>
-          <button id="btn-clear-lobby" class="danger">Очистити лоббі</button>
+          <button id="btn-clear-lobby" class="btn--danger">Очистити лоббі</button>
         </div>
       </div>
     </section>
 
     <section class="bal__card" id="sec-player-picker">
-      <h2 class="blc-acc-head">Вибір гравців</h2>
-      <div class="blc-acc-body scroll-pane">
+      <h2 class="bal__acc-head">Вибір гравців</h2>
+      <div class="bal__acc-body scroll-pane">
         <section id="select-area" class="card hidden">
-          <div class="blc-row">
+          <div class="bal__row">
             <input type="text" id="player-search" placeholder="🔍 Пошук гравця..." autocomplete="off">
             <div class="sort-controls">
               <button id="btn-sort-name">А–Я</button>
@@ -49,35 +49,35 @@
     </section>
 
     <section class="bal__card open" id="sec-lobby">
-      <h2 class="blc-acc-head">Лоббі дня</h2>
-      <div class="blc-acc-body">
+      <h2 class="bal__acc-head">Лоббі дня</h2>
+      <div class="bal__acc-body">
         <section id="lobby-area" class="card">
           <div class="add-player">
             <input type="text" id="addPlayerInput" placeholder="Нік гравця">
             <button id="addPlayerBtn">Add</button>
           </div>
-          <div class="lobby-table-wrap">
-            <table class="lobby-table table">
+          <div class="bal__table-wrap">
+            <table class="bal__table table">
               <thead>
                 <tr><th>Нік</th><th>Бали</th><th>Ранг</th><th>Абонемент</th><th>Ключ</th><th>→Команда / ✕</th></tr>
               </thead>
               <tbody id="lobby-list"></tbody>
             </table>
           </div>
-          <div class="lobby-cards only-mobile"></div>
+          <div class="bal__players only-mobile"></div>
           <p class="text-muted">
             Гравців: <span id="lobby-count">0</span> |
             Сума: <span id="lobby-sum">0</span> |
             Середній: <span id="lobby-avg">0</span>
           </p>
-          <button id="btn-clear-lobby-dup" class="danger only-mobile">Очистити лоббі</button>
+          <button id="btn-clear-lobby-dup" class="btn--danger only-mobile">Очистити лоббі</button>
         </section>
       </div>
     </section>
 
     <section class="bal__card" id="sec-scenario">
-      <h2 class="blc-acc-head">Режим гри</h2>
-      <div class="blc-acc-body">
+      <h2 class="bal__acc-head">Режим гри</h2>
+      <div class="bal__acc-body">
         <section id="scenario-area" class="card hidden">
           <label for="teamsize">Кількість команд:</label>
           <select id="teamsize">
@@ -85,7 +85,7 @@
             <option value="3">3 команди</option>
             <option value="4">4 команди</option>
           </select>
-          <div class="blc-actions">
+          <div class="bal__actions">
             <button id="btn-auto">Авто-баланс</button>
             <button id="btn-manual">Ручне формування</button>
           </div>
@@ -122,9 +122,9 @@
     </section>
 
     <section class="bal__card" id="sec-avatar-admin">
-      <h2 class="blc-acc-head">Керування аватарами</h2>
+      <h2 class="bal__acc-head">Керування аватарами</h2>
       <section id="avatar-admin" class="card">
-        <div class="blc-acc-body">
+        <div class="bal__acc-body">
           <p class="text-muted">Обери мініатюру для гравця, натисни «Зберегти аватари» та зображення оновиться автоматично.</p>
           <table class="table avatar-table">
             <tbody id="avatar-list"></tbody>

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -214,10 +214,10 @@ function renderLobby() {
     </tr>
   `).join('');
 
-  const cards = document.querySelector('.lobby-cards');
+  const cards = document.querySelector('.bal__players');
   if (cards) {
     cards.innerHTML = lobby.map((p, i) => `
-      <div class="lobby-card">
+      <div class="player">
         <div class="row"><span class="nick">${p.nick}</span><span class="pts">${p.pts}</span></div>
         <div class="row"><span class="rank">${p.rank}</span><span class="season">${p.abonement || ''}</span></div>
         <div class="row">
@@ -304,7 +304,7 @@ document.addEventListener('click', async e => {
   const nick = btn.dataset.nick;
   try {
     const key = await issueAccessKey({ nick, league: uiLeague });
-    const host = btn.closest('tr') || btn.closest('.lobby-card');
+    const host = btn.closest('tr') || btn.closest('.player');
     const cell = host?.querySelector('.access-key');
     if (cell) cell.textContent = key;
   } catch (err) {

--- a/styles/balance.css
+++ b/styles/balance.css
@@ -1,91 +1,108 @@
-/* Mobile-specific styles for balance page */
+:root {
+  --bal-gap: 10px;
+  --bal-panel-width: 360px;
+  --bal-card-bg: var(--card-bg, #242424);
+}
 
-/* Base layout */
-.blc-container {
+.bal__panel {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 10px;
+  gap: var(--bal-gap);
+  padding: var(--bal-gap);
+  width: 100%;
+  max-width: var(--bal-panel-width);
 }
 
-.sticky {
-  position: sticky;
-  top: 0;
-  z-index: 100;
+.bal__card {
+  background: var(--bal-card-bg);
+  border-radius: 8px;
+  padding: var(--bal-gap);
 }
 
-.blc-row {
+.bal__row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--bal-gap);
   flex-wrap: wrap;
 }
 
-.blc-actions {
+.bal__actions {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-button, select, input {
-  min-height: 42px;
-  font-size: 14px;
-  padding: 6px 12px;
+.btn--danger {
+  background: var(--danger);
+  color: #fff;
 }
+.btn--danger:hover { background: #c62828; }
 
-.danger {
-  background: var(--danger, #E53935);
-}
-
-/* Accordion behavior */
-.blc-accordion {
+.bal__accordion {
   border: 1px solid #2e2e2e;
   border-radius: 8px;
 }
 
-.blc-acc-head {
+.bal__acc-head {
   font-size: 1.1rem;
   padding: 10px;
   cursor: pointer;
 }
 
-.blc-acc-body {
+.bal__acc-body {
   padding: 10px;
 }
 
-.blc-accordion:not(.open) .blc-acc-body {
+.bal__accordion:not(.open) .bal__acc-body {
   display: none;
 }
 
-/* Scrollable player selector */
 .scroll-pane {
   max-height: 60vh;
   overflow: auto;
 }
 
-/* Lobby responsiveness */
-.lobby-table-wrap {overflow-x: auto;}
-.lobby-table thead th {position: sticky; top: 0;}
-.lobby-cards {display: none;}
+.bal__table-wrap { overflow-x: auto; }
+.bal__table thead th { position: sticky; top: 0; }
 
-.only-mobile {display: none;}
+.bal__players { display: none; }
+.only-mobile { display: none; }
 
 @media (max-width: 768px) {
-  .only-mobile {display: block;}
-  .lobby-table {display: none;}
-  .lobby-cards {display: grid; gap: 10px;}
-  .lobby-card {border: 1px solid #2a2a2a; border-radius: 10px; padding: 10px; background: #121212;}
-  .lobby-card .row {display: flex; justify-content: space-between; padding: 4px 0;}
+  .only-mobile { display: block; }
+  .bal__table { display: none; }
+  .bal__players { display: grid; gap: 10px; }
+  .player {
+    border: 1px solid #2a2a2a;
+    border-radius: 10px;
+    padding: 10px;
+    background: #121212;
+  }
+  .player .row {
+    display: flex;
+    justify-content: space-between;
+    padding: 4px 0;
+  }
 
   /* Avatar admin mobile adjustments */
-  .avatar-table {display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px;}
-  #avatar-list {display: grid; gap: 10px;}
-  #avatar-list .avatar-row {display: grid; grid-template-columns: 1fr auto; align-items: center;}
-  #save-avatars {width: 100%;}
+  .avatar-table {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
+  #avatar-list {
+    display: grid;
+    gap: 10px;
+  }
+  #avatar-list .avatar-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+  }
+  #save-avatars { width: 100%; }
 }
 
-/* Expand all sections on wider screens */
 @media (min-width: 769px) {
-  .blc-accordion .blc-acc-body {display: block !important;}
+  .bal__accordion .bal__acc-body { display: block !important; }
 }
 


### PR DESCRIPTION
## Summary
- add responsive `styles/balance.css` with `bal__*` classes and player cards
- update balance page and lobby script to use new classes and danger button style
- rely on one balance stylesheet by dropping old mobile CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0450973988321ac4592adbdc1865b