### PR TITLE
Refresh lobby avatars using direct URL

### DIFF
--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -10,7 +10,6 @@ import {
   getProfile,
   safeDel,
   getAvatarUrl,
-  avatarSrcFromRecord,
   clearFetchCache,
 } from './api.js';
 import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js';
@@ -43,8 +42,11 @@ async function refreshAvatars(nick) {
   for (const img of imgs) {
     try {
       const rec = await getAvatarUrl(img.dataset.nick);
-      img.src = rec ? avatarSrcFromRecord(rec) : DEFAULT_AVATAR_URL;
+      const url = rec && rec.url ? rec.url : DEFAULT_AVATAR_URL;
+      img.onerror = () => { img.onerror = null; img.src = DEFAULT_AVATAR_URL; };
+      img.src = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
     } catch {
+      img.onerror = null;
       img.src = DEFAULT_AVATAR_URL;
     }
   }
@@ -85,7 +87,6 @@ async function addPlayer(nick){
     return;
   }
   lobby.push({ ...res, team: null });
-  getAvatarUrl(nick).then(rec => avatarSrcFromRecord(rec)).catch(() => {});
   renderLobby();
   renderLobbyCards();
   renderSelect(filtered);


### PR DESCRIPTION
## Summary
- Drop unused avatarSrcFromRecord import in lobby
- Load avatars via direct URLs and bust cache
- Avoid unnecessary avatar prefetch when adding players

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx eslint scripts/lobby.js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f695aaec83218fe36c13b6dfc087