### PR TITLE
Refine lobby clearing button handling

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -24,7 +24,7 @@
           <input type="text" id="new-nick" class="only-desktop" placeholder="Нік">
           <input type="number" id="new-age" class="only-desktop" placeholder="Вік" min="0">
           <button id="btn-create" class="only-desktop">Створити гравця</button>
-          <button id="ui-clear-lobby" class="btn--danger">Очистити лоббі</button>
+          <button id="ui-clear-lobby" class="btn--danger only-mobile">Очистити лоббі</button>
         </div>
       </div>
     </section>
@@ -71,7 +71,6 @@
             Сума: <span id="lobby-sum">0</span> |
             Середній: <span id="lobby-avg">0</span>
           </p>
-          <button id="btn-clear-lobby-dup" class="btn--danger only-mobile">Очистити лоббі</button>
         </section>
       </div>
     </section>

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -510,7 +510,6 @@ document.addEventListener('click', async e => {
   }
 });
 
-document.getElementById('btn-clear-lobby-dup')?.addEventListener('click', clearLobby);
 
 // Mobile shell
 (() => {

--- a/styles/balance.css
+++ b/styles/balance.css
@@ -71,6 +71,7 @@
 
 .bal__players { display: none; }
 .only-mobile { display: none; }
+#ui-clear-lobby.only-mobile { display: inline-block; }
 .only-desktop { display: inline-block; }
 
 @media (max-width: 768px) {

--- a/styles/balance.mobile.css
+++ b/styles/balance.mobile.css
@@ -18,7 +18,7 @@
   }
 
   #btn-load,
-  #ui-clear-lobby {
+  #ui-clear-lobby.only-mobile {
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- remove duplicate mobile-only "clear lobby" button from balance page
- style main clear lobby button with `.only-mobile` so it's visible on desktop and adapts for mobile
- drop unused event listener for the removed button

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b1c294758c83218ee34a6b13d418ea