### PR TITLE
Open player picker after loading players

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -44,6 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       initLobby(players, csvLeague);          // Рендер лоббі
+      document.getElementById('sec-player-picker')?.classList.add('open');
       await initAvatarAdmin(players, selLeague.value);    // Рендер аватарів
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
     } catch (err) {


### PR DESCRIPTION
## Summary
- Automatically open the player picker section after players are loaded into the lobby

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bc9f1ff483218109ce82edb78e45