### PR TITLE
Refresh avatars by data-nick attribute

### DIFF
--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,7 +1,9 @@
 // scripts/avatarAdmin.js
 import { log } from './logger.js';
-import { uploadAvatar, clearFetchCache } from './api.js';
+import { uploadAvatar, clearFetchCache, getAvatarUrl, avatarSrcFromRecord } from './api.js';
 import { setAvatar } from './avatar.js';
+
+const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 
 let defaultAvatars = [];
 async function loadDefaultAvatars(path = 'assets/default_avatars/list.json'){
@@ -45,6 +47,7 @@ export async function initAvatarAdmin(players = [], league = '') {
     const img = document.createElement('img');
     img.className = 'avatar-img';
     img.alt = p.nick;
+    img.dataset.nick = p.nick;
     setAvatar(img, p.nick);
     imgTd.appendChild(img);
 
@@ -154,11 +157,17 @@ export async function initAvatarAdmin(players = [], league = '') {
   };
 }
 
-function refreshAvatars(nick){
-  const sel = nick ? `#avatar-list img.avatar-img[data-nick="${nick}"]` : '#avatar-list img.avatar-img[data-nick]';
-  document.querySelectorAll(sel).forEach(img => {
-    setAvatar(img, img.dataset.nick);
-  });
+async function refreshAvatars(nick){
+  const sel = nick ? `#avatar-list img[data-nick="${nick}"]` : '#avatar-list img[data-nick]';
+  const imgs = document.querySelectorAll(sel);
+  for(const img of imgs){
+    try{
+      const rec = await getAvatarUrl(img.dataset.nick);
+      img.src = rec ? avatarSrcFromRecord(rec) : DEFAULT_AVATAR_URL;
+    }catch{
+      img.src = DEFAULT_AVATAR_URL;
+    }
+  }
 }
 
 window.addEventListener('storage', e => {

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,13 +1,22 @@
 import { log } from './logger.js';
-import { getPdfLinks, fetchOnce, CSV_URLS, clearFetchCache } from "./api.js";
+import { getPdfLinks, fetchOnce, CSV_URLS, clearFetchCache, getAvatarUrl, avatarSrcFromRecord } from "./api.js";
 import { rankLetterForPoints } from './rankUtils.js';
 import { setAvatar } from './avatar.js';
+const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 (function () {
   const CSV_TTL = 60 * 1000;
 
-  function refreshAvatars(nick){
-    const sel = nick ? `img.avatar-img[data-nick="${nick}"]` : 'img.avatar-img[data-nick]';
-    document.querySelectorAll(sel).forEach(img=>setAvatar(img, img.dataset.nick));
+  async function refreshAvatars(nick){
+    const sel = nick ? `img[data-nick="${nick}"]` : 'img[data-nick]';
+    const imgs = document.querySelectorAll(sel);
+    for(const img of imgs){
+      try{
+        const rec = await getAvatarUrl(img.dataset.nick);
+        img.src = rec ? avatarSrcFromRecord(rec) : DEFAULT_AVATAR_URL;
+      }catch{
+        img.src = DEFAULT_AVATAR_URL;
+      }
+    }
   }
 
 
@@ -236,6 +245,7 @@ import { setAvatar } from './avatar.js';
       const img=document.createElement('img');
       img.className='avatar-img';
       img.alt=p.nick;
+      img.dataset.nick = p.nick;
       setAvatar(img,p.nick);
       tdAvatar.appendChild(img);
 

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -17,6 +17,8 @@ import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js';
 import { refreshArenaTeams } from './scenario.js';
 import { setAvatar } from './avatar.js';
 
+const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
+
 export let lobby = [];
 let players = [], filtered = [], selected = [], manualCount = 0;
 const ABONEMENT_TYPES = ['none', 'lite', 'full'];
@@ -35,9 +37,17 @@ function updatePlayersDatalist() {
   }
 }
 
-function refreshAvatars(nick) {
-  const sel = nick ? `img.avatar-img[data-nick="${nick}"]` : 'img.avatar-img[data-nick]';
-  document.querySelectorAll(sel).forEach(img => setAvatar(img, img.dataset.nick));
+async function refreshAvatars(nick) {
+  const sel = nick ? `img[data-nick="${nick}"]` : 'img[data-nick]';
+  const imgs = document.querySelectorAll(sel);
+  for (const img of imgs) {
+    try {
+      const rec = await getAvatarUrl(img.dataset.nick);
+      img.src = rec ? avatarSrcFromRecord(rec) : DEFAULT_AVATAR_URL;
+    } catch {
+      img.src = DEFAULT_AVATAR_URL;
+    }
+  }
 }
 
 window.addEventListener('storage', e => {
@@ -296,6 +306,7 @@ function renderPlayerList(el, arr) {
     img.loading = 'lazy';
     img.width = 40;
     img.height = 40;
+    img.dataset.nick = p.nick;
     setAvatar(img, p.nick, 40);
 
     const meta = document.createElement('div');


### PR DESCRIPTION
## Summary
- Ensure avatar `<img>` tags in ranking, gameday, lobby, and avatar admin carry `data-nick`
- On storage events, locate matching `img[data-nick]` and refresh `src` using `getAvatarUrl`/`avatarSrcFromRecord`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3358613088321aa5f53b5bb1f898d