### PR TITLE
Map sundaygames league to olds in ranking stats

### DIFF
--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -70,7 +70,8 @@ export async function loadData(rankingURL, gamesURL) {
 export function computeStats(rank, games, { alias = {}, league } = {}) {
   const stats = {};
   let totalRounds = 0;
-  const filtered = league ? games.filter((g) => g.League === league) : games;
+  const leagueKey = league === 'sundaygames' ? 'olds' : league;
+  const filtered = league ? games.filter((g) => g.League === leagueKey) : games;
   filtered.forEach((g) => {
     const t1 = g.Team1.split(",").map((n) => alias[n.trim()] || n.trim());
     const t2 = g.Team2.split(",").map((n) => alias[n.trim()] || n.trim());


### PR DESCRIPTION
## Summary
- Normalize adult league key by mapping `sundaygames` to `olds` before filtering games

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --input-type=module - <<'NODE' ...` (sample computeStats call)


------
https://chatgpt.com/codex/tasks/task_e_68b0b3a91a7c83219a8774ab797fdf91