### PR TITLE
Restore blc-accordion markup

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -29,7 +29,7 @@
       </div>
     </section>
 
-    <section class="bal__card bal__accordion" id="sec-player-picker">
+    <section class="bal__card blc-accordion" id="sec-player-picker">
       <h2 class="bal__acc-head">Вибір гравців</h2>
       <div class="bal__acc-body scroll-pane">
         <section id="select-area" class="card hidden">
@@ -49,7 +49,7 @@
       </div>
     </section>
 
-    <section class="bal__card bal__accordion open" id="sec-lobby">
+    <section class="bal__card blc-accordion open" id="sec-lobby">
       <h2 class="bal__acc-head">Лоббі дня</h2>
       <div class="bal__acc-body">
         <section id="lobby-area" class="card">
@@ -76,7 +76,7 @@
       </div>
     </section>
 
-    <section class="bal__card bal__accordion" id="sec-scenario">
+    <section class="bal__card blc-accordion" id="sec-scenario">
       <h2 class="bal__acc-head">Режим гри</h2>
       <div class="bal__acc-body">
         <section id="scenario-area" class="card hidden">
@@ -122,7 +122,7 @@
       </div>
     </section>
 
-    <section class="bal__card bal__accordion" id="sec-avatar-admin">
+    <section class="bal__card blc-accordion" id="sec-avatar-admin">
       <h2 class="bal__acc-head">Керування аватарами</h2>
       <section id="avatar-admin" class="card">
         <div class="bal__acc-body">

--- a/styles/balance.css
+++ b/styles/balance.css
@@ -38,7 +38,6 @@
 }
 .btn--danger:hover { background: #c62828; }
 
-.bal__accordion,
 .blc-accordion {
   border: 1px solid #2e2e2e;
   border-radius: 8px;
@@ -54,12 +53,10 @@
   padding: 10px;
 }
 
-.bal__accordion:not(.open) .bal__acc-body,
 .blc-accordion:not(.open) .bal__acc-body {
   display: none;
 }
 
-.bal__accordion.open .bal__acc-body,
 .blc-accordion.open .bal__acc-body {
   display: block;
 }
@@ -110,7 +107,6 @@
 }
 
 @media (min-width: 769px) {
-  .bal__accordion .bal__acc-body,
   .blc-accordion .bal__acc-body { display: block !important; }
 }
 


### PR DESCRIPTION
## Summary
- Replace `bal__accordion` sections with `blc-accordion` to restore legacy markup
- Simplify accordion CSS to target `.blc-accordion` selectors only

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*
- `node test-accordion.js`

------
https://chatgpt.com/codex/tasks/task_e_68b0e3800f688321949cc021ebf89eea