### PR TITLE
Implement avatar cache-busting and fallback

### DIFF
--- a/scripts/avatar.js
+++ b/scripts/avatar.js
@@ -1,5 +1,5 @@
 import { log } from './logger.js';
-import { getAvatarUrl, avatarSrcFromRecord } from './api.js';
+import { getAvatarUrl } from './api.js';
 
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 const avatarFailures = new Set();
@@ -22,11 +22,9 @@ export async function setAvatar(img, nick, size = 40) {
       }
     }
   }
-  const src = rec ? avatarSrcFromRecord(rec) : DEFAULT_AVATAR_URL;
+  const url = rec && rec.url ? rec.url : DEFAULT_AVATAR_URL;
+  img.onerror = () => { img.onerror = null; img.src = DEFAULT_AVATAR_URL; };
+  const src = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
   img.src = src;
-  img.onerror = () => {
-    img.onerror = null;
-    img.src = DEFAULT_AVATAR_URL;
-  };
   return src;
 }


### PR DESCRIPTION
## Summary
- Remove avatarSrcFromRecord usage and import
- Add cache-busting query parameter and fallback to default avatar

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f385af188321b6ddcf968f0bbc76