### PR TITLE
Return full avatar upload response

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -234,10 +234,13 @@ export async function uploadAvatar(nick, file) {
   } catch {
     resp = { status: 'ERR', raw: text };
   }
-  if (resp && typeof resp === 'object' && resp.status && resp.status !== 'OK') {
+  if (!resp || typeof resp !== 'object') {
+    resp = { status: 'ERR', raw: text };
+  }
+  if (resp.status && resp.status !== 'OK') {
     throw new Error(resp.status);
   }
-  return resp && resp.url ? resp.url : null;
+  return resp;
 }
 
 // ---------------------- Реєстрація/статистика ----------------------

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -174,10 +174,11 @@ export async function initAvatarAdmin(players = [], league = '') {
       }
       const nick = row.dataset.nick;
       try {
-        const url = await uploadAvatar(nick, file);
-        applyAvatarToUI(nick, url);
-        renderAllAvatars({ bust: Date.now() });
-        localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
+        const resp = await uploadAvatar(nick, file);
+        if (resp.status !== 'OK') throw new Error(resp.status);
+        applyAvatarToUI(nick, resp.url);
+        renderAllAvatars({ bust: resp.updatedAt });
+        localStorage.setItem('avatarRefresh', nick + ':' + resp.updatedAt);
         row.querySelector('input[type="file"]').value = '';
       } catch (err) {
         log('[ranking]', err);

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -179,10 +179,17 @@ async function loadProfile(nick, key = '') {
       return;
     }
     try {
-      await uploadAvatar(nick, file);
+      const resp = await uploadAvatar(nick, file);
+      if (resp.status !== 'OK') throw new Error(resp.status);
       clearFetchCache(`avatar:${nick}`);
-      localStorage.setItem('avatarRefresh', nick + ':' + Date.now());
-      await renderAllAvatars({ bust: Date.now() });
+      localStorage.setItem('avatarRefresh', nick + ':' + resp.updatedAt);
+      const avatarEl = document.getElementById('avatar');
+      if (avatarEl && resp.url) {
+        const bust = resp.updatedAt;
+        const src = resp.url + (resp.url.includes('?') ? '&' : '?') + 't=' + bust;
+        avatarEl.src = src;
+      }
+      await renderAllAvatars({ bust: resp.updatedAt });
     } catch (err) {
       log('[ranking]', err);
       const msg = 'Помилка завантаження';


### PR DESCRIPTION
## Summary
- Update `uploadAvatar` to return parsed response object
- Verify upload status and apply `url` and `updatedAt` in avatar admin
- Handle avatar upload response in profile page and bust caches with `updatedAt`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7dc47cc348321a280efbf9901a5d7