### PR TITLE
Add default avatar URL and timestamp cache buster

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,6 +1,8 @@
 // scripts/api.js
 import { log } from './logger.js';
 
+const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
+
 // ---------------------- Safe storage helpers ----------------------
 export function safeGet(storage, key) {
   if (!storage) return null;
@@ -409,9 +411,8 @@ export async function getPdfLinks(params) {
 }
 
 export function avatarSrcFromRecord(rec) {
-  if (!rec || !rec.url) return '';
-  const v = rec.updatedAt ? Number(rec.updatedAt) : Date.now();
-  return `${rec.url}?v=${v}`;
+  const url = rec && rec.url ? rec.url : DEFAULT_AVATAR_URL;
+  return url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
 }
 
 export function toBase64NoPrefix(file) {


### PR DESCRIPTION
## Summary
- define DEFAULT_AVATAR_URL in API module
- append timestamp cache buster and default fallback in avatarSrcFromRecord

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c342f552b083219c7c8d8cf0047022