### PR TITLE
feat: add keyboard access to ranking nicknames

### DIFF
--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -165,6 +165,12 @@ function createRow(p, i) {
   const tdNick = document.createElement("td");
   tdNick.className = cls.replace("rank-", "nick-");
   tdNick.style.cursor = "pointer";
+  tdNick.tabIndex = 0;
+  tdNick.setAttribute("role", "button");
+  tdNick.setAttribute(
+    "aria-label",
+    `Показати статистику гравця ${p.nickname}`
+  );
   tdNick.textContent = p.nickname;
   tr.appendChild(tdNick);
 
@@ -361,6 +367,14 @@ async function init() {
   rankingEl.addEventListener("click", (e) => {
     const cell = e.target.closest("td");
     if (cell && cell.className.startsWith("nick-")) {
+      showQuickStats(cell.textContent, e);
+    }
+  });
+  rankingEl.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    const cell = e.target.closest("td");
+    if (cell && cell.className.startsWith("nick-")) {
+      e.preventDefault();
       showQuickStats(cell.textContent, e);
     }
   });


### PR DESCRIPTION
## Summary
- make nickname cells focusable buttons with aria labels
- open quick stats on Enter or Space key

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/laser-tag-ranking/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b09e8b55c083218464f3a3196c7c49