### PR TITLE
Handle avatar cache refresh in ranking

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -56,6 +56,15 @@ const rankFromPoints = (p) => (p < 200 ? 'D' : p < 500 ? 'C' : p < 800 ? 'B' : p
 // ---------------------- Cached fetch ----------------------
 const _fetchCache = {};
 
+export function clearFetchCache(key) {
+  delete _fetchCache[key];
+  try {
+    sessionStorage.removeItem(key);
+  } catch (err) {
+    console.debug('[ranking]', err);
+  }
+}
+
 export async function fetchOnce(url, ttlMs = 0, fetchFn) {
   const now = Date.now();
   const cached = _fetchCache[url];

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,4 +1,4 @@
-import { getAvatarUrl, fetchOnce, CSV_URLS } from "./api.js";
+import { getAvatarUrl, fetchOnce, CSV_URLS, clearFetchCache } from "./api.js";
 import { LEAGUE } from "./constants.js";
 
 const DEFAULT_AVATAR_URL = "assets/default_avatars/av0.png";
@@ -14,7 +14,7 @@ async function setAvatar(img, nick) {
   img.dataset.nick = nick;
   const url = await fetchAvatar(nick);
   if (url) {
-    img.src = `${url}?t=${Date.now()}`;
+    img.src = url;
   } else {
     img.src = DEFAULT_AVATAR_URL;
   }
@@ -35,6 +35,7 @@ window.addEventListener("storage", (e) => {
   if (e.key === "avatarRefresh") {
     const [nick] = (e.newValue || "").split(":");
     if (nick) {
+      clearFetchCache(`avatar:${nick}`);
       try {
         sessionStorage.removeItem(`avatar:${nick}`);
       } catch (err) {


### PR DESCRIPTION
## Summary
- Export `clearFetchCache` to remove cached fetch responses
- Load avatar images directly without cache-busting query parameters
- Flush avatar caches and refresh images when `avatarRefresh` fires

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ac6f73948321aa74282572bed12e