### PR TITLE
Use toast for duplicate player creation alerts

### DIFF
--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -228,7 +228,11 @@ document.addEventListener('DOMContentLoaded', () => {
       try {
         const status = await adminCreatePlayer({ league: uiLeague, nick, age });
         if (status === 'DUPLICATE') {
-          alert('Такий нік вже існує');
+          if (typeof showToast === 'function') {
+            showToast('Такий нік вже існує');
+          } else {
+            alert('Такий нік вже існує');
+          }
           return;
         }
         if (status === 'OK') {


### PR DESCRIPTION
## Summary
- Guard duplicate player creation message with `showToast` and fallback to `alert`

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c318c8344483218c85c671da899e73