### PR TITLE
Connect mobile clear button to lobby reset

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -23,7 +23,7 @@
           <input type="text" id="new-nick" placeholder="Нік">
           <input type="number" id="new-age" placeholder="Вік" min="0">
           <button id="btn-create">Створити гравця</button>
-          <button id="btn-clear-lobby" class="btn--danger">Очистити лоббі</button>
+          <button id="ui-clear-lobby" class="btn--danger">Очистити лоббі</button>
         </div>
       </div>
     </section>

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -446,7 +446,6 @@ document.addEventListener('click', async e => {
   }
 });
 
-document.getElementById('btn-clear-lobby')?.addEventListener('click', clearLobby);
 document.getElementById('btn-clear-lobby-dup')?.addEventListener('click', clearLobby);
 
 // Mobile shell


### PR DESCRIPTION
## Summary
- add `ui-clear-lobby` id to main lobby reset button
- trigger `clearLobby` from mobile menu via this id and close the panel

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `npx eslint scripts/lobby.js` *(fails: ESLint couldn't find an eslint.config.* file)*


------
https://chatgpt.com/codex/tasks/task_e_68b060341a7c8321bce922a07acd8ebd