### PR TITLE
Fix abonement type update in lobby

### DIFF
--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -406,14 +406,16 @@ function renderLobby() {
       sel.value = player.abonement || 'none';
       sel.onchange = async () => {
         const newType = sel.value;
+        const prevType = player.abonement || 'none';
         try {
-          await updateAbonement(player.nick, newType);
+          const res = await updateAbonement({ nick: player.nick, league: uiLeague, type: newType });
+          if (res !== 'OK' && res?.status !== 'OK') throw new Error('Failed');
           player.abonement = newType;
           const full = players.find(p => p.nick === player.nick);
           if (full) full.abonement = newType;
           alert('Абонемент оновлено');
         } catch (err) {
-          sel.value = player.abonement || 'none';
+          sel.value = prevType;
           alert('Помилка оновлення абонемента');
         }
       };


### PR DESCRIPTION
## Summary
- pass player info object to `updateAbonement`
- restore abonement select on failure

## Testing
- `npm test` *(fails: could not read package.json)*
- `npx eslint scripts/lobby.js` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b05ba9b4e4832197bd28ce9739fffe