### PR TITLE
Reset manual count when clearing lobby and re-render player selection

### DIFF
--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -230,6 +230,7 @@ export function setManualCount(n) {
 
 export function clearLobby() {
   lobby.length = 0;
+  manualCount = 0;
   Object.keys(teams).forEach(k => { teams[k].length = 0; });
 
   localStorage.removeItem(getLobbyStorageKey(undefined, uiLeague));
@@ -237,6 +238,7 @@ export function clearLobby() {
   renderLobby();
   renderTeams();
   updateSummary();
+  renderSelect(filtered);
 }
 
 function renderTeams() {


### PR DESCRIPTION
## Summary
- Reset `manualCount` when clearing the lobby
- Re-render selectable players after clearing to reactivate checkboxes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b06ac829d48321994df4914932903f