### PR TITLE
Debounce player search input in lobby

### DIFF
--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -135,11 +135,15 @@ function renderSelect(arr) {
 document.addEventListener('DOMContentLoaded', () => {
   const searchInput = document.getElementById('player-search');
   if (searchInput) {
+    let searchTimeout;
     searchInput.addEventListener('input', () => {
-      const term = searchInput.value.trim().toLowerCase();
-      filtered = players.filter(p => p.nick.toLowerCase().includes(term));
-      selected = [];
-      renderSelect(filtered);
+      clearTimeout(searchTimeout);
+      searchTimeout = setTimeout(() => {
+        const term = searchInput.value.trim().toLowerCase();
+        filtered = players.filter(p => p.nick.toLowerCase().includes(term));
+        selected = [];
+        renderSelect(filtered);
+      }, 300);
     });
   }
 


### PR DESCRIPTION
## Summary
- Debounce player search input by 300ms to reduce excessive filtering operations

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b05ccc77448321b1ed2cabc97d6988