### PR TITLE
feat: cache avatar records

### DIFF
--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,23 +1,22 @@
 // scripts/avatarAdmin.js
 import { log } from './logger.js';
-import { uploadAvatar, getAvatarUrl, fetchOnce, safeSet, safeDel, clearFetchCache } from './api.js';
+import { uploadAvatar, getAvatarUrl, avatarSrcFromRecord, safeSet, safeDel, clearFetchCache } from './api.js';
 
-const AVATAR_TTL = 6 * 60 * 60 * 1000;
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 
 
 async function fetchAvatar(nick){
-  return fetchOnce(`avatar:${nick}`, AVATAR_TTL, () => getAvatarUrl(nick));
+  return getAvatarUrl(nick);
 }
 
 const avatarFailures = new Set();
 
 async function setAvatar(img, nick){
   img.dataset.nick = nick;
-  let url;
-  for(let attempt=0; attempt<2 && !url; attempt++){
+  let rec;
+  for(let attempt=0; attempt<2 && !rec; attempt++){
     try{
-      url = await fetchAvatar(nick);
+      rec = await fetchAvatar(nick);
       avatarFailures.delete(nick);
     }catch(err){
       if(!avatarFailures.has(nick)){
@@ -26,10 +25,11 @@ async function setAvatar(img, nick){
       }
     }
   }
-  img.src = (url || DEFAULT_AVATAR_URL) + '?t=' + Date.now();
+  const src = rec ? avatarSrcFromRecord(rec) : DEFAULT_AVATAR_URL;
+  img.src = src;
   img.onerror = () => {
     img.onerror = null;
-    img.src = DEFAULT_AVATAR_URL + '?t=' + Date.now();
+    img.src = DEFAULT_AVATAR_URL;
   };
 }
 


### PR DESCRIPTION
## Summary
- add WEB_APP_URL constant and JSON gasPost helper
- cache avatar records using sessionStorage and in-memory map
- update avatar loading in pages to use cached records and versioned URLs

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c321f7c9e08321a73344c9c31e6108