### PR TITLE
Add clear lobby button in lobby area

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -71,6 +71,9 @@
             Сума: <span id="lobby-sum">0</span> |
             Середній: <span id="lobby-avg">0</span>
           </p>
+          <div class="actions">
+            <button id="btn-clear-lobby" class="btn--danger">Очистити лоббі</button>
+          </div>
         </section>
       </div>
     </section>

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -546,6 +546,10 @@ document.addEventListener('click', async e => {
     closePanel();
   });
 
+  document.getElementById('btn-clear-lobby')?.addEventListener('click', () => {
+    if (typeof clearLobby === 'function') clearLobby();
+  });
+
   const fixVh = () => {
     const vh = window.innerHeight * 0.01;
     document.documentElement.style.setProperty('--vh', `${vh}px`);

--- a/styles/balance.mobile.css
+++ b/styles/balance.mobile.css
@@ -18,7 +18,8 @@
   }
 
   #btn-load,
-  #ui-clear-lobby {
+  #ui-clear-lobby,
+  #btn-clear-lobby {
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- Add a visible "Clear lobby" button in the lobby section for quick resets
- Style the new button for mobile views and match existing actions
- Hook the button into the existing `clearLobby` logic

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c6644b908321b3b9973155ef6182