### PR TITLE
refactor: add safe storage helpers

### DIFF
--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -1,7 +1,7 @@
 // scripts/arena.js
 import { log } from './logger.js';
 
-import { saveResult, saveDetailedStats, normalizeLeague } from './api.js';
+import { saveResult, saveDetailedStats, normalizeLeague, safeSet } from './api.js';
 import { parseGamePdf }                   from './pdfParser.js';
 import { updateLobbyState }               from './lobby.js';
 import { teams }                          from './teams.js';
@@ -144,7 +144,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       alert('Гру успішно збережено та рейтинги оновлено');
-      localStorage.setItem('gamedayRefresh', Date.now());
+      safeSet(localStorage, 'gamedayRefresh', Date.now());
       btnClear.click();
     } catch (err) {
       log('[ranking]', err);

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,6 +1,6 @@
 // scripts/avatarAdmin.js
 import { log } from './logger.js';
-import { uploadAvatar, getAvatarUrl, fetchOnce } from './api.js';
+import { uploadAvatar, getAvatarUrl, fetchOnce, safeSet } from './api.js';
 
 const AVATAR_TTL = 6 * 60 * 60 * 1000;
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
@@ -136,7 +136,7 @@ export async function initAvatarAdmin(players = [], league = '') {
       try {
         const url = await uploadAvatar(nick, file);
         img.src = `${url}?t=${Date.now()}`;
-        localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
+        safeSet(localStorage, 'avatarRefresh', nick + ':' + Date.now());
         row.querySelector('input[type="file"]').value = '';
       } catch (err) {
         log('[ranking]', err);

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,5 +1,5 @@
 import { log } from './logger.js';
-import { getAvatarUrl, getPdfLinks, fetchOnce, CSV_URLS } from "./api.js";
+import { getAvatarUrl, getPdfLinks, fetchOnce, CSV_URLS, safeDel } from "./api.js";
 (function () {
   const AVATAR_TTL = 6 * 60 * 60 * 1000;
   const CSV_TTL = 60 * 1000;
@@ -55,7 +55,7 @@ import { getAvatarUrl, getPdfLinks, fetchOnce, CSV_URLS } from "./api.js";
     if(e.key === 'avatarRefresh') {
       const [nick] = (e.newValue || '').split(':');
       if(nick){
-      try{ sessionStorage.removeItem(`avatar:${nick}`); }catch(err){ log('[ranking]', err); }
+      safeDel(sessionStorage, `avatar:${nick}`);
       }
       refreshAvatars(nick);
     }

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -3,7 +3,7 @@ import { log } from './logger.js';
 
 import { initTeams, teams } from './teams.js';
 import { sortByName, sortByPtsDesc } from './sortUtils.js';
-import { updateAbonement, adminCreatePlayer, issueAccessKey, getAvatarUrl, getProfile, fetchOnce } from './api.js';
+import { updateAbonement, adminCreatePlayer, issueAccessKey, getAvatarUrl, getProfile, fetchOnce, safeDel } from './api.js';
 import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js';
 
 export let lobby = [];
@@ -225,7 +225,7 @@ export function clearLobby() {
   manualCount = 0;
   Object.keys(teams).forEach(k => { teams[k].length = 0; });
 
-  localStorage.removeItem(getLobbyStorageKey(undefined, uiLeague));
+  safeDel(localStorage, getLobbyStorageKey(undefined, uiLeague));
 
   renderLobby();
   renderTeams();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,7 +1,7 @@
 // scripts/main.js
 import { log } from './logger.js';
 
-import { loadPlayers } from './api.js';
+import { loadPlayers, safeGet, safeSet } from './api.js';
 import { initLobby }   from './lobby.js';
 import { initScenario } from './scenario.js';
 import { initAvatarAdmin } from './avatarAdmin.js';
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const cacheKey = csvLeague + CACHE_VERSION;
 
       let players;
-      const cached = sessionStorage.getItem(cacheKey);
+      const cached = safeGet(sessionStorage, cacheKey);
       if (cached) {
         try {
           players = JSON.parse(cached);
@@ -40,11 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       if (!players) {
         players = await loadPlayers(csvLeague);
-        try {
-          sessionStorage.setItem(cacheKey, JSON.stringify(players));
-        } catch (e) {
-          log('[ranking]', e);
-        }
+        safeSet(sessionStorage, cacheKey, JSON.stringify(players));
       }
 
       initLobby(players, csvLeague);          // Рендер лоббі

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,5 +1,5 @@
 import { log } from './logger.js';
-import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, getAvatarUrl, fetchOnce } from './api.js';
+import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, getAvatarUrl, fetchOnce, safeSet, safeGet } from './api.js';
 
 let gameLimit = 0;
 let gamesLeftEl = null;
@@ -128,7 +128,7 @@ function askKey(nick) {
     document.getElementById('key-submit').addEventListener('click', () => {
       const key = document.getElementById('key-input').value.trim();
       if (key) {
-        localStorage.setItem(`profileKey:${nick}`, key);
+        safeSet(localStorage, `profileKey:${nick}`, key);
         box.remove();
         loadProfile(nick, key);
       }
@@ -185,7 +185,7 @@ async function loadProfile(nick, key = '') {
       const url = await uploadAvatar(nick, file);
       avatarUrl = url;
       document.getElementById('avatar').src = `${url}?t=${Date.now()}`;
-      localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
+      safeSet(localStorage, 'avatarRefresh', nick + ':' + Date.now());
     } catch (err) {
       log('[ranking]', err);
       showToast('Помилка завантаження');
@@ -203,7 +203,7 @@ document.addEventListener('DOMContentLoaded', () => {
     showError('Нік не вказано');
     return;
   }
-  const key = localStorage.getItem(`profileKey:${nick}`) || '';
+  const key = safeGet(localStorage, `profileKey:${nick}`) || '';
   currentNick = nick;
   loadProfile(nick, key);
 });

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,5 +1,5 @@
 import { log } from './logger.js';
-import { getAvatarUrl, fetchOnce, CSV_URLS, clearFetchCache } from "./api.js";
+import { getAvatarUrl, fetchOnce, CSV_URLS, clearFetchCache, safeDel } from "./api.js";
 import { LEAGUE } from "./constants.js";
 
 const DEFAULT_AVATAR_URL = "assets/default_avatars/av0.png";
@@ -37,11 +37,7 @@ window.addEventListener("storage", (e) => {
     const [nick] = (e.newValue || "").split(":");
     if (nick) {
       clearFetchCache(`avatar:${nick}`);
-      try {
-        sessionStorage.removeItem(`avatar:${nick}`);
-      } catch (err) {
-        log('[ranking]', err);
-      }
+      safeDel(sessionStorage, `avatar:${nick}`);
     }
     refreshAvatars(nick);
   }

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -1,4 +1,5 @@
 import { log } from './logger.js';
+import { safeSet, safeGet } from './api.js';
 export function getLobbyStorageKey(date, league){
   const d = date || document.getElementById('date')?.value || new Date().toISOString().slice(0,10);
   const sel = document.getElementById('league');
@@ -7,20 +8,17 @@ export function getLobbyStorageKey(date, league){
 }
 
 export function saveLobbyState({lobby, teams, manualCount, league}){
-  try{
-    const key = getLobbyStorageKey(undefined, league);
-    localStorage.setItem(key, JSON.stringify({lobby, teams, manualCount}));
-  }catch(err){
-    log('[ranking]', err);
-  }
+  const key = getLobbyStorageKey(undefined, league);
+  safeSet(localStorage, key, JSON.stringify({lobby, teams, manualCount}));
 }
 
 export function loadLobbyState(league){
-  try{
-    const key = getLobbyStorageKey(undefined, league);
-    const data = localStorage.getItem(key);
-    return data ? JSON.parse(data) : null;
-  }catch(err){
+  const key = getLobbyStorageKey(undefined, league);
+  const data = safeGet(localStorage, key);
+  if (!data) return null;
+  try {
+    return JSON.parse(data);
+  } catch (err) {
     log('[ranking]', err);
     return null;
   }


### PR DESCRIPTION
## Summary
- add safeGet, safeSet, and safeDel wrappers for Web Storage
- use safe storage helpers across ranking, quick stats, profile, and other modules

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0c1084a1c83218b25d6e4847974ef