### PR TITLE
refactor: centralize CSV URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This repository contains a small static web app used for managing and displaying
 
 All data submissions—saving match results, importing detailed stats and uploading avatars—are sent to this Apps Script which then updates the underlying spreadsheets and storage.
 
+## CSV data sources
+
+The app consumes public CSV exports from Google Sheets:
+
+- **Kids ranking:** https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv
+- **Adults (Sunday Games) ranking:** https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv
+- **Match logs for both leagues:** https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv
+
 ## Running the site locally
 
 The pages use ES modules, therefore they must be served via HTTP. Any static server will work, for example:

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -32,18 +32,26 @@ window.uiLeagueToGas = window.uiLeagueToGas || function uiLeagueToGas(v) {
 };
 
 // Google Apps Script backend (веб-апп)
-export const PROXY_URL = 'https://script.google.com/macros/s/AKfycbyXQz_D2HMtVJRomi83nK3iuIMSPKOehg2Lesj7IvHE1TwpqCiHqVCPwsvboxigvV1yIA/exec';
+export const PROXY_URL =
+  'https://script.google.com/macros/s/AKfycbyXQz_D2HMtVJRomi83nK3iuIMSPKOehg2Lesj7IvHE1TwpqCiHqVCPwsvboxigvV1yIA/exec';
 
-// Публічні фіди рейтингу (CSV)
-  const rankingURLs = {
-    kids:        'https://docs.google.com/spreadsheets/d/19VYkNmFJCArLFDngYLkpkxF0LYqvDz78yF1oqLT7Ukw/export?format=csv&gid=1648067737',
-    sundaygames: 'https://docs.google.com/spreadsheets/d/19VYkNmFJCArLFDngYLkpkxF0LYqvDz78yF1oqLT7Ukw/export?format=csv&gid=1286735969'
-  };
+// Публічні фіди (CSV)
+export const CSV_URLS = {
+  kids: {
+    ranking:
+      'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv',
+    games:
+      'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv',
+  },
+  sundaygames: {
+    ranking:
+      'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv',
+    games:
+      'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv',
+  },
+};
 
-const rankFromPoints = p => (p < 200 ? 'D' : p < 500 ? 'C' : p < 800 ? 'B' : p < 1200 ? 'A' : 'S');
-
-// Логи ігор (CSV)
-const gamesURL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv';
+const rankFromPoints = (p) => (p < 200 ? 'D' : p < 500 ? 'C' : p < 800 ? 'B' : p < 1200 ? 'A' : 'S');
 
 // ---------------------- Cached fetch ----------------------
 const _fetchCache = {};
@@ -94,7 +102,14 @@ export function normalizeLeague(v) {
 
 export function getLeagueFeedUrl(league) {
   const key = normalizeLeague(league);
-  const url = rankingURLs[key];
+  const url = CSV_URLS[key]?.ranking;
+  if (!url) throw new Error('Unknown league: ' + league);
+  return url;
+}
+
+export function getGamesFeedUrl(league) {
+  const key = normalizeLeague(league);
+  const url = CSV_URLS[key]?.games;
   if (!url) throw new Error('Unknown league: ' + league);
   return url;
 }
@@ -251,7 +266,7 @@ export async function fetchPlayerGames(nick, league = '') {
     if (!res.ok) throw new Error('HTTP ' + res.status);
   } catch (err) {
     console.debug('[ranking]', err);
-    res = await fetch(gamesURL);
+    res = await fetch(getGamesFeedUrl(league));
   }
   const text = await res.text();
 

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,5 +1,5 @@
-import { getAvatarUrl, getPdfLinks, fetchOnce } from "./api.js";
-(function(){
+import { getAvatarUrl, getPdfLinks, fetchOnce, CSV_URLS } from "./api.js";
+(function () {
   const AVATAR_TTL = 6 * 60 * 60 * 1000;
   const CSV_TTL = 60 * 1000;
   const DEFAULT_AVATAR_URL = "assets/default_avatars/av0.png";
@@ -26,11 +26,7 @@ import { getAvatarUrl, getPdfLinks, fetchOnce } from "./api.js";
     const sel = nick ? `img.avatar-img[data-nick="${nick}"]` : 'img.avatar-img[data-nick]';
     document.querySelectorAll(sel).forEach(img=>setAvatar(img, img.dataset.nick));
   }
-    const rankingURLs = {
-      kids: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv",
-      sundaygames: "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv"
-    };
-  const gamesURL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv";
+
 
   const alias = {
     "Zavodchanyn": "Romario",
@@ -112,12 +108,13 @@ import { getAvatarUrl, getPdfLinks, fetchOnce } from "./api.js";
 
   async function loadData(){
     if(!dateInput.value) return; // require date
-    const rURL = rankingURLs[leagueSel.value];
+    const rURL = CSV_URLS[leagueSel.value].ranking;
+    const gURL = CSV_URLS[leagueSel.value].games;
     let rText, gText;
-    try{
+    try {
       [rText, gText] = await Promise.all([
         fetchOnce(rURL, CSV_TTL),
-        fetchOnce(gamesURL, CSV_TTL)
+        fetchOnce(gURL, CSV_TTL),
       ]);
     }catch(err){
       playersTb.innerHTML = '';

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,4 +1,4 @@
-import { getAvatarUrl, fetchOnce } from "./api.js";
+import { getAvatarUrl, fetchOnce, CSV_URLS } from "./api.js";
 import { LEAGUE } from "./constants.js";
 
 const DEFAULT_AVATAR_URL = "assets/default_avatars/av0.png";
@@ -327,10 +327,6 @@ export function formatFull(d) {
 
 const CONFIG = {
   kids: {
-    rankingURL:
-      "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv",
-    gamesURL:
-      "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv",
     alias: {
       Zavodchanyn: "Romario",
       Mariko: "Gidora",
@@ -338,10 +334,6 @@ const CONFIG = {
     },
   },
   sundaygames: {
-    rankingURL:
-      "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv",
-    gamesURL:
-      "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv",
     alias: {
       Romario: "Zavodchanyn",
       Mariko: "Gidora",
@@ -353,7 +345,10 @@ const CONFIG = {
 async function init() {
   const cfg = CONFIG[LEAGUE];
   if (!cfg) return;
-  const { rank, games } = await loadData(cfg.rankingURL, cfg.gamesURL);
+  const { rank, games } = await loadData(
+    CSV_URLS[LEAGUE].ranking,
+    CSV_URLS[LEAGUE].games
+  );
   const { players, totalGames, totalRounds, minDate, maxDate } = computeStats(
     rank,
     games,

--- a/scripts/script-kids.js
+++ b/scripts/script-kids.js
@@ -1,5 +1,6 @@
+import { CSV_URLS } from "./api.js";
 
-const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv";
+const csvUrl = CSV_URLS.kids.ranking;
 
 function getRank(points) {
     if (points >= 1200) return { rank: "S-ранг", class: "rank-S", icon: "🟣" };

--- a/scripts/script-sunday.js
+++ b/scripts/script-sunday.js
@@ -1,5 +1,6 @@
+import { CSV_URLS } from "./api.js";
 
-const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv";
+const csvUrl = CSV_URLS.sundaygames.ranking;
 
 function getRank(points) {
     if (points >= 1200) return { rank: "S-ранг", class: "rank-S", icon: "🟣" };


### PR DESCRIPTION
## Summary
- centralize kids and Sunday Games CSV endpoints in a shared `CSV_URLS` map
- update ranking and gameday pages to consume `CSV_URLS` instead of hard-coded links
- document exact sheet URLs in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a39635808321bccbab547d9ba3d9