### PR TITLE
Hide lobby panel after init and reopen via burger

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -47,6 +47,8 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('sec-player-picker')?.classList.add('open');
       await initAvatarAdmin(players, selLeague.value);    // Рендер аватарів
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
+      document.getElementById('ui-panel').hidden = true;
+      document.getElementById('ui-overlay').hidden = true;
     } catch (err) {
       log('[ranking]', err);
       const msg = 'Не вдалося завантажити гравців';
@@ -63,5 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initLobby([], csvLeague);               // Порожнє лоббі
     await initAvatarAdmin([], selLeague.value);
     scenArea.classList.add('hidden');
+    document.getElementById('ui-panel').hidden = true;
+    document.getElementById('ui-overlay').hidden = true;
   });
 });


### PR DESCRIPTION
## Summary
- Hide panel and overlay once lobby and avatars load so UI stays hidden until burger is tapped
- Keep panel hidden when league changes for consistent behavior

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c06bf2f08321be896c8d53c7298f