### PR TITLE
Use event delegation for ranking table

### DIFF
--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -170,7 +170,6 @@ export function renderTable(list, tbodyEl) {
       if (idx === 1) {
         td.className = cls.replace("rank-", "nick-");
         td.style.cursor = "pointer";
-        td.addEventListener("click", (e) => showQuickStats(p.nickname, e));
       }
       td.textContent = val;
       tr.appendChild(td);
@@ -284,7 +283,14 @@ async function init() {
     `Перший сезон — старт ${formatFull(minDate)}`;
   renderTopMVP(players, document.getElementById("top-mvp"));
   renderChart(players, document.getElementById("rank-chart"));
-  renderTable(players, document.getElementById("ranking"));
+  const rankingEl = document.getElementById("ranking");
+  rankingEl.addEventListener("click", (e) => {
+    const cell = e.target.closest("td");
+    if (cell && cell.className.startsWith("nick-")) {
+      showQuickStats(cell.textContent, e);
+    }
+  });
+  renderTable(players, rankingEl);
   initSearch(document.getElementById("search"), "#ranking tr");
   initToggle(document.getElementById("toggle"), "#ranking tr");
 }


### PR DESCRIPTION
## Summary
- Delegate quick stats clicks to the table body
- Remove per-cell click listeners for nicknames

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b09c82af848321a4d86131fab1780e