### PR TITLE
Include toast script before modules

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -150,6 +150,8 @@
       'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js';
   </script>
 
+  <script src="scripts/toast.js"></script>
+
   <!-- ES-модулі -->
   <script type="module" src="scripts/api.js"></script>
   <script type="module" src="scripts/pdfParser.js"></script>

--- a/profile.html
+++ b/profile.html
@@ -49,6 +49,7 @@
       <tbody id="games-body"></tbody>
     </table>
   </div>
+  <script src="scripts/toast.js"></script>
   <script type="module" src="scripts/profile.js"></script>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -59,6 +59,7 @@
       <div id="reg-status" class="status"></div>
     </form>
   </div>
+  <script src="scripts/toast.js"></script>
   <script type="module" src="scripts/register.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load toast.js ahead of all module scripts on balance, register, and profile pages to ensure toast notifications are available.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bf3c6bdc8321bb9fdefb58f22fee