### PR TITLE
Track avatar upload failures

### DIFF
--- a/scripts/avatar.js
+++ b/scripts/avatar.js
@@ -1,9 +1,7 @@
-import { log } from './logger.js';
 import { getAvatarUrl } from './api.js';
+import { noteAvatarFailure } from './avatarAdmin.js';
 
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
-const avatarFailures = new Set();
-
 export async function setAvatar(img, nick, size = 40) {
   if (!img) return '';
   img.dataset.nick = nick;
@@ -14,12 +12,8 @@ export async function setAvatar(img, nick, size = 40) {
   for (let attempt = 0; attempt < 2 && !rec; attempt++) {
     try {
       rec = await getAvatarUrl(nick);
-      avatarFailures.delete(nick);
     } catch (err) {
-      if (!avatarFailures.has(nick)) {
-        log('[ranking]', err);
-        avatarFailures.add(nick);
-      }
+      noteAvatarFailure(nick, err);
     }
   }
   const url = rec && rec.url ? rec.url : DEFAULT_AVATAR_URL;

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -5,6 +5,15 @@ import { setAvatar } from './avatar.js';
 
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 
+export let avatarFailures = 0;
+
+export function noteAvatarFailure(nick, reason) {
+  avatarFailures++;
+  const msg = `Avatar issue for ${nick}: ${reason}`;
+  console.warn(msg);
+  if (typeof showToast === 'function') showToast(msg);
+}
+
 let defaultAvatars = [];
 async function loadDefaultAvatars(path = 'assets/default_avatars/list.json'){
   if(defaultAvatars.length) return;
@@ -139,13 +148,13 @@ export async function initAvatarAdmin(players = [], league = '') {
         img.onerror = () => { img.onerror = null; img.src = DEFAULT_AVATAR_URL; };
         const src = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
         img.src = src;
-        avatarFailures.delete(nick);
         clearFetchCache(`avatar:${nick}`);
         localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
         row.querySelector('input[type="file"]').value = '';
       } catch (err) {
         log('[ranking]', err);
         failed.push(nick);
+        noteAvatarFailure(nick, err?.message || err);
       }
     }
     updateSaveBtn();


### PR DESCRIPTION
## Summary
- track avatar issues with a central counter and helper
- report avatar upload errors using the new helper
- simplify avatar fetching by noting failures instead of set bookkeeping

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check scripts/avatarAdmin.js`
- `node --check scripts/avatar.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4215870508321961ee133585bd0fc