### PR TITLE
Use download export for Drive files

### DIFF
--- a/gas/doPost.gs
+++ b/gas/doPost.gs
@@ -539,7 +539,7 @@ function getFolderByPropKey_(key) {
   return id ? DriveApp.getFolderById(id) : null;
 }
 function publicFileUrl_(fileId) {
-  return 'https://drive.google.com/uc?export=view&id=' + fileId;
+  return 'https://drive.google.com/uc?export=download&id=' + fileId;
 }
 function makeKey_(len) {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';


### PR DESCRIPTION
## Summary
- ensure publicFileUrl_ generates Google Drive download links instead of view links

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c34178af4883218ea8b9b650d9ddf1