### PR TITLE
Keep balance panel visible after league changes

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -47,8 +47,8 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('sec-player-picker')?.classList.add('open');
       await initAvatarAdmin(players, selLeague.value);    // Рендер аватарів
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
-      document.getElementById('ui-panel').hidden = true;
-      document.getElementById('ui-overlay').hidden = true;
+      document.getElementById('ui-panel').hidden = false;
+      document.getElementById('ui-overlay').hidden = false;
     } catch (err) {
       log('[ranking]', err);
       const msg = 'Не вдалося завантажити гравців';
@@ -65,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initLobby([], csvLeague);               // Порожнє лоббі
     await initAvatarAdmin([], selLeague.value);
     scenArea.classList.add('hidden');
-    document.getElementById('ui-panel').hidden = true;
-    document.getElementById('ui-overlay').hidden = true;
+    document.getElementById('ui-panel').hidden = false;
+    document.getElementById('ui-overlay').hidden = false;
   });
 });


### PR DESCRIPTION
## Summary
- Keep control panel and overlay visible after loading players
- Reopen control panel when switching leagues

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `npm run lint` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b1c50b65648321897a628d3925efdc