### PR TITLE
Add cache-busting and file size checks for avatars

### DIFF
--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -26,10 +26,10 @@ import { rankLetterForPoints } from './rankUtils.js';
         }
       }
     }
-    img.src = url || DEFAULT_AVATAR_URL;
+    img.src = (url || DEFAULT_AVATAR_URL) + '?t=' + Date.now();
     img.onerror = () => {
       img.onerror = null;
-      img.src = DEFAULT_AVATAR_URL;
+      img.src = DEFAULT_AVATAR_URL + '?t=' + Date.now();
     };
   }
 

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -43,10 +43,10 @@ async function setAvatar(img, nick) {
       }
     }
   }
-  img.src = url || DEFAULT_AVATAR_URL;
+  img.src = (url || DEFAULT_AVATAR_URL) + '?t=' + Date.now();
   img.onerror = () => {
     img.onerror = null;
-    img.src = DEFAULT_AVATAR_URL;
+    img.src = DEFAULT_AVATAR_URL + '?t=' + Date.now();
   };
 }
 

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -33,10 +33,10 @@ async function updateAvatar(nick) {
   avatarUrl = url || DEFAULT_AVATAR_URL;
   const avatarEl = document.getElementById('avatar');
   if (avatarEl) {
-    avatarEl.src = avatarUrl;
+    avatarEl.src = avatarUrl + '?t=' + Date.now();
     avatarEl.onerror = () => {
       avatarEl.onerror = null;
-      avatarEl.src = DEFAULT_AVATAR_URL;
+      avatarEl.src = DEFAULT_AVATAR_URL + '?t=' + Date.now();
     };
   }
 }
@@ -198,10 +198,16 @@ async function loadProfile(nick, key = '') {
   fileInput.addEventListener('change', async () => {
     const file = fileInput.files[0];
     if (!file) return;
+    if (file.size > 2 * 1024 * 1024) {
+      const msg = 'Файл завеликий (max 2MB)';
+      if (typeof showToast === 'function') showToast(msg); else alert(msg);
+      fileInput.value = '';
+      return;
+    }
     try {
       const url = await uploadAvatar(nick, file);
       avatarUrl = url;
-      document.getElementById('avatar').src = url;
+      document.getElementById('avatar').src = url + '?t=' + Date.now();
       avatarFailures.delete(nick);
       safeSet(localStorage, 'avatarRefresh', nick + ':' + Date.now());
     } catch (err) {

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -28,10 +28,10 @@ async function setAvatar(img, nick) {
       }
     }
   }
-  img.src = url || DEFAULT_AVATAR_URL;
+  img.src = (url || DEFAULT_AVATAR_URL) + '?t=' + Date.now();
   img.onerror = () => {
     img.onerror = null;
-    img.src = DEFAULT_AVATAR_URL;
+    img.src = DEFAULT_AVATAR_URL + '?t=' + Date.now();
   };
 }
 


### PR DESCRIPTION
## Summary
- Bust avatar image caching by appending a timestamp query in all loaders
- Reject avatar uploads over 2MB with a toast/alert in admin and profile pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c317b583dc83219facaf76ceedd9fa