### PR TITLE
feat: guard toast calls

### DIFF
--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -49,7 +49,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (res.trim() === 'OK') {
           alert('Детальна статистика з PDF імпортована успішно');
         } else {
-          showToast('Помилка імпорту статистики: ' + res);
+          const msg = 'Помилка імпорту статистики: ' + res;
+          if (typeof showToast === 'function') showToast(msg); else alert(msg);
         }
       } catch (err) {
         log('[ranking]', err);
@@ -132,7 +133,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const res = await saveResult(data);
       if (res.status !== 'OK') {
-        showToast('Помилка збереження: ' + (res.status || res));
+        const msg = 'Помилка збереження: ' + (res.status || res);
+        if (typeof showToast === 'function') showToast(msg); else alert(msg);
         return;
       }
 
@@ -148,7 +150,8 @@ document.addEventListener('DOMContentLoaded', () => {
       btnClear.click();
     } catch (err) {
       log('[ranking]', err);
-      showToast('Не вдалося зберегти гру');
+      const msg = 'Не вдалося зберегти гру';
+      if (typeof showToast === 'function') showToast(msg); else alert(msg);
     }
   }
   btnSave.addEventListener('click', saveGame);

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -44,7 +44,8 @@ async function loadDefaultAvatars(path = 'assets/default_avatars/list.json'){
     }
   }catch(err){
     log('[ranking]', err);
-    showToast('Failed to load default avatars');
+    const msg = 'Failed to load default avatars';
+    if (typeof showToast === 'function') showToast(msg); else alert(msg);
   }
 }
 
@@ -113,7 +114,8 @@ export async function initAvatarAdmin(players = [], league = '') {
           updateSaveBtn();
         } catch (err) {
           log('[ranking]', err);
-          showToast('Failed to fetch avatar');
+          const msg = 'Failed to fetch avatar';
+          if (typeof showToast === 'function') showToast(msg); else alert(msg);
         }
       });
       thumbs.appendChild(t);
@@ -155,7 +157,8 @@ export async function initAvatarAdmin(players = [], league = '') {
     }
     updateSaveBtn();
     if (failed.length) {
-      showToast('Failed to upload avatars for: ' + failed.join(', '));
+      const msg = 'Failed to upload avatars for: ' + failed.join(', ');
+      if (typeof showToast === 'function') showToast(msg); else alert(msg);
     }
     if (statusEl) {
       statusEl.textContent = 'Аватари оновлено';

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -131,7 +131,8 @@ import { getAvatarUrl, getPdfLinks, fetchOnce, CSV_URLS, safeDel, clearFetchCach
       playersTb.innerHTML = '';
       matchesTb.innerHTML = '';
       log('[ranking]', err);
-      showToast('Failed to load gameday data. Please try again later.');
+      const msg = 'Failed to load gameday data. Please try again later.';
+      if (typeof showToast === 'function') showToast(msg); else alert(msg);
       return;
     }
     const ranking = Papa.parse(rText,{header:true,skipEmptyLines:true}).data;

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -227,11 +227,13 @@ document.addEventListener('DOMContentLoaded', () => {
           newNick.value = '';
           newAge.value = '';
         } else {
-          showToast('Не вдалося створити гравця');
+          const msg = 'Не вдалося створити гравця';
+          if (typeof showToast === 'function') showToast(msg); else alert(msg);
         }
       } catch (err) {
         log('[ranking]', err);
-        showToast('Не вдалося створити гравця');
+        const msg = 'Не вдалося створити гравця';
+        if (typeof showToast === 'function') showToast(msg); else alert(msg);
       }
     });
   }
@@ -447,11 +449,13 @@ function onLobbyAction(e) {
         player.abonement = newType;
         const full = players.find(p => p.nick === player.nick);
         if (full) full.abonement = newType;
-        showToast('Абонемент оновлено');
+        const msg = 'Абонемент оновлено';
+        if (typeof showToast === 'function') showToast(msg); else alert(msg);
       } catch (err) {
         sel.value = prevType;
         log('[ranking]', err);
-        showToast('Помилка оновлення абонемента');
+        const msg = 'Помилка оновлення абонемента';
+        if (typeof showToast === 'function') showToast(msg); else alert(msg);
       }
     })();
   }
@@ -470,7 +474,8 @@ document.addEventListener('click', async e => {
     }
   } catch (err) {
     log('[ranking]', err);
-    showToast('Не вдалося видати ключ');
+    const msg = 'Не вдалося видати ключ';
+    if (typeof showToast === 'function') showToast(msg); else alert(msg);
   }
 });
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -48,7 +48,8 @@ document.addEventListener('DOMContentLoaded', () => {
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
     } catch (err) {
       log('[ranking]', err);
-      showToast('Не вдалося завантажити гравців');
+      const msg = 'Не вдалося завантажити гравців';
+      if (typeof showToast === 'function') showToast(msg); else alert(msg);
     } finally {
       btnLoad.disabled = false;
       btnLoad.textContent = 'Завантажити гравців';

--- a/scripts/playerStats.js
+++ b/scripts/playerStats.js
@@ -33,7 +33,8 @@ function init(){
       body.appendChild(table);
     }catch(err){
       log('[ranking]', err);
-      showToast('Помилка завантаження');
+      const msg = 'Помилка завантаження';
+      if (typeof showToast === 'function') showToast(msg); else alert(msg);
       body.textContent='Помилка завантаження';
     }
   };

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -176,7 +176,8 @@ async function loadProfile(nick, key = '') {
     }
   } catch (err) {
     log('[ranking]', err);
-    showToast('Помилка завантаження профілю');
+    const msg = 'Помилка завантаження профілю';
+    if (typeof showToast === 'function') showToast(msg); else alert(msg);
     showError('Помилка завантаження профілю');
     return;
   }
@@ -212,7 +213,8 @@ async function loadProfile(nick, key = '') {
       safeSet(localStorage, 'avatarRefresh', nick + ':' + Date.now());
     } catch (err) {
       log('[ranking]', err);
-      showToast('Помилка завантаження');
+      const msg = 'Помилка завантаження';
+      if (typeof showToast === 'function') showToast(msg); else alert(msg);
     }
   });
 

--- a/scripts/quickStats.js
+++ b/scripts/quickStats.js
@@ -104,7 +104,8 @@ export async function showQuickStats(nick, evt) {
     safeSet(localStorage, key, JSON.stringify({ ts: Date.now(), data }));
   } catch (err) {
     log('[ranking]', err);
-    if (typeof showToast === 'function') showToast('Не вдалося завантажити статистику');
+    const msg = 'Не вдалося завантажити статистику';
+    if (typeof showToast === 'function') showToast(msg); else alert(msg);
     render(null);
   }
 }

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -63,7 +63,7 @@ export async function loadData(rankingURL, gamesURL) {
   } catch (err) {
     log('[ranking]', err);
     const msg = "Не вдалося завантажити дані рейтингу";
-    if (typeof showToast === 'function') showToast(msg);
+    if (typeof showToast === 'function') showToast(msg); else alert(msg);
     if (typeof document !== "undefined") {
       const div = document.createElement("div");
       div.textContent = msg;

--- a/scripts/register.js
+++ b/scripts/register.js
@@ -31,7 +31,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }catch(err){
       log('[ranking]', err);
       status.textContent = 'Помилка: '+err.message;
-      showToast('Помилка реєстрації');
+      const msg = 'Помилка реєстрації';
+      if (typeof showToast === 'function') showToast(msg); else alert(msg);
     }
   });
 });

--- a/scripts/script-kids.js
+++ b/scripts/script-kids.js
@@ -40,7 +40,8 @@ function loadRanking() {
       })
         .catch(err => {
             log('[ranking]', err);
-            showToast('Помилка завантаження даних');
+            const msg = 'Помилка завантаження даних';
+            if (typeof showToast === 'function') showToast(msg); else alert(msg);
         });
 }
 

--- a/scripts/script-sunday.js
+++ b/scripts/script-sunday.js
@@ -40,7 +40,8 @@ function loadRanking() {
         })
         .catch(err => {
             log('[ranking]', err);
-            showToast('Помилка завантаження даних');
+            const msg = 'Помилка завантаження даних';
+            if (typeof showToast === 'function') showToast(msg); else alert(msg);
         });
 }
 


### PR DESCRIPTION
## Summary
- guard toast notifications across scripts
- provide alert fallback when toast library is missing

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b159d1b6ac8321a731d03a03b78d3a