### PR TITLE
Filter rankings by league and standardize headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@
               <th data-key="rank">Ранг <span class="sort-arrow"></span></th>
               <th data-key="points">Бали <span class="sort-arrow"></span></th>
               <th data-key="games">Ігор <span class="sort-arrow"></span></th>
-              <th data-key="winRate">% Win <span class="sort-arrow"></span></th>
+              <th data-key="winRate">%Win <span class="sort-arrow"></span></th>
               <th data-key="mvp">MVP <span class="sort-arrow"></span></th>
             </tr>
           </thead>

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -67,8 +67,10 @@ export async function loadData(rankingURL, gamesURL) {
 export function computeStats(rank, games, { alias = {}, league } = {}) {
   const stats = {};
   let totalRounds = 0;
-  const leagueKey = league === 'sundaygames' ? 'olds' : league;
-  const filtered = league ? games.filter((g) => g.League === leagueKey) : games;
+  const validLeagues = ["kids", "olds"];
+  const filtered = validLeagues.includes(league)
+    ? games.filter((g) => g.League === league)
+    : games;
   filtered.forEach((g) => {
     const t1 = g.Team1.split(",").map((n) => alias[n.trim()] || n.trim());
     const t2 = g.Team2.split(",").map((n) => alias[n.trim()] || n.trim());
@@ -109,7 +111,7 @@ export function computeStats(rank, games, { alias = {}, league } = {}) {
         mvp: stats[nick]?.mvp || 0,
       };
       p.losses = p.games - p.wins;
-      p.winRate = p.games ? ((p.wins / p.games) * 100).toFixed(2) : "0";
+      p.winRate = p.games ? ((p.wins / p.games) * 100).toFixed(2) : "0.00";
       return p;
     })
     .sort((a, b) => b.points - a.points);

--- a/sunday.html
+++ b/sunday.html
@@ -304,7 +304,7 @@
               <th data-key="rank">Ранг <span class="sort-arrow"></span></th>
               <th data-key="points">Бали <span class="sort-arrow"></span></th>
               <th data-key="games">Ігор <span class="sort-arrow"></span></th>
-              <th data-key="winRate">% Win <span class="sort-arrow"></span></th>
+              <th data-key="winRate">%Win <span class="sort-arrow"></span></th>
               <th data-key="mvp">MVP <span class="sort-arrow"></span></th>
             </tr>
           </thead>


### PR DESCRIPTION
## Summary
- filter games strictly by `kids` or `olds` leagues and compute player stats from that subset
- format win rate to two decimals and remove sundaygames fallback
- unify ranking table headers with `%Win` column for both leagues

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check scripts/ranking.js`

------
https://chatgpt.com/codex/tasks/task_e_68b0c782fbbc8321ac48245fe187227a