### PR TITLE
feat: add toast notifications for network errors

### DIFF
--- a/gas/doPost.gs
+++ b/gas/doPost.gs
@@ -167,6 +167,7 @@ function doPost(e) {
 
     return JsonOK({status:'OK', players: updatedPlayers});
   } catch (err) {
+    console.debug('[ranking]', err);
     return TextPlain('Error: ' + err.message);
   }
 }

--- a/index.html
+++ b/index.html
@@ -317,6 +317,7 @@
         <div id="stats-body"></div>
       </div>
     </div>
+    <script src="scripts/toast.js"></script>
     <script type="module" src="scripts/api.js"></script>
     <script type="module" src="scripts/quickStats.js"></script>
     <script type="module" src="scripts/ranking.js"></script>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -16,7 +16,8 @@ window.postJson = window.postJson || async function postJson(url, body) {
   const text = await res.text();
   try {
     return JSON.parse(text);
-  } catch {
+  } catch (err) {
+    console.debug('[ranking]', err);
     return { status: 'TEXT', text };
   }
 };
@@ -63,6 +64,7 @@ export async function fetchOnce(url, ttlMs = 0, fetchFn) {
       }
     }
   } catch (e) {
+    console.debug('[ranking]', e);
     if (e && e.name === 'SecurityError') {
       storageOk = false;
     }
@@ -75,7 +77,9 @@ export async function fetchOnce(url, ttlMs = 0, fetchFn) {
   _fetchCache[url] = info;
   try {
     sessionStorage.setItem(url, JSON.stringify(info));
-  } catch {}
+  } catch (err) {
+    console.debug('[ranking]', err);
+  }
   return data;
 }
 
@@ -246,7 +250,7 @@ export async function fetchPlayerGames(nick, league = '') {
     res = await fetch(`${PROXY_URL}?sheet=games&t=${Date.now()}`);
     if (!res.ok) throw new Error('HTTP ' + res.status);
   } catch (err) {
-    console.warn('Failed to load games from proxy', err);
+    console.debug('[ranking]', err);
     res = await fetch(gamesURL);
   }
   const text = await res.text();
@@ -299,7 +303,8 @@ async function gasPost(action, payload = {}) {
   if (ct.includes('application/json')) {
     try {
       return JSON.parse(text);
-    } catch {
+    } catch (err) {
+      console.debug('[ranking]', err);
       return text;
     }
   }

--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -48,10 +48,10 @@ document.addEventListener('DOMContentLoaded', () => {
         if (res.trim() === 'OK') {
           alert('Детальна статистика з PDF імпортована успішно');
         } else {
-          alert('Помилка імпорту статистики: ' + res);
+          showToast('Помилка імпорту статистики: ' + res);
         }
       } catch (err) {
-        console.error('Помилка парсингу PDF:', err);
+        console.debug('[ranking]', err);
         alert('Не вдалося розпарсити PDF: ' + err.message);
       }
     });
@@ -131,7 +131,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const res = await saveResult(data);
       if (res.status !== 'OK') {
-        alert('Помилка збереження: ' + (res.status || res));
+        showToast('Помилка збереження: ' + (res.status || res));
         return;
       }
 
@@ -146,9 +146,8 @@ document.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem('gamedayRefresh', Date.now());
       btnClear.click();
     } catch (err) {
-      console.error('Помилка під час збереження:', err);
-      const msg = err && err.message ? err.message : String(err);
-      alert('Не вдалося зберегти гру:\n' + msg);
+      console.debug('[ranking]', err);
+      showToast('Не вдалося зберегти гру');
     }
   }
   btnSave.addEventListener('click', saveGame);

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -33,7 +33,8 @@ async function loadDefaultAvatars(path = 'assets/default_avatars/list.json'){
       defaultAvatars = list.map(f => `assets/default_avatars/${f}`);
     }
   }catch(err){
-    console.error('Failed to load default avatars', err);
+    console.debug('[ranking]', err);
+    showToast('Failed to load default avatars');
   }
 }
 
@@ -101,7 +102,8 @@ export async function initAvatarAdmin(players = [], league = '') {
           img.src = src;
           updateSaveBtn();
         } catch (err) {
-          console.error('Failed to fetch avatar', err);
+          console.debug('[ranking]', err);
+          showToast('Failed to fetch avatar');
         }
       });
       thumbs.appendChild(t);
@@ -135,13 +137,14 @@ export async function initAvatarAdmin(players = [], league = '') {
         img.src = `${url}?t=${Date.now()}`;
         localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
         row.querySelector('input[type="file"]').value = '';
-      } catch {
+      } catch (err) {
+        console.debug('[ranking]', err);
         failed.push(nick);
       }
     }
     updateSaveBtn();
     if (failed.length) {
-      alert('Failed to upload avatars for: ' + failed.join(', '));
+      showToast('Failed to upload avatars for: ' + failed.join(', '));
     }
     if (statusEl) {
       statusEl.textContent = 'Аватари оновлено';

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -58,7 +58,7 @@ import { getAvatarUrl, getPdfLinks, fetchOnce } from "./api.js";
     if(e.key === 'avatarRefresh') {
       const [nick] = (e.newValue || '').split(':');
       if(nick){
-        try{ sessionStorage.removeItem(`avatar:${nick}`); }catch{}
+      try{ sessionStorage.removeItem(`avatar:${nick}`); }catch(err){ console.debug('[ranking]', err); }
       }
       refreshAvatars(nick);
     }
@@ -122,10 +122,8 @@ import { getAvatarUrl, getPdfLinks, fetchOnce } from "./api.js";
     }catch(err){
       playersTb.innerHTML = '';
       matchesTb.innerHTML = '';
-      console.error('Failed to load gameday data', err);
-      if(typeof alert === 'function'){
-        alert('Failed to load gameday data. Please try again later.');
-      }
+      console.debug('[ranking]', err);
+      showToast('Failed to load gameday data. Please try again later.');
       return;
     }
     const ranking = Papa.parse(rText,{header:true,skipEmptyLines:true}).data;
@@ -134,7 +132,7 @@ import { getAvatarUrl, getPdfLinks, fetchOnce } from "./api.js";
     try{
       pdfLinks = await getPdfLinks({ league: leagueSel.value, date: dateInput.value });
     }catch(err){
-      console.error('Failed to load PDF links', err);
+      console.debug('[ranking]', err);
     }
 
     const players = {};

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -46,7 +46,9 @@ async function addPlayer(nick){
         players.push(res);
         filtered.push(res);
       }
-    } catch {}
+    } catch (err) {
+      console.debug('[ranking]', err);
+    }
   }
   if (!res) {
     alert('Гравця не знайдено');
@@ -195,10 +197,11 @@ document.addEventListener('DOMContentLoaded', () => {
           newNick.value = '';
           newAge.value = '';
         } else {
-          alert('Не вдалося створити гравця');
+          showToast('Не вдалося створити гравця');
         }
       } catch (err) {
-        alert('Не вдалося створити гравця');
+        console.debug('[ranking]', err);
+        showToast('Не вдалося створити гравця');
       }
     });
   }
@@ -414,10 +417,11 @@ function onLobbyAction(e) {
         player.abonement = newType;
         const full = players.find(p => p.nick === player.nick);
         if (full) full.abonement = newType;
-        alert('Абонемент оновлено');
+        showToast('Абонемент оновлено');
       } catch (err) {
         sel.value = prevType;
-        alert('Помилка оновлення абонемента');
+        console.debug('[ranking]', err);
+        showToast('Помилка оновлення абонемента');
       }
     })();
   }
@@ -435,7 +439,8 @@ document.addEventListener('click', async e => {
       cell.innerHTML = `<span class='key'>${key}</span><button class='copy-key'>Copy</button>`;
     }
   } catch (err) {
-    alert('Не вдалося видати ключ');
+    console.debug('[ranking]', err);
+    showToast('Не вдалося видати ключ');
   }
 });
 
@@ -448,7 +453,7 @@ document.addEventListener('click', async e => {
   try {
     await navigator.clipboard.writeText(key);
   } catch (err) {
-    // ignore
+    console.debug('[ranking]', err);
   }
 });
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
           players = JSON.parse(cached);
         } catch (e) {
-          // ignore bad cache
+          console.debug('[ranking]', e);
         }
       }
       if (!players) {
@@ -42,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
           sessionStorage.setItem(cacheKey, JSON.stringify(players));
         } catch (e) {
-          // ignore storage errors
+          console.debug('[ranking]', e);
         }
       }
 
@@ -50,8 +50,8 @@ document.addEventListener('DOMContentLoaded', () => {
       await initAvatarAdmin(players, selLeague.value);    // Рендер аватарів
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
     } catch (err) {
-      console.error('Помилка loadPlayers:', err);
-      alert('Не вдалося завантажити гравців:\n' + err.message);
+      console.debug('[ranking]', err);
+      showToast('Не вдалося завантажити гравців');
     } finally {
       btnLoad.disabled = false;
       btnLoad.textContent = 'Завантажити гравців';

--- a/scripts/playerStats.js
+++ b/scripts/playerStats.js
@@ -31,6 +31,8 @@ function init(){
       table.appendChild(tb);
       body.appendChild(table);
     }catch(err){
+      console.debug('[ranking]', err);
+      showToast('Помилка завантаження');
       body.textContent='Помилка завантаження';
     }
   };

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -73,6 +73,7 @@ async function renderGames(list, league) {
         const links = await getPdfLinks({ league, date: dt });
         pdfCache[dt] = links;
       } catch (err) {
+        console.debug('[ranking]', err);
         pdfCache[dt] = {};
       }
     }
@@ -147,6 +148,8 @@ async function loadProfile(nick, key = '') {
       return;
     }
   } catch (err) {
+    console.debug('[ranking]', err);
+    showToast('Помилка завантаження профілю');
     showError('Помилка завантаження профілю');
     return;
   }
@@ -183,7 +186,8 @@ async function loadProfile(nick, key = '') {
       document.getElementById('avatar').src = `${url}?t=${Date.now()}`;
       localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
     } catch (err) {
-      alert('Помилка завантаження');
+      console.debug('[ranking]', err);
+      showToast('Помилка завантаження');
     }
   });
 

--- a/scripts/quickStats.js
+++ b/scripts/quickStats.js
@@ -84,7 +84,7 @@ export async function showQuickStats(nick, evt) {
       }
     }
   } catch (e) {
-    /* ignore */
+    console.debug('[ranking]', e);
   }
 
   try {
@@ -95,9 +95,11 @@ export async function showQuickStats(nick, evt) {
     try {
       localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data }));
     } catch (e) {
-      /* ignore */
+      console.debug('[ranking]', e);
     }
   } catch (err) {
+    console.debug('[ranking]', err);
+    showToast('Не вдалося завантажити статистику');
     render(null);
   }
 }

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -37,7 +37,9 @@ window.addEventListener("storage", (e) => {
     if (nick) {
       try {
         sessionStorage.removeItem(`avatar:${nick}`);
-      } catch {}
+      } catch (err) {
+        console.debug('[ranking]', err);
+      }
     }
     refreshAvatars(nick);
   }
@@ -52,9 +54,9 @@ export async function loadData(rankingURL, gamesURL) {
     const games = Papa.parse(gText, { header: true, skipEmptyLines: true }).data;
     return { rank, games };
   } catch (err) {
-    console.error("Failed to load or parse ranking data", err);
+    console.debug('[ranking]', err);
     const msg = "Не вдалося завантажити дані рейтингу";
-    if (typeof alert === "function") alert(msg);
+    if (typeof showToast === 'function') showToast(msg);
     if (typeof document !== "undefined") {
       const div = document.createElement("div");
       div.textContent = msg;

--- a/scripts/register.js
+++ b/scripts/register.js
@@ -28,7 +28,9 @@ document.addEventListener('DOMContentLoaded', () => {
         form.reset();
       }
     }catch(err){
+      console.debug('[ranking]', err);
       status.textContent = 'Помилка: '+err.message;
+      showToast('Помилка реєстрації');
     }
   });
 });

--- a/scripts/script-kids.js
+++ b/scripts/script-kids.js
@@ -37,7 +37,10 @@ function loadRanking() {
                 table.appendChild(row);
             });
       })
-        .catch(error => console.error("Помилка завантаження даних:", error));
+        .catch(err => {
+            console.debug('[ranking]', err);
+            showToast('Помилка завантаження даних');
+        });
 }
 
 function togglePlayers() {

--- a/scripts/script-sunday.js
+++ b/scripts/script-sunday.js
@@ -37,7 +37,10 @@ function loadRanking() {
                 table.appendChild(row);
             });
         })
-        .catch(error => console.error("Помилка завантаження даних:", error));
+        .catch(err => {
+            console.debug('[ranking]', err);
+            showToast('Помилка завантаження даних');
+        });
 }
 
 function togglePlayers() {

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -10,7 +10,7 @@ export function saveLobbyState({lobby, teams, manualCount, league}){
     const key = getLobbyStorageKey(undefined, league);
     localStorage.setItem(key, JSON.stringify({lobby, teams, manualCount}));
   }catch(err){
-    console.error('Failed to save lobby state', err);
+    console.debug('[ranking]', err);
   }
 }
 
@@ -20,7 +20,7 @@ export function loadLobbyState(league){
     const data = localStorage.getItem(key);
     return data ? JSON.parse(data) : null;
   }catch(err){
-    console.error('Failed to load lobby state', err);
+    console.debug('[ranking]', err);
     return null;
   }
 }

--- a/scripts/toast.js
+++ b/scripts/toast.js
@@ -1,0 +1,34 @@
+(function(){
+  window.showToast = function(message){
+    if(!message) return;
+    let container = document.getElementById('toast-container');
+    if(!container){
+      container = document.createElement('div');
+      container.id = 'toast-container';
+      container.style.position = 'fixed';
+      container.style.bottom = '1rem';
+      container.style.left = '50%';
+      container.style.transform = 'translateX(-50%)';
+      container.style.zIndex = '9999';
+      container.style.display = 'flex';
+      container.style.flexDirection = 'column';
+      container.style.alignItems = 'center';
+      container.style.gap = '0.5rem';
+      document.body.appendChild(container);
+    }
+    const toast = document.createElement('div');
+    toast.textContent = message;
+    toast.style.background = 'rgba(0,0,0,0.8)';
+    toast.style.color = '#fff';
+    toast.style.padding = '0.5rem 1rem';
+    toast.style.borderRadius = '4px';
+    toast.style.fontSize = '0.75rem';
+    toast.style.boxShadow = '0 0 4px #000';
+    container.appendChild(toast);
+    setTimeout(()=>{
+      toast.style.transition = 'opacity 0.5s';
+      toast.style.opacity = '0';
+      setTimeout(()=>toast.remove(),500);
+    },3000);
+  };
+})();

--- a/sunday.html
+++ b/sunday.html
@@ -319,6 +319,7 @@
         <div id="stats-body"></div>
       </div>
     </div>
+    <script src="scripts/toast.js"></script>
     <script type="module" src="scripts/api.js"></script>
     <script type="module" src="scripts/quickStats.js"></script>
     <script type="module" src="scripts/ranking.js"></script>


### PR DESCRIPTION
## Summary
- add lightweight toast component for league pages
- replace network error alerts with toast notifications
- log errors via `console.debug('[ranking]', err)` in catch blocks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b09f41ef2c8321a46bffc724c82e19