### PR TITLE
feat: guard session storage

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -94,7 +94,7 @@ export const avatarCache = new Map();
 
 export function clearFetchCache(key) {
   delete _fetchCache[key];
-  safeDel(sessionStorage, key);
+  safeDel(window.__SESS, key);
   if (key.startsWith('avatar:')) avatarCache.delete(key.slice(7));
 }
 
@@ -103,7 +103,7 @@ export async function fetchOnce(url, ttlMs = 0, fetchFn) {
   const cached = _fetchCache[url];
   if (cached && now - cached.time < ttlMs) return cached.data;
 
-  const raw = safeGet(sessionStorage, url);
+  const raw = safeGet(window.__SESS, url);
   if (raw) {
     try {
       const obj = JSON.parse(raw);
@@ -120,7 +120,7 @@ export async function fetchOnce(url, ttlMs = 0, fetchFn) {
 
   const info = { data, time: now };
   _fetchCache[url] = info;
-  safeSet(sessionStorage, url, JSON.stringify(info));
+  safeSet(window.__SESS, url, JSON.stringify(info));
   return data;
 }
 
@@ -398,13 +398,13 @@ export async function getAvatarUrl(nick) {
   const key = `avatar:${nick}`;
   let rec = avatarCache.get(nick);
   if (!rec) {
-    const raw = safeGet(sessionStorage, key);
+    const raw = safeGet(window.__SESS, key);
     if (raw) {
       try {
         rec = JSON.parse(raw);
         avatarCache.set(nick, rec);
       } catch (err) {
-        safeDel(sessionStorage, key);
+        safeDel(window.__SESS, key);
       }
     }
   }
@@ -414,7 +414,7 @@ export async function getAvatarUrl(nick) {
   if (resp && resp.status && resp.status !== 'OK') throw new Error(resp.status);
   rec = { url: resp.url || null, updatedAt: resp.updatedAt || Date.now() };
   avatarCache.set(nick, rec);
-  safeSet(sessionStorage, key, JSON.stringify(rec));
+    safeSet(window.__SESS, key, JSON.stringify(rec));
   return rec;
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -8,6 +8,20 @@ import { initAvatarAdmin } from './avatarAdmin.js';
 
 const CACHE_VERSION = window.CACHE_VERSION || '1';
 
+function safeSessionStorage() {
+  try {
+    if (!('sessionStorage' in window)) return null;
+    const test = '__test__';
+    window.sessionStorage.setItem(test, '1');
+    window.sessionStorage.removeItem(test);
+    return window.sessionStorage;
+  } catch (err) {
+    return null;
+  }
+}
+
+window.__SESS = window.__SESS || safeSessionStorage();
+
 document.addEventListener('DOMContentLoaded', () => {
   const btnLoad   = document.getElementById('btn-load');
   const selLeague = document.getElementById('league');
@@ -30,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const cacheKey = csvLeague + CACHE_VERSION;
 
       let players;
-      const cached = safeGet(sessionStorage, cacheKey);
+      const cached = safeGet(window.__SESS, cacheKey);
       if (cached) {
         try {
           players = JSON.parse(cached);
@@ -40,7 +54,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       if (!players) {
         players = await loadPlayers(csvLeague);
-        safeSet(sessionStorage, cacheKey, JSON.stringify(players));
+        safeSet(window.__SESS, cacheKey, JSON.stringify(players));
       }
 
       initLobby(players, csvLeague);          // Рендер лоббі


### PR DESCRIPTION
## Summary
- add safeSessionStorage utility and expose via `window.__SESS`
- switch sessionStorage usage to rely on `window.__SESS`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4241b46dc8321be08b2cc5d1a5764