### PR TITLE
Delegate ranking interactions via tbody

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
       </div>
       <div class="top-mvp" id="top-mvp"></div>
       <div class="table-container">
-        <table>
+        <table id="ranking">
           <thead>
             <tr>
               <th data-key="place">Місце <span class="sort-arrow"></span></th>
@@ -306,7 +306,7 @@
               <th data-key="mvp">MVP <span class="sort-arrow"></span></th>
             </tr>
           </thead>
-          <tbody id="ranking"></tbody>
+          <tbody></tbody>
         </table>
       </div>
       <button class="show-more" id="toggle">Всі гравці</button>

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -251,11 +251,11 @@ function createRow(p, i) {
   const tdNick = document.createElement("td");
   tdNick.className = cls.replace("rank-", "nick-");
   tdNick.style.cursor = "pointer";
-  tdNick.tabIndex = 0;
   tdNick.setAttribute("role", "button");
+  tdNick.setAttribute("tabindex", "0");
   tdNick.setAttribute(
     "aria-label",
-    `Показати статистику гравця ${p.nickname}`
+    `Показати статистику ${p.nickname}`
   );
   tdNick.textContent = p.nickname;
   tr.appendChild(tdNick);
@@ -443,21 +443,19 @@ async function init() {
     `Перший сезон — старт ${formatFull(minDate)}`;
   renderTopMVP(allPlayers, document.getElementById("top-mvp"));
   renderChart(allPlayers, document.getElementById("rank-chart"));
-  rankingEl = document.getElementById("ranking");
-  rankingEl.addEventListener("click", (e) => {
+  rankingEl = document.querySelector("#ranking tbody");
+  const onRankInteract = (e) => {
     const cell = e.target.closest("td");
-    if (cell && cell.className.startsWith("nick-")) {
+    if (!cell || !cell.className.startsWith("nick-")) return;
+    if (e.type === "click") {
       showQuickStats(cell.textContent, e);
-    }
-  });
-  rankingEl.addEventListener("keydown", (e) => {
-    if (e.key !== "Enter" && e.key !== " ") return;
-    const cell = e.target.closest("td");
-    if (cell && cell.className.startsWith("nick-")) {
+    } else if (e.key === "Enter") {
       e.preventDefault();
       showQuickStats(cell.textContent, e);
     }
-  });
+  };
+  rankingEl.addEventListener("click", onRankInteract);
+  rankingEl.addEventListener("keydown", onRankInteract);
   const thead = document.querySelector("thead");
   verifySortableHeaders();
   thead.addEventListener("click", (e) => {

--- a/sunday.html
+++ b/sunday.html
@@ -295,7 +295,7 @@
       </div>
       <div class="top-mvp" id="top-mvp"></div>
       <div class="table-container">
-        <table>
+        <table id="ranking">
           <thead>
             <tr>
               <th data-key="place">Місце <span class="sort-arrow"></span></th>
@@ -308,7 +308,7 @@
               <th data-key="mvp">MVP <span class="sort-arrow"></span></th>
             </tr>
           </thead>
-          <tbody id="ranking"></tbody>
+          <tbody></tbody>
         </table>
       </div>
       <button class="show-more" id="toggle">Всі гравці</button>


### PR DESCRIPTION
## Summary
- Delegate ranking nickname interactions to `#ranking tbody` for both click and keydown
- Make nickname cells accessible with button roles and descriptive labels
- Adjust HTML tables to expose `<tbody>` under `#ranking`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx eslint .` *(fails: Requires installing eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ddbea13083219cbf684cbfcc0460