### PR TITLE
chore: improve avatar refresh

### DIFF
--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,5 +1,5 @@
 import { log } from './logger.js';
-import { fetchOnce, CSV_URLS, clearFetchCache, getAvatarUrl, avatarSrcFromRecord } from "./api.js";
+import { fetchOnce, CSV_URLS, clearFetchCache, getAvatarUrl } from "./api.js";
 import { LEAGUE } from "./constants.js";
 import { rankLetterForPoints } from './rankUtils.js';
 import { setAvatar } from './avatar.js';
@@ -14,8 +14,11 @@ async function refreshAvatars(nick) {
   for (const img of imgs) {
     try {
       const rec = await getAvatarUrl(img.dataset.nick);
-      img.src = rec ? avatarSrcFromRecord(rec) : DEFAULT_AVATAR_URL;
+      const url = rec && rec.url ? rec.url : DEFAULT_AVATAR_URL;
+      img.onerror = () => { img.onerror = null; img.src = DEFAULT_AVATAR_URL; };
+      img.src = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
     } catch {
+      img.onerror = null;
       img.src = DEFAULT_AVATAR_URL;
     }
   }


### PR DESCRIPTION
## Summary
- remove unused avatarSrcFromRecord import
- refresh avatars with cache-busting url and fallback

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f4b06c688321956ff32ea50c2bb2