### PR TITLE
Use reloadAvatars after avatar upload

### DIFF
--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,7 +1,7 @@
 import { log } from './logger.js';
 import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, clearFetchCache, safeSet, safeGet } from './api.js';
 import { rankLetterForPoints } from './rankUtils.js';
-import { renderAllAvatars } from './avatars.client.js';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
 
 let gameLimit = 0;
 let gamesLeftEl = null;
@@ -189,7 +189,7 @@ async function loadProfile(nick, key = '') {
         const src = resp.url + (resp.url.includes('?') ? '&' : '?') + 't=' + bust;
         avatarEl.src = src;
       }
-      await renderAllAvatars({ bust: resp.updatedAt });
+      await reloadAvatars();
     } catch (err) {
       log('[ranking]', err);
       const msg = 'Помилка завантаження';


### PR DESCRIPTION
## Summary
- import and use reloadAvatars alongside renderAllAvatars in profile script
- trigger reloadAvatars after avatar upload while preserving initial renderAllAvatars call

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c81a956288832180e7f77724218ef0