### PR TITLE
Ensure avatar cache bust after upload

### DIFF
--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -2,7 +2,7 @@
 import { log } from './logger.js';
 import { uploadAvatar } from './api.js';
 import { setAvatar } from './avatar.js';
-import { renderAllAvatars } from './avatars.client.js';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
 
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 
@@ -177,7 +177,7 @@ export async function initAvatarAdmin(players = [], league = '') {
         const resp = await uploadAvatar(nick, file);
         if (resp.status !== 'OK') throw new Error(resp.status);
         applyAvatarToUI(nick, resp.url);
-        renderAllAvatars({ bust: resp.updatedAt });
+        reloadAvatars({ bust: resp.updatedAt });
         localStorage.setItem('avatarRefresh', nick + ':' + resp.updatedAt);
         row.querySelector('input[type="file"]').value = '';
       } catch (err) {


### PR DESCRIPTION
## Summary
- Import `reloadAvatars` alongside `renderAllAvatars` in avatar admin module
- Reload cached avatars after uploading to force map refresh

## Testing
- ⚠️ `npm test` (missing package.json)
- ⚠️ `npx eslint scripts/avatarAdmin.js` (no ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68c81bbc7b808321b164f1944a454222