### PR TITLE
fix: update avatar placeholder

### DIFF
--- a/scripts/avatars.readonly.js
+++ b/scripts/avatars.readonly.js
@@ -1,5 +1,5 @@
 export const AVATARS_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=0&single=true&output=csv';
-const AVATAR_PLACEHOLDER = '/assets/avatars/default.png';
+const AVATAR_PLACEHOLDER = '/assets/default_avatars/av0.png';
 
 let mapPromise;
 

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,2 +1,2 @@
 export const AVATARS_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=0&single=true&output=csv';
-export const AVATAR_PLACEHOLDER = '/assets/avatars/default.png';
+export const AVATAR_PLACEHOLDER = '/assets/default_avatars/av0.png';


### PR DESCRIPTION
## Summary
- point avatar placeholder to an existing default avatar image

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/laser-tag-ranking/package.json')*
- `npm run lint` *(fails: ENOENT: no such file or directory, open '/workspace/laser-tag-ranking/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c7f97112488321890b733d8b2987ce