### PR TITLE
feat: refresh arena UI after player changes

### DIFF
--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -5,6 +5,7 @@ import { initTeams, teams } from './teams.js';
 import { sortByName, sortByPtsDesc } from './sortUtils.js';
 import { updateAbonement, adminCreatePlayer, issueAccessKey, getAvatarUrl, getProfile, fetchOnce, safeDel, clearFetchCache } from './api.js';
 import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js';
+import { refreshArenaTeams } from './scenario.js';
 
 export let lobby = [];
 let players = [], filtered = [], selected = [], manualCount = 0;
@@ -438,6 +439,7 @@ function onLobbyAction(e) {
     preset[teamNo].push(p);
 
     initTeams(manualCount, preset);
+    refreshArenaTeams();
     renderLobby();
     renderLobbyCards();
     renderSelect(filtered);
@@ -451,6 +453,7 @@ function onLobbyAction(e) {
     renderLobby();
     renderLobbyCards();
     renderSelect(filtered);
+    refreshArenaTeams();
     return;
   }
 

--- a/scripts/scenario.js
+++ b/scripts/scenario.js
@@ -62,6 +62,13 @@ function handleManual() {
   updateStartButton();
 }
 
+export function refreshArenaTeams() {
+  renderArenaCheckboxes();
+  updateStartButton();
+}
+
+export { renderArenaCheckboxes, updateStartButton };
+
 // Встановлюємо слухачі після завантаження DOM
 document.addEventListener('DOMContentLoaded', () => {
   scenarioArea    = document.getElementById('scenario-area');


### PR DESCRIPTION
## Summary
- export renderArenaCheckboxes and updateStartButton via new refreshArenaTeams helper
- update lobby assignment logic to refresh arena checkboxes and start button when players move

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd859e52508321b683b242aec6bd7a