### PR TITLE
Unify avatar loading and caching

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -37,7 +37,7 @@
     <a href="about.html">Про клуб</a>
   </nav>
   <div class="profile" id="profile">
-    <div class="avatar-wrap"><img id="avatar" alt="avatar"></div>
+    <div class="avatar-wrap"><img id="avatar" alt="avatar" loading="lazy" width="120" height="120"></div>
     <button id="change-avatar" style="margin-top:0.5rem;">Змінити аватарку</button>
     <input type="file" id="avatar-input" accept="image/*" style="display:none;">
     <div id="rating" style="margin-top:1rem;"></div>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -84,7 +84,7 @@ const rankFromPoints = (p) => (p < 200 ? 'D' : p < 500 ? 'C' : p < 800 ? 'B' : p
 
 // ---------------------- Cached fetch ----------------------
 const _fetchCache = {};
-const avatarCache = new Map();
+export const avatarCache = new Map();
 
 export function clearFetchCache(key) {
   delete _fetchCache[key];

--- a/scripts/avatar.js
+++ b/scripts/avatar.js
@@ -1,0 +1,32 @@
+import { log } from './logger.js';
+import { getAvatarUrl, avatarSrcFromRecord } from './api.js';
+
+const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
+const avatarFailures = new Set();
+
+export async function setAvatar(img, nick, size = 40) {
+  if (!img) return '';
+  img.dataset.nick = nick;
+  img.loading = 'lazy';
+  img.width = size;
+  img.height = size;
+  let rec;
+  for (let attempt = 0; attempt < 2 && !rec; attempt++) {
+    try {
+      rec = await getAvatarUrl(nick);
+      avatarFailures.delete(nick);
+    } catch (err) {
+      if (!avatarFailures.has(nick)) {
+        log('[ranking]', err);
+        avatarFailures.add(nick);
+      }
+    }
+  }
+  const src = rec ? avatarSrcFromRecord(rec) : DEFAULT_AVATAR_URL;
+  img.src = src;
+  img.onerror = () => {
+    img.onerror = null;
+    img.src = DEFAULT_AVATAR_URL;
+  };
+  return src;
+}

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,33 +1,10 @@
 import { log } from './logger.js';
-import {
-  getAvatarUrl,
-  avatarSrcFromRecord,
-  fetchOnce,
-  CSV_URLS,
-  clearFetchCache,
-  safeDel,
-} from "./api.js";
+import { fetchOnce, CSV_URLS, avatarCache, safeDel } from "./api.js";
 import { LEAGUE } from "./constants.js";
 import { rankLetterForPoints } from './rankUtils.js';
-
-const DEFAULT_AVATAR_URL = "assets/default_avatars/av0.png";
+import { setAvatar } from './avatar.js';
 
 const CSV_TTL = 60 * 1000;
-
-async function setAvatar(img, nick) {
-  img.dataset.nick = nick;
-  try {
-    const rec = await getAvatarUrl(nick);
-    img.src = rec ? avatarSrcFromRecord(rec) : DEFAULT_AVATAR_URL;
-  } catch (err) {
-    log('[ranking]', err);
-    img.src = DEFAULT_AVATAR_URL;
-  }
-  img.onerror = () => {
-    img.onerror = null;
-    img.src = DEFAULT_AVATAR_URL;
-  };
-}
 
 function refreshAvatars(nick) {
   const sel = nick
@@ -40,7 +17,7 @@ window.addEventListener("storage", (e) => {
   if (e.key === "avatarRefresh") {
     const [nick] = (e.newValue || "").split(":");
     if (nick) {
-      clearFetchCache(`avatar:${nick}`);
+      avatarCache.delete(nick);
       safeDel(sessionStorage, `avatar:${nick}`);
     }
     refreshAvatars(nick);


### PR DESCRIPTION
## Summary
- add shared `setAvatar` utility to load avatars with lazy loading and sizing
- clear avatar cache and session storage on `storage` events
- apply lazy loading and sizing to avatar images

## Testing
- `node --check scripts/avatar.js && node --check scripts/lobby.js && node --check scripts/gameday.js && node --check scripts/ranking.js && node --check scripts/avatarAdmin.js && node --check scripts/profile.js`
- `node --check scripts/api.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c32b4691088321983734da0f0df4ae