### PR TITLE
feat: refresh avatars post upload

### DIFF
--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,7 +1,8 @@
 // scripts/avatarAdmin.js
 import { log } from './logger.js';
-import { uploadAvatar, clearFetchCache, getAvatarUrl } from './api.js';
+import { uploadAvatar } from './api.js';
 import { setAvatar } from './avatar.js';
+import { renderAllAvatars } from './avatars.readonly.js';
 
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 
@@ -175,7 +176,7 @@ export async function initAvatarAdmin(players = [], league = '') {
       try {
         const url = await uploadAvatar(nick, file);
         applyAvatarToUI(nick, url);
-        clearFetchCache(`avatar:${nick}`);
+        renderAllAvatars({ bust: Date.now() });
         localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
         row.querySelector('input[type="file"]').value = '';
       } catch (err) {
@@ -197,25 +198,8 @@ export async function initAvatarAdmin(players = [], league = '') {
   };
 }
 
-async function refreshAvatars(nick){
-  const sel = nick ? `#avatar-list img[data-nick="${nick}"]` : '#avatar-list img[data-nick]';
-  const imgs = document.querySelectorAll(sel);
-  for (const img of imgs) {
-    let url = DEFAULT_AVATAR_URL;
-    try {
-      const rec = await getAvatarUrl(img.dataset.nick);
-      if (rec && rec.url) url = rec.url;
-    } catch {
-      // ignore and use default
-    }
-    setImgSafe(img, url);
-  }
-}
-
 window.addEventListener('storage', e => {
   if(e.key === 'avatarRefresh') {
-    const [nick] = (e.newValue || '').split(':');
-    if(nick) clearFetchCache(`avatar:${nick}`);
-    refreshAvatars(nick);
+    renderAllAvatars({ bust: Date.now() });
   }
 });


### PR DESCRIPTION
## Summary
- import renderAllAvatars and remove backend refetch logic
- refresh all avatars after successful uploads and storage events

## Testing
- `npm test` (fails: Could not read package.json)
- `npm run lint` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c7d343a34883219625242cf2ec91f0