### PR TITLE
Refactor avatar rendering to use avatars.client

### DIFF
--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,7 +1,6 @@
 // scripts/avatarAdmin.js
 import { log } from './logger.js';
 import { uploadAvatar } from './api.js';
-import { setAvatar } from './avatar.js';
 import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
 
 const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
@@ -90,7 +89,6 @@ export async function initAvatarAdmin(players = [], league = '') {
     img.className = 'avatar-img';
     img.alt = p.nick;
     img.dataset.nick = p.nick;
-    setAvatar(img, p.nick);
     imgTd.appendChild(img);
 
     const nickTd = document.createElement('td');
@@ -153,6 +151,8 @@ export async function initAvatarAdmin(players = [], league = '') {
     listEl.appendChild(tr);
   });
 
+  await renderAllAvatars();
+
   const rows = () => Array.from(document.querySelectorAll('#avatar-list .avatar-row'));
 
   function updateSaveBtn() {
@@ -201,6 +201,6 @@ export async function initAvatarAdmin(players = [], league = '') {
 
 window.addEventListener('storage', e => {
   if(e.key === 'avatarRefresh') {
-    renderAllAvatars({ bust: Date.now() });
+    reloadAvatars();
   }
 });

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,26 +1,9 @@
 import { log } from './logger.js';
-import { getPdfLinks, fetchOnce, CSV_URLS, clearFetchCache, getAvatarUrl } from "./api.js";
+import { getPdfLinks, fetchOnce, CSV_URLS } from "./api.js";
 import { rankLetterForPoints } from './rankUtils.js';
-import { setAvatar } from './avatar.js';
-const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
 (function () {
   const CSV_TTL = 60 * 1000;
-
-  async function refreshAvatars(nick) {
-    const sel = nick ? `img[data-nick="${nick}"]` : 'img[data-nick]';
-    const imgs = document.querySelectorAll(sel);
-    for (const img of imgs) {
-      try {
-        const rec = await getAvatarUrl(img.dataset.nick);
-        const url = rec && rec.url ? rec.url : DEFAULT_AVATAR_URL;
-        img.onerror = () => { img.onerror = null; img.src = DEFAULT_AVATAR_URL; };
-        img.src = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
-      } catch {
-        img.onerror = null;
-        img.src = DEFAULT_AVATAR_URL;
-      }
-    }
-  }
 
 
   const alias = {
@@ -46,11 +29,7 @@ const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
   });
   window.addEventListener('storage', e => {
     if(e.key === 'gamedayRefresh') loadData();
-    if(e.key === 'avatarRefresh') {
-      const [nick] = (e.newValue || '').split(':');
-      if(nick) clearFetchCache(`avatar:${nick}`);
-      refreshAvatars(nick);
-    }
+    if(e.key === 'avatarRefresh') reloadAvatars();
   });
   if(fullscreenBtn){
     fullscreenBtn.addEventListener('click', () => {
@@ -249,7 +228,6 @@ const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
       img.className='avatar-img';
       img.alt=p.nick;
       img.dataset.nick = p.nick;
-      setAvatar(img,p.nick);
       tdAvatar.appendChild(img);
 
       const nick=document.createElement('td');
@@ -272,6 +250,8 @@ const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
       [rank,tdAvatar,nick,pts,games,wins,delta].forEach(td=>tr.appendChild(td));
       playersTb.appendChild(tr);
     });
+
+    renderAllAvatars();
 
     const displayMatches = matchRows.slice().sort((a,b)=>{
       const tDiff = new Date(b.timestamp) - new Date(a.timestamp);

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,5 +1,5 @@
 import { log } from './logger.js';
-import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, clearFetchCache, safeSet, safeGet } from './api.js';
+import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, safeSet, safeGet } from './api.js';
 import { rankLetterForPoints } from './rankUtils.js';
 import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
 
@@ -181,7 +181,6 @@ async function loadProfile(nick, key = '') {
     try {
       const resp = await uploadAvatar(nick, file);
       if (resp.status !== 'OK') throw new Error(resp.status);
-      clearFetchCache(`avatar:${nick}`);
       localStorage.setItem('avatarRefresh', nick + ':' + resp.updatedAt);
       const avatarEl = document.getElementById('avatar');
       if (avatarEl && resp.url) {
@@ -217,8 +216,8 @@ window.addEventListener('storage', e => {
   if (e.key === 'avatarRefresh') {
     const [nick] = (e.newValue || '').split(':');
     if (nick) {
-      clearFetchCache(`avatar:${nick}`);
       if (nick === currentNick) updateAvatar(nick);
+      reloadAvatars();
     }
   }
 });


### PR DESCRIPTION
## Summary
- Switch ranking, gameday, lobby, profile, and avatar admin pages to `avatars.client` for avatar rendering
- Drop legacy avatar helpers and refresh logic
- Render or reload avatars via `renderAllAvatars`/`reloadAvatars`

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c81ca753888321b816b6e0c5bc2cdc