### PR TITLE
Add MVP datalist inputs for arena

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -108,9 +108,19 @@
 
     <section id="arena-area" class="bal__card card hidden">
       <h2>Арена: <span id="arena-vs"></span></h2>
-      <label for="mvp">MVP:</label>
-      <select id="mvp"></select>
-      <div class="field"></div>
+      <datalist id="players-datalist"></datalist>
+      <div class="field">
+        <label for="mvp1">MVP:</label>
+        <input id="mvp1" list="players-datalist" required>
+      </div>
+      <div class="field">
+        <label for="mvp2">Срібна зірка:</label>
+        <input id="mvp2" list="players-datalist">
+      </div>
+      <div class="field">
+        <label for="mvp3">Бронзова зірка:</label>
+        <input id="mvp3" list="players-datalist">
+      </div>
       <div class="field">
         <label for="penalty">Штраф:</label>
         <input type="text" id="penalty" placeholder="нік1:-10, нік2:-5">

--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -12,7 +12,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const arenaArea   = document.getElementById('arena-area');
   const arenaVS     = document.getElementById('arena-vs');
   const arenaRounds = document.getElementById('arena-rounds');
-  const mvpSelect   = document.getElementById('mvp');
+  const mvpInputs   = [
+    document.getElementById('mvp1'),
+    document.getElementById('mvp2'),
+    document.getElementById('mvp3')
+  ];
   const penaltyInput= document.getElementById('penalty');
   const btnSave     = document.getElementById('btn-save-match');
   const btnClear    = document.getElementById('btn-clear-arena');
@@ -75,15 +79,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     arenaVS.textContent = `Команда ${a} ✕ Команда ${b}`;
     arenaRounds.innerHTML = '';
-    mvpSelect.innerHTML   = '';
+    mvpInputs.forEach(inp => inp.value = '');
     penaltyInput.value    = '';
-
-    // Заповнюємо MVP
-    [...teams[a], ...teams[b]].forEach(player => {
-      mvpSelect.insertAdjacentHTML('beforeend',
-        `<option value="${player.nick}">${player.nick}</option>`
-      );
-    });
 
     // Створюємо блоки раундів для кожної команди
     [a, b].forEach((teamId, idx) => {
@@ -120,13 +117,17 @@ document.addEventListener('DOMContentLoaded', () => {
                    : 'tie';
 
       const league = normalizeLeague(leagueSel.value);
+      const mvp = mvpInputs
+        .map(inp => inp.value.trim())
+        .filter(Boolean)
+        .join(', ');
 
       const data = {
         league,
         team1: teams[vs[0]].map(p => p.nick).join(', '),
         team2: teams[vs[1]].map(p => p.nick).join(', '),
         winner,
-        mvp: mvpSelect.value,
+        mvp,
         series,
         penalties: penaltyInput.value.trim()
       };
@@ -162,5 +163,6 @@ document.addEventListener('DOMContentLoaded', () => {
     arenaRounds.innerHTML = '';
     btnSave.disabled = true;
     document.querySelectorAll('.arena-team').forEach(cb => cb.checked = false);
+    mvpInputs.forEach(inp => inp.value = '');
   });
 });

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -16,6 +16,13 @@ const ABONEMENT_TYPES = ['none', 'lite', 'full'];
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 const AVATAR_TTL = 6 * 60 * 60 * 1000;
 
+function updatePlayersDatalist() {
+  const dl = document.getElementById('players-datalist');
+  if (dl) {
+    dl.innerHTML = lobby.map(p => `<option value="${p.nick}"></option>`).join('');
+  }
+}
+
 async function fetchAvatar(nick) {
   return fetchOnce(`avatar:${nick}`, AVATAR_TTL, () => getAvatarUrl(nick));
 }
@@ -363,6 +370,7 @@ function renderLobby() {
     setupDnD([lobbyEl, teamAEl, teamBEl].filter(Boolean));
     updateSummary();
     saveLobbyState({ lobby, teams, manualCount, league: uiLeague });
+    updatePlayersDatalist();
     return;
   }
 
@@ -393,6 +401,7 @@ function renderLobby() {
   document.getElementById('lobby-sum').textContent   = total;
   document.getElementById('lobby-avg').textContent   = lobby.length ? (total / lobby.length).toFixed(1) : '0';
 
+  updatePlayersDatalist();
   saveLobbyState({lobby, teams, manualCount, league: uiLeague});
 }
 


### PR DESCRIPTION
## Summary
- replace old MVP select with three datalist inputs and penalty field reposition
- populate a shared players datalist from the lobby
- adjust arena logic to handle multiple MVP entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eb1ea5a883219bca14adb1ee621a