### PR TITLE
Improve avatar cache refresh and error handling

### DIFF
--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,6 +1,6 @@
 // scripts/avatarAdmin.js
 import { log } from './logger.js';
-import { uploadAvatar, getAvatarUrl, fetchOnce, safeSet } from './api.js';
+import { uploadAvatar, getAvatarUrl, fetchOnce, safeSet, safeDel, clearFetchCache } from './api.js';
 
 const AVATAR_TTL = 6 * 60 * 60 * 1000;
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
@@ -10,14 +10,23 @@ async function fetchAvatar(nick){
   return fetchOnce(`avatar:${nick}`, AVATAR_TTL, () => getAvatarUrl(nick));
 }
 
+const avatarFailures = new Set();
+
 async function setAvatar(img, nick){
   img.dataset.nick = nick;
-  const url = await fetchAvatar(nick);
-  if(url){
-    img.src = `${url}?t=${Date.now()}`;
-  }else{
-    img.src = DEFAULT_AVATAR_URL;
+  let url;
+  for(let attempt=0; attempt<2 && !url; attempt++){
+    try{
+      url = await fetchAvatar(nick);
+      avatarFailures.delete(nick);
+    }catch(err){
+      if(!avatarFailures.has(nick)){
+        log('[ranking]', err);
+        avatarFailures.add(nick);
+      }
+    }
   }
+  img.src = url || DEFAULT_AVATAR_URL;
   img.onerror = () => {
     img.onerror = null;
     img.src = DEFAULT_AVATAR_URL;
@@ -135,7 +144,8 @@ export async function initAvatarAdmin(players = [], league = '') {
       const img = row.querySelector('img.avatar-img');
       try {
         const url = await uploadAvatar(nick, file);
-        img.src = `${url}?t=${Date.now()}`;
+        img.src = url;
+        avatarFailures.delete(nick);
         safeSet(localStorage, 'avatarRefresh', nick + ':' + Date.now());
         row.querySelector('input[type="file"]').value = '';
       } catch (err) {
@@ -165,6 +175,10 @@ function refreshAvatars(nick){
 window.addEventListener('storage', e => {
   if(e.key === 'avatarRefresh') {
     const [nick] = (e.newValue || '').split(':');
+    if(nick){
+      clearFetchCache(`avatar:${nick}`);
+      safeDel(sessionStorage, `avatar:${nick}`);
+    }
     refreshAvatars(nick);
   }
 });


### PR DESCRIPTION
## Summary
- Replace cache-busting avatar URLs with direct assignments
- Add retry and per-nick error suppression around avatar fetches
- Clear avatar caches and refresh images on storage `avatarRefresh` events

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c8d00b28832192ab1c2e38b14e84