### PR TITLE
Enable mobile player creation and visible lobby controls

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -21,10 +21,10 @@
           </select>
         <div class="bal__actions">
           <button id="btn-load">Завантажити гравців</button>
-          <input type="text" id="new-nick" class="only-desktop" placeholder="Нік">
-          <input type="number" id="new-age" class="only-desktop" placeholder="Вік" min="0">
-          <button id="btn-create" class="only-desktop">Створити гравця</button>
-          <button id="ui-clear-lobby" class="btn--danger only-mobile">Очистити лоббі</button>
+          <input type="text" id="new-nick" placeholder="Нік">
+          <input type="number" id="new-age" placeholder="Вік" min="0">
+          <button id="btn-create">Створити гравця</button>
+          <button id="ui-clear-lobby" class="btn--danger">Очистити лоббі</button>
         </div>
       </div>
     </section>

--- a/styles/balance.css
+++ b/styles/balance.css
@@ -71,7 +71,6 @@
 
 .bal__players { display: none; }
 .only-mobile { display: none; }
-#ui-clear-lobby.only-mobile { display: inline-block; }
 .only-desktop { display: inline-block; }
 
 @media (max-width: 768px) {

--- a/styles/balance.mobile.css
+++ b/styles/balance.mobile.css
@@ -18,7 +18,7 @@
   }
 
   #btn-load,
-  #ui-clear-lobby.only-mobile {
+  #ui-clear-lobby {
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- Expose player name/age inputs and creation button on all devices
- Remove desktop/mobile-only restrictions so lobby Clear button is always visible
- Simplify responsive CSS for mobile/desktop toggles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c5b693988321ad520662910c9fcb