### PR TITLE
refactor: streamline gameday avatar refresh

### DIFF
--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,19 +1,22 @@
 import { log } from './logger.js';
-import { getPdfLinks, fetchOnce, CSV_URLS, clearFetchCache, getAvatarUrl, avatarSrcFromRecord } from "./api.js";
+import { getPdfLinks, fetchOnce, CSV_URLS, clearFetchCache, getAvatarUrl } from "./api.js";
 import { rankLetterForPoints } from './rankUtils.js';
 import { setAvatar } from './avatar.js';
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 (function () {
   const CSV_TTL = 60 * 1000;
 
-  async function refreshAvatars(nick){
+  async function refreshAvatars(nick) {
     const sel = nick ? `img[data-nick="${nick}"]` : 'img[data-nick]';
     const imgs = document.querySelectorAll(sel);
-    for(const img of imgs){
-      try{
+    for (const img of imgs) {
+      try {
         const rec = await getAvatarUrl(img.dataset.nick);
-        img.src = rec ? avatarSrcFromRecord(rec) : DEFAULT_AVATAR_URL;
-      }catch{
+        const url = rec && rec.url ? rec.url : DEFAULT_AVATAR_URL;
+        img.onerror = () => { img.onerror = null; img.src = DEFAULT_AVATAR_URL; };
+        img.src = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
+      } catch {
+        img.onerror = null;
         img.src = DEFAULT_AVATAR_URL;
       }
     }


### PR DESCRIPTION
## Summary
- load avatar images in gameday view using latest refresh snippet
- drop unused `avatarSrcFromRecord` import

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/laser-tag-ranking/package.json')*
- `npm run lint` *(fails: ENOENT: no such file or directory, open '/workspace/laser-tag-ranking/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c3f97bad3483218f2771c05138ba03