### PR TITLE
Use CDN papaparse and streamline league pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,7 @@
       rel="stylesheet"
     />
     <!-- PapaParse для CSV -->
-    <script src="assets/papaparse.min.js"></script>
-    <script>
-      if (typeof Papa === "undefined") {
-        throw new Error("PapaParse failed to load");
-      }
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
     <style>
       /* Reset & Base */
       * {
@@ -322,45 +317,8 @@
         <div id="stats-body"></div>
       </div>
     </div>
-    <script type="module">
-      import { LEAGUE } from "./scripts/constants.js";
-      import {
-        loadData,
-        computeStats,
-        renderTopMVP,
-        renderChart,
-        renderTable,
-        initSearch,
-        initToggle,
-        formatD,
-        formatFull,
-      } from "./scripts/ranking.js";
-      const rankingURL =
-        "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv";
-      const gamesURL =
-        "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv";
-      const alias = {
-        Zavodchanyn: "Romario",
-        Mariko: "Gidora",
-        Timabuilding: "Бойбуд",
-      };
-      async function init() {
-        const { rank, games } = await loadData(rankingURL, gamesURL);
-        const { players, totalGames, totalRounds, minDate, maxDate } =
-          computeStats(rank, games, { alias, league: LEAGUE });
-        document.getElementById("summary").textContent =
-          `Ігор: ${totalGames} (${totalRounds} раундів). Період: ${formatD(minDate)}–${formatD(maxDate)}`;
-        document.getElementById("season-info").textContent =
-          `Перший сезон — старт ${formatFull(minDate)}`;
-        renderTopMVP(players, document.getElementById("top-mvp"));
-        renderChart(players, document.getElementById("rank-chart"));
-        renderTable(players, document.getElementById("ranking"));
-        initSearch(document.getElementById("search"), "#ranking tr");
-        initToggle(document.getElementById("toggle"), "#ranking tr");
-      }
-      document.addEventListener("DOMContentLoaded", init);
-    </script>
-    <script type="module" src="scripts/playerStats.js"></script>
+    <script type="module" src="scripts/api.js"></script>
     <script type="module" src="scripts/quickStats.js"></script>
+    <script type="module" src="scripts/ranking.js"></script>
   </body>
 </html>

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,4 +1,5 @@
 import { getAvatarUrl } from "./api.js";
+import { LEAGUE } from "./constants.js";
 
 const DEFAULT_AVATAR_URL = "assets/default_avatars/av0.png";
 
@@ -250,4 +251,51 @@ export function formatFull(d) {
     d.getFullYear()
   );
 }
+
+const CONFIG = {
+  kids: {
+    rankingURL:
+      "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv",
+    gamesURL:
+      "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv",
+    alias: {
+      Zavodchanyn: "Romario",
+      Mariko: "Gidora",
+      Timabuilding: "Бойбуд",
+    },
+  },
+  sundaygames: {
+    rankingURL:
+      "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv",
+    gamesURL:
+      "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv",
+    alias: {
+      Romario: "Zavodchanyn",
+      Mariko: "Gidora",
+      Timabuilding: "Бойбуд",
+    },
+  },
+};
+
+async function init() {
+  const cfg = CONFIG[LEAGUE];
+  if (!cfg) return;
+  const { rank, games } = await loadData(cfg.rankingURL, cfg.gamesURL);
+  const { players, totalGames, totalRounds, minDate, maxDate } = computeStats(
+    rank,
+    games,
+    { alias: cfg.alias, league: LEAGUE }
+  );
+  document.getElementById("summary").textContent =
+    `Ігор: ${totalGames} (${totalRounds} раундів). Період: ${formatD(minDate)}–${formatD(maxDate)}`;
+  document.getElementById("season-info").textContent =
+    `Перший сезон — старт ${formatFull(minDate)}`;
+  renderTopMVP(players, document.getElementById("top-mvp"));
+  renderChart(players, document.getElementById("rank-chart"));
+  renderTable(players, document.getElementById("ranking"));
+  initSearch(document.getElementById("search"), "#ranking tr");
+  initToggle(document.getElementById("toggle"), "#ranking tr");
+}
+
+document.addEventListener("DOMContentLoaded", init);
 

--- a/sunday.html
+++ b/sunday.html
@@ -319,45 +319,8 @@
         <div id="stats-body"></div>
       </div>
     </div>
-    <script type="module">
-      import { LEAGUE } from "./scripts/constants.js";
-      import {
-        loadData,
-        computeStats,
-        renderTopMVP,
-        renderChart,
-        renderTable,
-        initSearch,
-        initToggle,
-        formatD,
-        formatFull,
-      } from "./scripts/ranking.js";
-      const rankingURL =
-        "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv";
-      const gamesURL =
-        "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv";
-      const alias = {
-        Romario: "Zavodchanyn",
-        Mariko: "Gidora",
-        Timabuilding: "Бойбуд",
-      };
-      async function init() {
-        const { rank, games } = await loadData(rankingURL, gamesURL);
-        const { players, totalGames, totalRounds, minDate, maxDate } =
-          computeStats(rank, games, { alias, league: LEAGUE });
-        document.getElementById("summary").textContent =
-          `Ігор: ${totalGames} (${totalRounds} раундів). Період: ${formatD(minDate)}–${formatD(maxDate)}`;
-        document.getElementById("season-info").textContent =
-          `Перший сезон — старт ${formatFull(minDate)}`;
-        renderTopMVP(players, document.getElementById("top-mvp"));
-        renderChart(players, document.getElementById("rank-chart"));
-        renderTable(players, document.getElementById("ranking"));
-        initSearch(document.getElementById("search"), "#ranking tr");
-        initToggle(document.getElementById("toggle"), "#ranking tr");
-      }
-      document.addEventListener("DOMContentLoaded", init);
-    </script>
-    <script type="module" src="scripts/playerStats.js"></script>
+    <script type="module" src="scripts/api.js"></script>
     <script type="module" src="scripts/quickStats.js"></script>
+    <script type="module" src="scripts/ranking.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Load PapaParse from CDN instead of local copy
- Initialize ranking data via `ranking.js` with league-specific config
- Only include `api.js`, `quickStats.js`, and `ranking.js` on league pages

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b095931b1c8321938e3e391bc7c800