### PR TITLE
Normalize league values before saving results

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -105,9 +105,7 @@ export async function fetchPlayerData(league) {
 // ---------------------- Збереження результату ----------------------
 export async function saveResult(data) {
   const payload = { ...(data || {}) };
-  if (payload.league && !['kids', 'sunday'].includes(payload.league)) {
-    payload.league = 'sunday';
-  }
+  if (payload.league) payload.league = normalizeLeague(payload.league);
   const body = new URLSearchParams(payload);
   const res = await fetch(PROXY_URL, {
     method: 'POST',

--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -1,6 +1,6 @@
 // scripts/arena.js
 
-import { saveResult, saveDetailedStats } from './api.js';
+import { saveResult, saveDetailedStats, normalizeLeague } from './api.js';
 import { parseGamePdf }                   from './pdfParser.js';
 import { updateLobbyState }               from './lobby.js';
 import { teams }                          from './teams.js';
@@ -117,10 +117,10 @@ document.addEventListener('DOMContentLoaded', () => {
                    : winsB > winsA ? 'team2'
                    : 'tie';
 
-      const leagueForGamesLog = leagueSel.value === 'kids' ? 'kids' : 'sunday';
+      const league = normalizeLeague(leagueSel.value);
 
       const data = {
-        league: leagueForGamesLog,
+        league,
         team1: teams[vs[0]].map(p => p.nick).join(', '),
         team2: teams[vs[1]].map(p => p.nick).join(', '),
         winner,


### PR DESCRIPTION
## Summary
- Normalize league selection in arena UI before sending match data
- Normalize payload league in API `saveResult`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b05f00c0b88321bad28f2c06581334