### PR TITLE
feat: cache fetches with sessionStorage

### DIFF
--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,24 +1,12 @@
 // scripts/avatarAdmin.js
-import { uploadAvatar, getAvatarUrl } from './api.js';
+import { uploadAvatar, getAvatarUrl, fetchOnce } from './api.js';
 
 const AVATAR_TTL = 6 * 60 * 60 * 1000;
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 
 
 async function fetchAvatar(nick){
-  const key = `avatar:${nick}`;
-  const now = Date.now();
-  try{
-    const cached = JSON.parse(sessionStorage.getItem(key) || 'null');
-    if(cached && now - cached.time < AVATAR_TTL) return cached.url;
-  }catch{}
-  try{
-    const url = await getAvatarUrl(nick);
-    sessionStorage.setItem(key, JSON.stringify({ url, time: now }));
-    return url;
-  }catch{
-    return null;
-  }
+  return fetchOnce(`avatar:${nick}`, AVATAR_TTL, () => getAvatarUrl(nick));
 }
 
 async function setAvatar(img, nick){

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -2,7 +2,7 @@
 
 import { initTeams, teams } from './teams.js';
 import { sortByName, sortByPtsDesc } from './sortUtils.js';
-import { updateAbonement, adminCreatePlayer, issueAccessKey, getAvatarUrl, getProfile } from './api.js';
+import { updateAbonement, adminCreatePlayer, issueAccessKey, getAvatarUrl, getProfile, fetchOnce } from './api.js';
 import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js';
 
 export let lobby = [];
@@ -15,19 +15,7 @@ const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 const AVATAR_TTL = 6 * 60 * 60 * 1000;
 
 async function fetchAvatar(nick) {
-  const key = `avatar:${nick}`;
-  const now = Date.now();
-  try {
-    const cached = JSON.parse(sessionStorage.getItem(key) || 'null');
-    if (cached && now - cached.time < AVATAR_TTL) return cached.url;
-  } catch {}
-  try {
-    const url = await getAvatarUrl(nick);
-    if (url) sessionStorage.setItem(key, JSON.stringify({ url, time: now }));
-    return url;
-  } catch {
-    return null;
-  }
+  return fetchOnce(`avatar:${nick}`, AVATAR_TTL, () => getAvatarUrl(nick));
 }
 
 async function setAvatar(img, nick) {

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,4 +1,4 @@
-import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, getAvatarUrl } from './api.js';
+import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, getAvatarUrl, fetchOnce } from './api.js';
 
 let gameLimit = 0;
 let gamesLeftEl = null;
@@ -10,19 +10,7 @@ const AVATAR_TTL = 6 * 60 * 60 * 1000;
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 
 async function fetchAvatar(nick){
-  const key = `avatar:${nick}`;
-  const now = Date.now();
-  try{
-    const cached = JSON.parse(sessionStorage.getItem(key) || 'null');
-    if(cached && now - cached.time < AVATAR_TTL) return cached.url;
-  }catch{}
-  try{
-    const url = await getAvatarUrl(nick);
-    sessionStorage.setItem(key, JSON.stringify({ url, time: now }));
-    return url;
-  }catch{
-    return null;
-  }
+  return fetchOnce(`avatar:${nick}`, AVATAR_TTL, () => getAvatarUrl(nick));
 }
 
 function computeRank(points) {


### PR DESCRIPTION
## Summary
- add `fetchOnce` helper for in-memory and sessionStorage caching
- use `fetchOnce` for avatar and CSV loads across scripts
- guard `sessionStorage.removeItem` with try/catch

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx eslint scripts/api.js` *(fails: ESLint couldn't find a configuration file)*


------
https://chatgpt.com/codex/tasks/task_e_68b098635f188321b5f13667d2ee33b0