### PR TITLE
Replace timestamp cache buster with versioned query

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -288,7 +288,8 @@ export async function fetchPlayerGames(nick, league = '') {
   let res;
   try {
     // якщо проксі віддає лист games
-    res = await fetch(`${PROXY_URL}?sheet=games&t=${Date.now()}`);
+    // Use a fixed version to control cache invalidation instead of Date.now()
+    res = await fetch(`${PROXY_URL}?sheet=games&v=1`);
     if (!res.ok) throw new Error('HTTP ' + res.status);
   } catch (err) {
     log('[ranking]', err);


### PR DESCRIPTION
## Summary
- remove `Date.now()` cache buster when fetching games
- use a fixed version query parameter instead for controlled invalidation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b14786fbf48321ab521d6063af6721