### PR TITLE
feat: centralize logging utility

### DIFF
--- a/gas/doPost.gs
+++ b/gas/doPost.gs
@@ -8,6 +8,14 @@ const SPREADSHEET_ID = '19VYkNmFJCArLFDngYLkpkxF0LYqvDz78yF1oqLT7Ukw';
 const PKEY_AVATARS_FOLDER_ID = 'LT_AVATARS_FOLDER_ID'; // 1UdG7dhV7iT1a5H2HkvjYxV711hT_ahhn
 const PKEY_PDFS_FOLDER_ID    = 'LT_PDFS_FOLDER_ID';    // 1l3uM7cRTPe4aUclZ874hYz_LxrZV4riP
 
+function log(...args) {
+  if (typeof console !== 'undefined' && typeof console.debug === 'function') {
+    console.debug(...args);
+  } else if (typeof console !== 'undefined' && typeof console.log === 'function') {
+    console.log(...args);
+  }
+}
+
 function doPost(e) {
   try {
     // ---------- JSON API ----------
@@ -167,7 +175,7 @@ function doPost(e) {
 
     return JsonOK({status:'OK', players: updatedPlayers});
   } catch (err) {
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
     return TextPlain('Error: ' + err.message);
   }
 }

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,4 +1,5 @@
 // scripts/api.js
+import { log } from './logger.js';
 
 // ---------------------- Глобальні утиліти ----------------------
 // Веб-апп GAS, якщо ще не визначено
@@ -17,7 +18,7 @@ window.postJson = window.postJson || async function postJson(url, body) {
   try {
     return JSON.parse(text);
   } catch (err) {
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
     return { status: 'TEXT', text };
   }
 };
@@ -61,7 +62,7 @@ export function clearFetchCache(key) {
   try {
     sessionStorage.removeItem(key);
   } catch (err) {
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
   }
 }
 
@@ -81,7 +82,7 @@ export async function fetchOnce(url, ttlMs = 0, fetchFn) {
       }
     }
   } catch (e) {
-    console.debug('[ranking]', e);
+    log('[ranking]', e);
     if (e && e.name === 'SecurityError') {
       storageOk = false;
     }
@@ -95,7 +96,7 @@ export async function fetchOnce(url, ttlMs = 0, fetchFn) {
   try {
     sessionStorage.setItem(url, JSON.stringify(info));
   } catch (err) {
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
   }
   return data;
 }
@@ -274,7 +275,7 @@ export async function fetchPlayerGames(nick, league = '') {
     res = await fetch(`${PROXY_URL}?sheet=games&t=${Date.now()}`);
     if (!res.ok) throw new Error('HTTP ' + res.status);
   } catch (err) {
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
     res = await fetch(getGamesFeedUrl(league));
   }
   const text = await res.text();
@@ -328,7 +329,7 @@ async function gasPost(action, payload = {}) {
     try {
       return JSON.parse(text);
     } catch (err) {
-      console.debug('[ranking]', err);
+      log('[ranking]', err);
       return text;
     }
   }

--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -1,4 +1,5 @@
 // scripts/arena.js
+import { log } from './logger.js';
 
 import { saveResult, saveDetailedStats, normalizeLeague } from './api.js';
 import { parseGamePdf }                   from './pdfParser.js';
@@ -51,7 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
           showToast('Помилка імпорту статистики: ' + res);
         }
       } catch (err) {
-        console.debug('[ranking]', err);
+        log('[ranking]', err);
         alert('Не вдалося розпарсити PDF: ' + err.message);
       }
     });
@@ -146,7 +147,7 @@ document.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem('gamedayRefresh', Date.now());
       btnClear.click();
     } catch (err) {
-      console.debug('[ranking]', err);
+      log('[ranking]', err);
       showToast('Не вдалося зберегти гру');
     }
   }

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,4 +1,5 @@
 // scripts/avatarAdmin.js
+import { log } from './logger.js';
 import { uploadAvatar, getAvatarUrl, fetchOnce } from './api.js';
 
 const AVATAR_TTL = 6 * 60 * 60 * 1000;
@@ -33,7 +34,7 @@ async function loadDefaultAvatars(path = 'assets/default_avatars/list.json'){
       defaultAvatars = list.map(f => `assets/default_avatars/${f}`);
     }
   }catch(err){
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
     showToast('Failed to load default avatars');
   }
 }
@@ -102,7 +103,7 @@ export async function initAvatarAdmin(players = [], league = '') {
           img.src = src;
           updateSaveBtn();
         } catch (err) {
-          console.debug('[ranking]', err);
+          log('[ranking]', err);
           showToast('Failed to fetch avatar');
         }
       });
@@ -138,7 +139,7 @@ export async function initAvatarAdmin(players = [], league = '') {
         localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
         row.querySelector('input[type="file"]').value = '';
       } catch (err) {
-        console.debug('[ranking]', err);
+        log('[ranking]', err);
         failed.push(nick);
       }
     }

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,3 +1,4 @@
+import { log } from './logger.js';
 import { getAvatarUrl, getPdfLinks, fetchOnce, CSV_URLS } from "./api.js";
 (function () {
   const AVATAR_TTL = 6 * 60 * 60 * 1000;
@@ -54,7 +55,7 @@ import { getAvatarUrl, getPdfLinks, fetchOnce, CSV_URLS } from "./api.js";
     if(e.key === 'avatarRefresh') {
       const [nick] = (e.newValue || '').split(':');
       if(nick){
-      try{ sessionStorage.removeItem(`avatar:${nick}`); }catch(err){ console.debug('[ranking]', err); }
+      try{ sessionStorage.removeItem(`avatar:${nick}`); }catch(err){ log('[ranking]', err); }
       }
       refreshAvatars(nick);
     }
@@ -119,7 +120,7 @@ import { getAvatarUrl, getPdfLinks, fetchOnce, CSV_URLS } from "./api.js";
     }catch(err){
       playersTb.innerHTML = '';
       matchesTb.innerHTML = '';
-      console.debug('[ranking]', err);
+      log('[ranking]', err);
       showToast('Failed to load gameday data. Please try again later.');
       return;
     }
@@ -129,7 +130,7 @@ import { getAvatarUrl, getPdfLinks, fetchOnce, CSV_URLS } from "./api.js";
     try{
       pdfLinks = await getPdfLinks({ league: leagueSel.value, date: dateInput.value });
     }catch(err){
-      console.debug('[ranking]', err);
+      log('[ranking]', err);
     }
 
     const players = {};

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -1,4 +1,5 @@
 // scripts/lobby.js
+import { log } from './logger.js';
 
 import { initTeams, teams } from './teams.js';
 import { sortByName, sortByPtsDesc } from './sortUtils.js';
@@ -47,7 +48,7 @@ async function addPlayer(nick){
         filtered.push(res);
       }
     } catch (err) {
-      console.debug('[ranking]', err);
+      log('[ranking]', err);
     }
   }
   if (!res) {
@@ -200,7 +201,7 @@ document.addEventListener('DOMContentLoaded', () => {
           showToast('Не вдалося створити гравця');
         }
       } catch (err) {
-        console.debug('[ranking]', err);
+        log('[ranking]', err);
         showToast('Не вдалося створити гравця');
       }
     });
@@ -420,7 +421,7 @@ function onLobbyAction(e) {
         showToast('Абонемент оновлено');
       } catch (err) {
         sel.value = prevType;
-        console.debug('[ranking]', err);
+        log('[ranking]', err);
         showToast('Помилка оновлення абонемента');
       }
     })();
@@ -439,7 +440,7 @@ document.addEventListener('click', async e => {
       cell.innerHTML = `<span class='key'>${key}</span><button class='copy-key'>Copy</button>`;
     }
   } catch (err) {
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
     showToast('Не вдалося видати ключ');
   }
 });
@@ -453,7 +454,7 @@ document.addEventListener('click', async e => {
   try {
     await navigator.clipboard.writeText(key);
   } catch (err) {
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
   }
 });
 

--- a/scripts/logger.js
+++ b/scripts/logger.js
@@ -1,0 +1,7 @@
+export function log(...args) {
+  if (typeof console !== 'undefined' && typeof console.debug === 'function') {
+    console.debug(...args);
+  } else if (typeof console !== 'undefined' && typeof console.log === 'function') {
+    console.log(...args);
+  }
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,5 @@
 // scripts/main.js
+import { log } from './logger.js';
 
 import { loadPlayers } from './api.js';
 import { initLobby }   from './lobby.js';
@@ -34,7 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
           players = JSON.parse(cached);
         } catch (e) {
-          console.debug('[ranking]', e);
+          log('[ranking]', e);
         }
       }
       if (!players) {
@@ -42,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
           sessionStorage.setItem(cacheKey, JSON.stringify(players));
         } catch (e) {
-          console.debug('[ranking]', e);
+          log('[ranking]', e);
         }
       }
 
@@ -50,7 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
       await initAvatarAdmin(players, selLeague.value);    // Рендер аватарів
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
     } catch (err) {
-      console.debug('[ranking]', err);
+      log('[ranking]', err);
       showToast('Не вдалося завантажити гравців');
     } finally {
       btnLoad.disabled = false;

--- a/scripts/playerStats.js
+++ b/scripts/playerStats.js
@@ -1,3 +1,4 @@
+import { log } from './logger.js';
 import { fetchPlayerStats } from './api.js';
 
 function init(){
@@ -31,7 +32,7 @@ function init(){
       table.appendChild(tb);
       body.appendChild(table);
     }catch(err){
-      console.debug('[ranking]', err);
+      log('[ranking]', err);
       showToast('Помилка завантаження');
       body.textContent='Помилка завантаження';
     }

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,3 +1,4 @@
+import { log } from './logger.js';
 import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, getAvatarUrl, fetchOnce } from './api.js';
 
 let gameLimit = 0;
@@ -73,7 +74,7 @@ async function renderGames(list, league) {
         const links = await getPdfLinks({ league, date: dt });
         pdfCache[dt] = links;
       } catch (err) {
-        console.debug('[ranking]', err);
+        log('[ranking]', err);
         pdfCache[dt] = {};
       }
     }
@@ -148,7 +149,7 @@ async function loadProfile(nick, key = '') {
       return;
     }
   } catch (err) {
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
     showToast('Помилка завантаження профілю');
     showError('Помилка завантаження профілю');
     return;
@@ -186,7 +187,7 @@ async function loadProfile(nick, key = '') {
       document.getElementById('avatar').src = `${url}?t=${Date.now()}`;
       localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
     } catch (err) {
-      console.debug('[ranking]', err);
+      log('[ranking]', err);
       showToast('Помилка завантаження');
     }
   });

--- a/scripts/quickStats.js
+++ b/scripts/quickStats.js
@@ -1,4 +1,5 @@
 // Quick stats popover
+import { log } from './logger.js';
 const STYLE_ID = "quick-stats-style";
 if (!document.getElementById(STYLE_ID)) {
   const style = document.createElement("style");
@@ -98,7 +99,7 @@ export async function showQuickStats(nick, evt) {
       }
     }
   } catch (e) {
-    console.debug('[ranking]', e);
+    log('[ranking]', e);
   }
 
   try {
@@ -109,10 +110,10 @@ export async function showQuickStats(nick, evt) {
     try {
       localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data }));
     } catch (e) {
-      console.debug('[ranking]', e);
+      log('[ranking]', e);
     }
   } catch (err) {
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
     if (typeof showToast === 'function') showToast('Не вдалося завантажити статистику');
     render(null);
   }

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,3 +1,4 @@
+import { log } from './logger.js';
 import { getAvatarUrl, fetchOnce, CSV_URLS, clearFetchCache } from "./api.js";
 import { LEAGUE } from "./constants.js";
 
@@ -39,7 +40,7 @@ window.addEventListener("storage", (e) => {
       try {
         sessionStorage.removeItem(`avatar:${nick}`);
       } catch (err) {
-        console.debug('[ranking]', err);
+        log('[ranking]', err);
       }
     }
     refreshAvatars(nick);
@@ -55,7 +56,7 @@ export async function loadData(rankingURL, gamesURL) {
     const games = Papa.parse(gText, { header: true, skipEmptyLines: true }).data;
     return { rank, games };
   } catch (err) {
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
     const msg = "Не вдалося завантажити дані рейтингу";
     if (typeof showToast === 'function') showToast(msg);
     if (typeof document !== "undefined") {

--- a/scripts/register.js
+++ b/scripts/register.js
@@ -1,3 +1,4 @@
+import { log } from './logger.js';
 import { registerPlayer } from './api.js';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -28,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
         form.reset();
       }
     }catch(err){
-      console.debug('[ranking]', err);
+      log('[ranking]', err);
       status.textContent = 'Помилка: '+err.message;
       showToast('Помилка реєстрації');
     }

--- a/scripts/script-kids.js
+++ b/scripts/script-kids.js
@@ -1,3 +1,4 @@
+import { log } from './logger.js';
 import { CSV_URLS } from "./api.js";
 
 const csvUrl = CSV_URLS.kids.ranking;
@@ -39,7 +40,7 @@ function loadRanking() {
             });
       })
         .catch(err => {
-            console.debug('[ranking]', err);
+            log('[ranking]', err);
             showToast('Помилка завантаження даних');
         });
 }

--- a/scripts/script-sunday.js
+++ b/scripts/script-sunday.js
@@ -1,3 +1,4 @@
+import { log } from './logger.js';
 import { CSV_URLS } from "./api.js";
 
 const csvUrl = CSV_URLS.sundaygames.ranking;
@@ -39,7 +40,7 @@ function loadRanking() {
             });
         })
         .catch(err => {
-            console.debug('[ranking]', err);
+            log('[ranking]', err);
             showToast('Помилка завантаження даних');
         });
 }

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -1,3 +1,4 @@
+import { log } from './logger.js';
 export function getLobbyStorageKey(date, league){
   const d = date || document.getElementById('date')?.value || new Date().toISOString().slice(0,10);
   const sel = document.getElementById('league');
@@ -10,7 +11,7 @@ export function saveLobbyState({lobby, teams, manualCount, league}){
     const key = getLobbyStorageKey(undefined, league);
     localStorage.setItem(key, JSON.stringify({lobby, teams, manualCount}));
   }catch(err){
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
   }
 }
 
@@ -20,7 +21,7 @@ export function loadLobbyState(league){
     const data = localStorage.getItem(key);
     return data ? JSON.parse(data) : null;
   }catch(err){
-    console.debug('[ranking]', err);
+    log('[ranking]', err);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- add `scripts/logger.js` with `log(...args)` using `console.debug` when available
- replace direct `console.debug` calls across frontend and GAS scripts with `log`
- ensure backend `doPost.gs` defines and uses the same logger

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bd0c320483219e7b61d8d189fc24