### PR TITLE
Clear avatar cache on refresh

### DIFF
--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,6 +1,6 @@
 // scripts/avatarAdmin.js
 import { log } from './logger.js';
-import { uploadAvatar, avatarCache, safeSet, safeDel } from './api.js';
+import { uploadAvatar, clearFetchCache } from './api.js';
 import { setAvatar } from './avatar.js';
 
 let defaultAvatars = [];
@@ -133,7 +133,8 @@ export async function initAvatarAdmin(players = [], league = '') {
         const url = await uploadAvatar(nick, file);
         img.src = url + '?t=' + Date.now();
         avatarFailures.delete(nick);
-        safeSet(localStorage, 'avatarRefresh', nick + ':' + Date.now());
+        clearFetchCache(`avatar:${nick}`);
+        localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
         row.querySelector('input[type="file"]').value = '';
       } catch (err) {
         log('[ranking]', err);
@@ -163,10 +164,7 @@ function refreshAvatars(nick){
 window.addEventListener('storage', e => {
   if(e.key === 'avatarRefresh') {
     const [nick] = (e.newValue || '').split(':');
-    if(nick){
-      avatarCache.delete(nick);
-      safeDel(sessionStorage, `avatar:${nick}`);
-    }
+    if(nick) clearFetchCache(`avatar:${nick}`);
     refreshAvatars(nick);
   }
 });

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,5 +1,5 @@
 import { log } from './logger.js';
-import { getPdfLinks, fetchOnce, CSV_URLS, avatarCache, safeDel } from "./api.js";
+import { getPdfLinks, fetchOnce, CSV_URLS, clearFetchCache } from "./api.js";
 import { rankLetterForPoints } from './rankUtils.js';
 import { setAvatar } from './avatar.js';
 (function () {
@@ -36,10 +36,7 @@ import { setAvatar } from './avatar.js';
     if(e.key === 'gamedayRefresh') loadData();
     if(e.key === 'avatarRefresh') {
       const [nick] = (e.newValue || '').split(':');
-      if(nick){
-        avatarCache.delete(nick);
-        safeDel(sessionStorage, `avatar:${nick}`);
-      }
+      if(nick) clearFetchCache(`avatar:${nick}`);
       refreshAvatars(nick);
     }
   });

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -8,10 +8,10 @@ import {
   adminCreatePlayer,
   issueAccessKey,
   getProfile,
-  avatarCache,
   safeDel,
   getAvatarUrl,
   avatarSrcFromRecord,
+  clearFetchCache,
 } from './api.js';
 import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js';
 import { refreshArenaTeams } from './scenario.js';
@@ -43,10 +43,7 @@ function refreshAvatars(nick) {
 window.addEventListener('storage', e => {
   if (e.key === 'avatarRefresh') {
     const [nick] = (e.newValue || '').split(':');
-    if (nick) {
-      avatarCache.delete(nick);
-      safeDel(sessionStorage, `avatar:${nick}`);
-    }
+    if (nick) clearFetchCache(`avatar:${nick}`);
     refreshAvatars(nick);
   }
 });

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,5 +1,5 @@
 import { log } from './logger.js';
-import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, avatarCache, safeSet, safeGet, safeDel } from './api.js';
+import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, clearFetchCache, safeSet, safeGet } from './api.js';
 import { rankLetterForPoints } from './rankUtils.js';
 import { setAvatar } from './avatar.js';
 
@@ -181,7 +181,8 @@ async function loadProfile(nick, key = '') {
       const url = await uploadAvatar(nick, file);
       avatarUrl = url;
       document.getElementById('avatar').src = url + '?t=' + Date.now();
-      safeSet(localStorage, 'avatarRefresh', nick + ':' + Date.now());
+      clearFetchCache(`avatar:${nick}`);
+      localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
     } catch (err) {
       log('[ranking]', err);
       const msg = 'Помилка завантаження';
@@ -209,8 +210,7 @@ window.addEventListener('storage', e => {
   if (e.key === 'avatarRefresh') {
     const [nick] = (e.newValue || '').split(':');
     if (nick) {
-      avatarCache.delete(nick);
-      safeDel(sessionStorage, `avatar:${nick}`);
+      clearFetchCache(`avatar:${nick}`);
       if (nick === currentNick) updateAvatar(nick);
     }
   }

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,5 +1,5 @@
 import { log } from './logger.js';
-import { fetchOnce, CSV_URLS, avatarCache, safeDel } from "./api.js";
+import { fetchOnce, CSV_URLS, clearFetchCache } from "./api.js";
 import { LEAGUE } from "./constants.js";
 import { rankLetterForPoints } from './rankUtils.js';
 import { setAvatar } from './avatar.js';
@@ -16,10 +16,7 @@ function refreshAvatars(nick) {
 window.addEventListener("storage", (e) => {
   if (e.key === "avatarRefresh") {
     const [nick] = (e.newValue || "").split(":");
-    if (nick) {
-      avatarCache.delete(nick);
-      safeDel(sessionStorage, `avatar:${nick}`);
-    }
+    if (nick) clearFetchCache(`avatar:${nick}`);
     refreshAvatars(nick);
   }
 });


### PR DESCRIPTION
## Summary
- clear cached avatars after uploads and notify other tabs
- unify storage listeners to drop avatarCache via clearFetchCache

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3326c3bb48321943937c1865252e4