### PR TITLE
feat: use client-side avatar renderer

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -176,14 +176,8 @@
   <script type="module" src="scripts/avatarAdmin.js"></script>
   <script type="module" src="scripts/main.js"></script>
   <script type="module">
-    import { renderAllAvatars } from "./scripts/avatars.readonly.js";
-
-    document.addEventListener("DOMContentLoaded", () => {
-      const rerender = () => renderAllAvatars();
-      rerender();
-      const observer = new MutationObserver(rerender);
-      observer.observe(document.body, { childList: true, subtree: true });
-    });
+    import { renderAllAvatars } from './scripts/avatars.client.js';
+    document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
   </script>
 </body>
 </html>

--- a/gameday.html
+++ b/gameday.html
@@ -166,14 +166,8 @@
   </div>
   <script type="module" src="scripts/gameday.js"></script>
   <script type="module">
-    import { renderAllAvatars } from "./scripts/avatars.readonly.js";
-
-    document.addEventListener("DOMContentLoaded", () => {
-      const rerender = () => renderAllAvatars();
-      rerender();
-      const observer = new MutationObserver(rerender);
-      observer.observe(document.body, { childList: true, subtree: true });
-    });
+    import { renderAllAvatars } from './scripts/avatars.client.js';
+    document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -352,14 +352,8 @@
     <script type="module" src="scripts/quickStats.js"></script>
     <script type="module" src="scripts/ranking.js"></script>
     <script type="module">
-      import { renderAllAvatars } from "./scripts/avatars.readonly.js";
-
-      document.addEventListener("DOMContentLoaded", () => {
-        const rerender = () => renderAllAvatars();
-        rerender();
-        const observer = new MutationObserver(rerender);
-        observer.observe(document.body, { childList: true, subtree: true });
-      });
+      import { renderAllAvatars } from './scripts/avatars.client.js';
+      document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
     </script>
   </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -37,7 +37,7 @@
     <a href="about.html">Про клуб</a>
   </nav>
   <div class="profile" id="profile">
-    <div class="avatar-wrap"><img id="avatar" data-nick="" alt="avatar" loading="lazy" width="120" height="120"></div>
+    <div class="avatar-wrap"><img id="avatar" data-nick="" alt="" loading="lazy" width="120" height="120"></div>
     <button id="change-avatar" style="margin-top:0.5rem;">Змінити аватарку</button>
     <input type="file" id="avatar-input" accept="image/*" style="display:none;">
     <div id="rating" style="margin-top:1rem;"></div>
@@ -52,14 +52,8 @@
   <script src="scripts/toast.js"></script>
   <script type="module" src="scripts/profile.js"></script>
   <script type="module">
-    import { renderAllAvatars } from "./scripts/avatars.readonly.js";
-
-    document.addEventListener("DOMContentLoaded", () => {
-      const rerender = () => renderAllAvatars();
-      rerender();
-      const observer = new MutationObserver(rerender);
-      observer.observe(document.body, { childList: true, subtree: true });
-    });
+    import { renderAllAvatars } from './scripts/avatars.client.js';
+    document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
   </script>
 </body>
 </html>

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -2,7 +2,7 @@
 import { log } from './logger.js';
 import { uploadAvatar } from './api.js';
 import { setAvatar } from './avatar.js';
-import { renderAllAvatars } from './avatars.readonly.js';
+import { renderAllAvatars } from './avatars.client.js';
 
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 

--- a/scripts/avatars.client.js
+++ b/scripts/avatars.client.js
@@ -1,0 +1,12 @@
+import { setAvatar } from './avatar.js';
+
+export async function renderAllAvatars() {
+  const imgs = document.querySelectorAll('img[data-nick]');
+  const tasks = Array.from(imgs).map(img => {
+    const nick = img.dataset.nick || '';
+    if (!img.alt) img.alt = nick || 'avatar';
+    return setAvatar(img, nick, img.width || 40);
+  });
+  await Promise.all(tasks);
+}
+

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,7 +1,7 @@
 import { log } from './logger.js';
 import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, clearFetchCache, safeSet, safeGet } from './api.js';
 import { rankLetterForPoints } from './rankUtils.js';
-import { renderAllAvatars } from './avatars.readonly.js';
+import { renderAllAvatars } from './avatars.client.js';
 
 let gameLimit = 0;
 let gamesLeftEl = null;


### PR DESCRIPTION
## Summary
- replace MutationObserver-based avatar rendering with direct call to `renderAllAvatars`
- add new `avatars.client.js` module using API-driven avatar loading
- ensure avatar images carry `data-nick` and alt text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c80bee809883219b6827f90b97515a