### PR TITLE
refactor: centralize league selection

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -16,9 +16,9 @@
     <section class="bal__card">
       <div class="bal__row">
         <select id="league">
-          <option value="kids">Молодша ліга</option>
-          <option value="sunday">Старша ліга</option>
-        </select>
+            <option value="kids">Молодша ліга</option>
+            <option value="sundaygames">Старша ліга</option>
+          </select>
         <div class="bal__actions">
           <button id="btn-load">Завантажити гравців</button>
           <input type="text" id="new-nick" placeholder="Нік">

--- a/gameday.html
+++ b/gameday.html
@@ -134,10 +134,10 @@
   </nav>
   <div class="container">
     <div class="filters">
-      <select id="league">
-        <option value="kids">Молодша ліга</option>
-        <option value="sunday">Старша ліга</option>
-      </select>
+        <select id="league">
+          <option value="kids">Молодша ліга</option>
+          <option value="sundaygames">Старша ліга</option>
+        </select>
       <input type="date" id="date" />
       <button id="loadBtn">Завантажити</button>
     </div>

--- a/index.html
+++ b/index.html
@@ -323,6 +323,7 @@
       </div>
     </div>
     <script type="module">
+      import { LEAGUE } from "./scripts/constants.js";
       import {
         loadData,
         computeStats,
@@ -343,11 +344,10 @@
         Mariko: "Gidora",
         Timabuilding: "Бойбуд",
       };
-      const league = "kids";
       async function init() {
         const { rank, games } = await loadData(rankingURL, gamesURL);
         const { players, totalGames, totalRounds, minDate, maxDate } =
-          computeStats(rank, games, { alias, league });
+          computeStats(rank, games, { alias, league: LEAGUE });
         document.getElementById("summary").textContent =
           `Ігор: ${totalGames} (${totalRounds} раундів). Період: ${formatD(minDate)}–${formatD(maxDate)}`;
         document.getElementById("season-info").textContent =

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -22,9 +22,9 @@ window.postJson = window.postJson || async function postJson(url, body) {
 };
 
 // Відображення UI-ліг до CSV та GAS назв
-window.uiLeagueToCsv = window.uiLeagueToCsv || function uiLeagueToCsv(v) {
-  return String(v).toLowerCase() === 'kids' ? 'kids' : 'sunday';
-};
+  window.uiLeagueToCsv = window.uiLeagueToCsv || function uiLeagueToCsv(v) {
+    return String(v).toLowerCase() === 'kids' ? 'kids' : 'sundaygames';
+  };
 
 window.uiLeagueToGas = window.uiLeagueToGas || function uiLeagueToGas(v) {
   return String(v).toLowerCase() === 'kids' ? 'kids' : 'sundaygames';
@@ -34,11 +34,10 @@ window.uiLeagueToGas = window.uiLeagueToGas || function uiLeagueToGas(v) {
 export const PROXY_URL = 'https://script.google.com/macros/s/AKfycbyXQz_D2HMtVJRomi83nK3iuIMSPKOehg2Lesj7IvHE1TwpqCiHqVCPwsvboxigvV1yIA/exec';
 
 // Публічні фіди рейтингу (CSV)
-const rankingURLs = {
-  kids:        'https://docs.google.com/spreadsheets/d/19VYkNmFJCArLFDngYLkpkxF0LYqvDz78yF1oqLT7Ukw/export?format=csv&gid=1648067737',
-  sunday:      'https://docs.google.com/spreadsheets/d/19VYkNmFJCArLFDngYLkpkxF0LYqvDz78yF1oqLT7Ukw/export?format=csv&gid=1286735969',
-  sundaygames: 'https://docs.google.com/spreadsheets/d/19VYkNmFJCArLFDngYLkpkxF0LYqvDz78yF1oqLT7Ukw/export?format=csv&gid=1286735969'
-};
+  const rankingURLs = {
+    kids:        'https://docs.google.com/spreadsheets/d/19VYkNmFJCArLFDngYLkpkxF0LYqvDz78yF1oqLT7Ukw/export?format=csv&gid=1648067737',
+    sundaygames: 'https://docs.google.com/spreadsheets/d/19VYkNmFJCArLFDngYLkpkxF0LYqvDz78yF1oqLT7Ukw/export?format=csv&gid=1286735969'
+  };
 
 const rankFromPoints = p => (p < 200 ? 'D' : p < 500 ? 'C' : p < 800 ? 'B' : p < 1200 ? 'A' : 'S');
 
@@ -48,12 +47,11 @@ const gamesURL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejv
 // ---------------------- Уніфікація ліг ----------------------
 export function normalizeLeague(v) {
   const x = String(v || '').toLowerCase();
-  if (x === 'sundaygames' || x === 'olds' || x === 'adult' || x === 'adults') return 'sundaygames';
-  if (x === 'kid' || x === 'junior') return 'kids';
-  if (x === 'sunday') return 'sundaygames';
-  if (x === 'kids') return 'kids';
-  return 'sundaygames'; // дефолт — старша
-}
+    if (x === 'sundaygames' || x === 'olds' || x === 'adult' || x === 'adults') return 'sundaygames';
+    if (x === 'kid' || x === 'junior') return 'kids';
+    if (x === 'kids') return 'kids';
+    return 'sundaygames'; // дефолт — старша
+  }
 
 export function getLeagueFeedUrl(league) {
   const key = normalizeLeague(league);
@@ -170,7 +168,7 @@ export async function fetchPlayerStats(nick) {
 // ---------------------- Абонементи ----------------------
 // Кнопка “Запросити абонемент” у профілі.
 // Під бекенд: action = 'requestAbonement' (а не 'abonement_request')
-export async function requestAbonement({ nick, league = 'sunday', requested = 'month' }) {
+export async function requestAbonement({ nick, league = 'sundaygames', requested = 'month' }) {
   const payload = {
     action: 'requestAbonement',
     nick,

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,0 +1,1 @@
+export const LEAGUE = location.pathname.endsWith('sunday.html') ? 'sundaygames' : 'kids';

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -38,10 +38,10 @@ import { getAvatarUrl, getPdfLinks } from "./api.js";
     const sel = nick ? `img.avatar-img[data-nick="${nick}"]` : 'img.avatar-img[data-nick]';
     document.querySelectorAll(sel).forEach(img=>setAvatar(img, img.dataset.nick));
   }
-  const rankingURLs = {
-    kids: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv",
-    sunday: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv"
-  };
+    const rankingURLs = {
+      kids: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv",
+      sundaygames: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv"
+    };
   const gamesURL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv";
 
   const alias = {
@@ -117,8 +117,7 @@ import { getAvatarUrl, getPdfLinks } from "./api.js";
   }
 
   function normalizeLeagueForFilter(v){
-    const s = String(v || '').toLowerCase();
-    return s === 'sundaygames' ? 'sunday' : s;
+    return String(v || '').toLowerCase() === 'kids' ? 'kids' : 'sundaygames';
   }
 
   async function loadData(){

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -9,7 +9,7 @@ export let lobby = [];
 let players = [], filtered = [], selected = [], manualCount = 0;
 const ABONEMENT_TYPES = ['none', 'lite', 'full'];
 
-let uiLeague = 'sunday';
+  let uiLeague = 'sundaygames';
 
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 const AVATAR_TTL = 6 * 60 * 60 * 1000;
@@ -70,8 +70,8 @@ async function addPlayer(nick){
 }
 
 // Ініціалізує лоббі новим набором гравців
-export function initLobby(pl, league = uiLeague) {
-  uiLeague = String(league || '').toLowerCase() === 'kids' ? 'kids' : 'sunday';
+  export function initLobby(pl, league = uiLeague) {
+    uiLeague = String(league || '').toLowerCase() === 'kids' ? 'kids' : 'sundaygames';
   players = pl;
   filtered = [...players];
   const saved = loadLobbyState(uiLeague);

--- a/sunday.html
+++ b/sunday.html
@@ -320,6 +320,7 @@
       </div>
     </div>
     <script type="module">
+      import { LEAGUE } from "./scripts/constants.js";
       import {
         loadData,
         computeStats,
@@ -340,11 +341,10 @@
         Mariko: "Gidora",
         Timabuilding: "Бойбуд",
       };
-      const league = "sunday";
       async function init() {
         const { rank, games } = await loadData(rankingURL, gamesURL);
         const { players, totalGames, totalRounds, minDate, maxDate } =
-          computeStats(rank, games, { alias, league });
+          computeStats(rank, games, { alias, league: LEAGUE });
         document.getElementById("summary").textContent =
           `Ігор: ${totalGames} (${totalRounds} раундів). Період: ${formatD(minDate)}–${formatD(maxDate)}`;
         document.getElementById("season-info").textContent =


### PR DESCRIPTION
## Summary
- Define LEAGUE once based on URL and reuse across pages
- Switch league selectors and utilities to use `sundaygames` instead of legacy `sunday`
- Remove remaining "sunday" league strings from codebase

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npx eslint .` *(fails: missing eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b07c86a9d8832188d11ba5e5152f0e