### PR TITLE
Add sortable ranking table

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,14 +296,14 @@
         <table>
           <thead>
             <tr>
-              <th>Місце</th>
+              <th data-key="place">Місце <span class="sort-arrow"></span></th>
               <th>Аватар</th>
-              <th>Нікнейм</th>
-              <th>Ранг</th>
-              <th>Бали</th>
-              <th>Ігор</th>
-              <th>% Win</th>
-              <th>MVP</th>
+              <th data-key="nickname">Нікнейм <span class="sort-arrow"></span></th>
+              <th data-key="rank">Ранг <span class="sort-arrow"></span></th>
+              <th data-key="points">Бали <span class="sort-arrow"></span></th>
+              <th data-key="games">Ігор <span class="sort-arrow"></span></th>
+              <th data-key="winRate">% Win <span class="sort-arrow"></span></th>
+              <th data-key="mvp">MVP <span class="sort-arrow"></span></th>
             </tr>
           </thead>
           <tbody id="ranking"></tbody>

--- a/sunday.html
+++ b/sunday.html
@@ -298,14 +298,14 @@
         <table>
           <thead>
             <tr>
-              <th>Місце</th>
+              <th data-key="place">Місце <span class="sort-arrow"></span></th>
               <th>Аватар</th>
-              <th>Нікнейм</th>
-              <th>Ранг</th>
-              <th>Бали</th>
-              <th>Ігор</th>
-              <th>% Win</th>
-              <th>MVP</th>
+              <th data-key="nickname">Нікнейм <span class="sort-arrow"></span></th>
+              <th data-key="rank">Ранг <span class="sort-arrow"></span></th>
+              <th data-key="points">Бали <span class="sort-arrow"></span></th>
+              <th data-key="games">Ігор <span class="sort-arrow"></span></th>
+              <th data-key="winRate">% Win <span class="sort-arrow"></span></th>
+              <th data-key="mvp">MVP <span class="sort-arrow"></span></th>
             </tr>
           </thead>
           <tbody id="ranking"></tbody>


### PR DESCRIPTION
## Summary
- Make ranking headers clickable and show sort arrows
- Sort players with stable comparator and preserve search filtering

## Testing
- `npm test` (fails: ENOENT could not read package.json)
- `npm run lint` (fails: ENOENT could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b0bb4af8fc8321a221ea0b128053fe