### PR TITLE
Use DOM APIs to render lobby and stat views safely

### DIFF
--- a/scripts/playerStats.js
+++ b/scripts/playerStats.js
@@ -15,18 +15,36 @@ function init(){
     body.textContent = 'Loading...';
     try{
       const rows = await fetchPlayerStats(nick);
-      body.innerHTML = `<h3 style="text-align:center">${nick}</h3>`;
+      body.replaceChildren();
+      const h3 = document.createElement('h3');
+      h3.style.textAlign = 'center';
+      h3.textContent = nick;
+      body.appendChild(h3);
       if(!rows.length){
-        body.innerHTML += '<p>Статистика відсутня</p>';
+        const p = document.createElement('p');
+        p.textContent = 'Статистика відсутня';
+        body.appendChild(p);
         return;
       }
       const table = document.createElement('table');
       table.style.width='100%';
-      table.innerHTML='<thead><tr><th>Match</th><th>Kills</th><th>Deaths</th><th>Shots</th><th>Hits</th><th>Acc</th></tr></thead>';
+      const thead = document.createElement('thead');
+      const trHead = document.createElement('tr');
+      ['Match','Kills','Deaths','Shots','Hits','Acc'].forEach(text=>{
+        const th = document.createElement('th');
+        th.textContent = text;
+        trHead.appendChild(th);
+      });
+      thead.appendChild(trHead);
+      table.appendChild(thead);
       const tb = document.createElement('tbody');
       rows.forEach(r=>{
         const tr=document.createElement('tr');
-        [0,2,3,4,5,6].forEach(i=>{const td=document.createElement('td');td.textContent=r[i];tr.appendChild(td);});
+        [0,2,3,4,5,6].forEach(i=>{
+          const td=document.createElement('td');
+          td.textContent=r[i];
+          tr.appendChild(td);
+        });
         tb.appendChild(tr);
       });
       table.appendChild(tb);

--- a/scripts/quickStats.js
+++ b/scripts/quickStats.js
@@ -31,8 +31,10 @@ export async function showQuickStats(nick, evt) {
   if (existing) existing.remove();
   const el = document.createElement("div");
   el.id = "quick-stats";
-  el.innerHTML =
-    '<div class="qs-loading"><div></div><div></div><div></div></div>';
+  const loading = document.createElement('div');
+  loading.className = 'qs-loading';
+  for (let i = 0; i < 3; i++) loading.appendChild(document.createElement('div'));
+  el.appendChild(loading);
   if (window.matchMedia("(pointer:coarse)").matches) {
     el.classList.add("bottom");
   } else {
@@ -55,8 +57,11 @@ export async function showQuickStats(nick, evt) {
   document.addEventListener("keydown", onKey);
 
   const render = (data) => {
+    el.replaceChildren();
     if (!data) {
-      el.innerHTML = "<p>N/A</p>";
+      const p = document.createElement('p');
+      p.textContent = 'N/A';
+      el.appendChild(p);
       return;
     }
     const val = (v) =>
@@ -67,19 +72,33 @@ export async function showQuickStats(nick, evt) {
       val(data.wins) === "N/A" || val(data.losses) === "N/A"
         ? "N/A"
         : `${val(data.wins)}/${val(data.losses)}`;
-    el.innerHTML = `<h4>${nick}</h4>
-    <ul>
-      <li>Last on: ${val(data.lastOn)}</li>
-      <li>Matches: ${val(data.matches)}</li>
-      <li>Rounds: ${val(data.rounds)}</li>
-      <li>Wins/Losses: ${winsLosses}</li>
-      <li>K/D: ${val(data.kd)}</li>
-      <li>Accuracy: ${val(data.accuracy)}</li>
-    </ul>
-    <button id="qs-open">Profile</button>`;
-    document.getElementById("qs-open").addEventListener("click", () => {
+
+    const h4 = document.createElement('h4');
+    h4.textContent = nick;
+    el.appendChild(h4);
+
+    const ul = document.createElement('ul');
+    [
+      `Last on: ${val(data.lastOn)}`,
+      `Matches: ${val(data.matches)}`,
+      `Rounds: ${val(data.rounds)}`,
+      `Wins/Losses: ${winsLosses}`,
+      `K/D: ${val(data.kd)}`,
+      `Accuracy: ${val(data.accuracy)}`,
+    ].forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      ul.appendChild(li);
+    });
+    el.appendChild(ul);
+
+    const btn = document.createElement('button');
+    btn.id = 'qs-open';
+    btn.textContent = 'Profile';
+    btn.addEventListener('click', () => {
       window.location.href = `profile.html?nick=${encodeURIComponent(nick)}`;
     });
+    el.appendChild(btn);
   };
 
   const key = `quickStats:${nick}`;


### PR DESCRIPTION
## Summary
- Rebuild player datalist, selection lists, lobby tables, and mobile cards using `createElement`/`appendChild` and `.textContent`
- Refactor player stats modal to construct content via DOM APIs instead of string HTML
- Render quick stats popover with DOM element creation to prevent raw HTML injection

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c319f70b58832198d4d0377eaae85e