### PR TITLE
feat: add paginated ranking tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,10 +180,14 @@
         height: 40px;
         object-fit: cover;
       }
-      /* Show-more Button */
-      .show-more {
-        display: block;
-        margin: 1rem auto;
+      /* Pagination */
+      .pagination {
+        display: flex;
+        justify-content: center;
+        gap: 0.5rem;
+        margin: 1rem 0;
+      }
+      .pagination button {
         padding: 0.75rem 1.5rem;
         background: #222;
         color: #f39c12;
@@ -198,8 +202,11 @@
           auto;
         transition: transform 0.2s;
       }
-      .show-more:hover {
+      .pagination button:hover {
         transform: scale(1.05);
+      }
+      .page-info {
+        align-self: center;
       }
       /* Rank highlight */
       .rank-S td {
@@ -309,7 +316,12 @@
           <tbody></tbody>
         </table>
       </div>
-      <button class="show-more" id="toggle">Всі гравці</button>
+      <div class="pagination">
+        <button id="prev-page">Назад</button>
+        <span id="page-info" class="page-info"></span>
+        <button id="next-page">Вперед</button>
+        <button id="show-all">Показати всі</button>
+      </div>
     </div>
     <div id="stats-modal" class="modal hidden">
       <div class="modal-content">

--- a/scripts/script-kids.js
+++ b/scripts/script-kids.js
@@ -29,7 +29,6 @@ function loadRanking() {
                 const rankInfo = getRank(player.points);
                 const row = document.createElement("tr");
                 row.classList.add(rankInfo.class);
-                if (index >= 10) row.classList.add("hidden-players");
                 row.innerHTML = `
                     <td>${index + 1}</td>
                     <td>${rankInfo.icon} ${player.nickname}</td>
@@ -43,18 +42,6 @@ function loadRanking() {
             log('[ranking]', err);
             showToast('Помилка завантаження даних');
         });
-}
-
-function togglePlayers() {
-    const hiddenRows = document.querySelectorAll(".hidden-players");
-    const button = document.querySelector(".show-more");
-    if (hiddenRows[0].style.display === "none" || hiddenRows[0].style.display === "") {
-        hiddenRows.forEach(row => row.style.display = "table-row");
-        button.textContent = "Показати Топ-10";
-    } else {
-        hiddenRows.forEach(row => row.style.display = "none");
-        button.textContent = "Показати більше";
-    }
 }
 
 document.addEventListener("DOMContentLoaded", loadRanking);

--- a/scripts/script-sunday.js
+++ b/scripts/script-sunday.js
@@ -29,7 +29,6 @@ function loadRanking() {
                 const rankInfo = getRank(player.points);
                 const row = document.createElement("tr");
                 row.classList.add(rankInfo.class);
-                if (index >= 10) row.classList.add("hidden-players");
                 row.innerHTML = `
                     <td>${index + 1}</td>
                     <td>${rankInfo.icon} ${player.nickname}</td>
@@ -43,18 +42,6 @@ function loadRanking() {
             log('[ranking]', err);
             showToast('Помилка завантаження даних');
         });
-}
-
-function togglePlayers() {
-    const hiddenRows = document.querySelectorAll(".hidden-players");
-    const button = document.querySelector(".show-more");
-    if (hiddenRows[0].style.display === "none" || hiddenRows[0].style.display === "") {
-        hiddenRows.forEach(row => row.style.display = "table-row");
-        button.textContent = "Показати Топ-10";
-    } else {
-        hiddenRows.forEach(row => row.style.display = "none");
-        button.textContent = "Показати більше";
-    }
 }
 
 document.addEventListener("DOMContentLoaded", loadRanking);

--- a/sunday.html
+++ b/sunday.html
@@ -179,10 +179,14 @@
         height: 40px;
         object-fit: cover;
       }
-      /* Кнопка */
-      .show-more {
-        display: block;
-        margin: 1rem auto;
+      /* Пагінація */
+      .pagination {
+        display: flex;
+        justify-content: center;
+        gap: 0.5rem;
+        margin: 1rem 0;
+      }
+      .pagination button {
         padding: 0.75rem 1.5rem;
         background: #222;
         color: #f39c12;
@@ -196,8 +200,11 @@
           auto;
         transition: transform 0.2s;
       }
-      .show-more:hover {
+      .pagination button:hover {
         transform: scale(1.05);
+      }
+      .page-info {
+        align-self: center;
       }
       /* Ранги */
       .rank-S td {
@@ -311,7 +318,12 @@
           <tbody></tbody>
         </table>
       </div>
-      <button class="show-more" id="toggle">Всі гравці</button>
+      <div class="pagination">
+        <button id="prev-page">Назад</button>
+        <span id="page-info" class="page-info"></span>
+        <button id="next-page">Вперед</button>
+        <button id="show-all">Показати всі</button>
+      </div>
     </div>
     <div id="stats-modal" class="modal hidden">
       <div class="modal-content">


### PR DESCRIPTION
## Summary
- replace "show more" toggle with pagination and a show-all option on ranking pages
- remove hidden player logic from legacy scripts

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e5377b9c83219d264a3ecc2b90a7