### PR TITLE
Hide player creation controls on mobile

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -21,9 +21,9 @@
           </select>
         <div class="bal__actions">
           <button id="btn-load">Завантажити гравців</button>
-          <input type="text" id="new-nick" placeholder="Нік">
-          <input type="number" id="new-age" placeholder="Вік" min="0">
-          <button id="btn-create">Створити гравця</button>
+          <input type="text" id="new-nick" class="only-desktop" placeholder="Нік">
+          <input type="number" id="new-age" class="only-desktop" placeholder="Вік" min="0">
+          <button id="btn-create" class="only-desktop">Створити гравця</button>
           <button id="ui-clear-lobby" class="btn--danger">Очистити лоббі</button>
         </div>
       </div>

--- a/styles/balance.css
+++ b/styles/balance.css
@@ -71,9 +71,11 @@
 
 .bal__players { display: none; }
 .only-mobile { display: none; }
+.only-desktop { display: inline-block; }
 
 @media (max-width: 768px) {
   .only-mobile { display: block; }
+  .only-desktop { display: none; }
   .bal__table { display: none; }
   .bal__players { display: grid; gap: 10px; }
   .player {

--- a/styles/balance.mobile.css
+++ b/styles/balance.mobile.css
@@ -1,5 +1,5 @@
 /* Mobile specific styles for the balance page */
-@media (max-width: 600px) {
+@media (max-width: 768px) {
   .bal__row {
     flex-direction: column;
     align-items: stretch;
@@ -15,6 +15,11 @@
     box-sizing: border-box;
     font-size: 1rem;
     padding: 8px;
+  }
+
+  #btn-load,
+  #ui-clear-lobby {
+    width: 100%;
   }
 
   .bal__table th,


### PR DESCRIPTION
## Summary
- Add `only-desktop` classes to player creation inputs in `balance.html`
- Define responsive `.only-desktop` rules in `balance.css`
- Expand mobile styles so load and clear buttons stack vertically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c163ceb88321a77fc7f2bb5e295e