### PR TITLE
Render avatars dynamically

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -175,6 +175,16 @@
   <script type="module" src="scripts/arena.js"></script>
   <script type="module" src="scripts/avatarAdmin.js"></script>
   <script type="module" src="scripts/main.js"></script>
+  <script type="module">
+    import { renderAllAvatars } from "./scripts/avatars.readonly.js";
+
+    document.addEventListener("DOMContentLoaded", () => {
+      const rerender = () => renderAllAvatars();
+      rerender();
+      const observer = new MutationObserver(rerender);
+      observer.observe(document.body, { childList: true, subtree: true });
+    });
+  </script>
 </body>
 </html>
 

--- a/gameday.html
+++ b/gameday.html
@@ -165,5 +165,15 @@
     </div>
   </div>
   <script type="module" src="scripts/gameday.js"></script>
+  <script type="module">
+    import { renderAllAvatars } from "./scripts/avatars.readonly.js";
+
+    document.addEventListener("DOMContentLoaded", () => {
+      const rerender = () => renderAllAvatars();
+      rerender();
+      const observer = new MutationObserver(rerender);
+      observer.observe(document.body, { childList: true, subtree: true });
+    });
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -351,5 +351,15 @@
     <script type="module" src="scripts/api.js"></script>
     <script type="module" src="scripts/quickStats.js"></script>
     <script type="module" src="scripts/ranking.js"></script>
+    <script type="module">
+      import { renderAllAvatars } from "./scripts/avatars.readonly.js";
+
+      document.addEventListener("DOMContentLoaded", () => {
+        const rerender = () => renderAllAvatars();
+        rerender();
+        const observer = new MutationObserver(rerender);
+        observer.observe(document.body, { childList: true, subtree: true });
+      });
+    </script>
   </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -51,5 +51,15 @@
   </div>
   <script src="scripts/toast.js"></script>
   <script type="module" src="scripts/profile.js"></script>
+  <script type="module">
+    import { renderAllAvatars } from "./scripts/avatars.readonly.js";
+
+    document.addEventListener("DOMContentLoaded", () => {
+      const rerender = () => renderAllAvatars();
+      rerender();
+      const observer = new MutationObserver(rerender);
+      observer.observe(document.body, { childList: true, subtree: true });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- import `renderAllAvatars` on main pages and render on DOM ready
- re-render avatars whenever player lists change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d88d34788321893b5abd889e49f6