### PR TITLE
feat: dynamic avatar fetching with gviz fallback

### DIFF
--- a/scripts/avatars.client.js
+++ b/scripts/avatars.client.js
@@ -1,78 +1,124 @@
-import { AVATARS_CSV_URL, AVATAR_PLACEHOLDER } from './config.js';
+import { AVATAR_PLACEHOLDER, AVATARS_SHEET_ID, AVATARS_GID } from './config.js';
 
-const AVATARS_JSON_URL = '/assets/avatars.json';
 let mapPromise;
 
-function normalize(url) {
-  const u = String(url || '').trim();
+function gvizJsonUrl() {
+  return `https://docs.google.com/spreadsheets/d/${AVATARS_SHEET_ID}/gviz/tq?tqx=out:json&gid=${AVATARS_GID}`;
+}
+
+function gvizCsvUrl() {
+  return `https://docs.google.com/spreadsheets/d/${AVATARS_SHEET_ID}/gviz/tq?tqx=out:csv&gid=${AVATARS_GID}`;
+}
+
+function nickKey(nick = '') {
+  return nick.trim().toLowerCase();
+}
+
+function driveThumbnail(url = '') {
+  const u = url.trim();
   if (!u) return '';
-  const m = u.match(/(?:file\/d\/|id=)([\w-]{10,})/);
+  const m = u.match(/(?:file\/d\/|id=|open\?id=|uc\?id=)([\w-]{10,})/);
   return m ? `https://drive.google.com/thumbnail?id=${m[1]}&sz=w512` : u;
 }
 
-async function fetchJsonMap() {
-  const res = await fetch(AVATARS_JSON_URL + '?t=' + Date.now());
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let col = '';
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') { col += '"'; i++; } else { inQuotes = false; }
+      } else {
+        col += ch;
+      }
+    } else {
+      if (ch === '"') { inQuotes = true; }
+      else if (ch === ',') { row.push(col); col = ''; }
+      else if (ch === '\n') { row.push(col); rows.push(row); row = []; col = ''; }
+      else if (ch !== '\r') { col += ch; }
+    }
+  }
+  row.push(col);
+  rows.push(row);
+  return rows;
+}
+
+async function fetchMapFromJson(bust) {
+  const res = await fetch(gvizJsonUrl() + (bust ? `&t=${bust}` : ''));
   if (!res.ok) throw new Error('JSON fetch failed: ' + res.status);
-  const data = await res.json();
+  const text = await res.text();
+  const json = JSON.parse(text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1));
+  const cols = json.table.cols.map(c => c.label);
   const map = new Map();
-  Object.entries(data).forEach(([nick, url]) => {
-    const n = nick.trim();
-    const u = normalize(url);
-    if (n && u) map.set(n, u);
-  });
+  for (const r of json.table.rows) {
+    const obj = {};
+    cols.forEach((label, i) => {
+      obj[label] = r.c[i] ? r.c[i].v : '';
+    });
+    const nick = obj.nick || obj.Nickname || obj[cols[0]] || '';
+    const url = driveThumbnail(obj.url || obj.URL || obj[cols[1]] || '');
+    if (nick && url) map.set(nickKey(nick), url);
+  }
   return map;
 }
 
-async function fetchCsvMap() {
-  const res = await fetch(AVATARS_CSV_URL + '&t=' + Date.now());
+async function fetchMapFromCsv(bust) {
+  const res = await fetch(gvizCsvUrl() + (bust ? `&t=${bust}` : ''));
   if (!res.ok) throw new Error('CSV fetch failed: ' + res.status);
   const text = await res.text();
-  const lines = text.trim().split('\n').filter(Boolean);
-  const header = lines.shift().split(',').map(h => h.trim());
+  const rows = parseCsv(text.trim());
+  const header = rows.shift().map(h => h.trim());
   const map = new Map();
-  for (const line of lines) {
-    const cols = line.split(',');
+  for (const cols of rows) {
     const row = {};
-    header.forEach((h, i) => { row[h] = (cols[i] || '').trim(); });
+    header.forEach((h, i) => {
+      row[h] = (cols[i] || '').trim();
+    });
     const nick = row.nick || row.Nickname || row[header[0]] || '';
-    const url = normalize(row.url || row.URL || row[header[1]] || '');
-    if (nick && url) map.set(nick, url);
+    const url = driveThumbnail(row.url || row.URL || row[header[1]] || '');
+    if (nick && url) map.set(nickKey(nick), url);
   }
   return map;
 }
 
-async function fetchMap() {
-  if (!mapPromise) {
-    mapPromise = (async () => {
-      try {
-        return await fetchJsonMap();
-      } catch (err) {
-        try {
-          return await fetchCsvMap();
-        } catch (err2) {
-          console.error('Failed to load avatar map', err, err2);
-          return new Map();
-        }
-      }
-    })();
+async function fetchMap(bust) {
+  try {
+    const map = await fetchMapFromJson(bust);
+    if (map.size) return map;
+  } catch (err) {
+    console.warn('Avatar JSON fetch failed', err);
   }
-  return mapPromise;
+  try {
+    return await fetchMapFromCsv(bust);
+  } catch (err) {
+    console.error('Avatar CSV fetch failed', err);
+    return new Map();
+  }
 }
 
 export async function renderAllAvatars({ bust } = {}) {
-  const map = await fetchMap();
+  const map = await (mapPromise && !bust ? mapPromise : (mapPromise = fetchMap(bust)));
   document.querySelectorAll('img[data-nick]').forEach(img => {
     const nick = img.dataset.nick || '';
-    let src = map.get(nick) || AVATAR_PLACEHOLDER;
+    let src = map.get(nickKey(nick)) || AVATAR_PLACEHOLDER;
     if (bust) src += (src.includes('?') ? '&' : '?') + 'v=' + bust;
-    img.onerror = () => { img.onerror = null; img.src = AVATAR_PLACEHOLDER; };
+    img.referrerPolicy = 'no-referrer';
+    img.loading = 'lazy';
+    img.decoding = 'async';
+    img.onerror = () => {
+      img.onerror = null;
+      img.src = AVATAR_PLACEHOLDER;
+    };
     if (!img.alt) img.alt = nick || 'avatar';
     img.src = src;
   });
 }
 
-export function reloadAvatars(opts = {}) {
+export function reloadAvatars({ bust = Date.now() } = {}) {
   mapPromise = null;
-  const bust = opts.bust || Date.now();
-  return renderAllAvatars({ ...opts, bust });
+  return renderAllAvatars({ bust });
 }
+

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,2 +1,4 @@
-export const AVATARS_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=0&single=true&output=csv';
+export const AVATARS_SHEET_ID =
+  '2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN';
+export const AVATARS_GID = '0';
 export const AVATAR_PLACEHOLDER = '/assets/default_avatars/av0.png';


### PR DESCRIPTION
## Summary
- build gviz URLs from sheet id and gid
- fetch avatars via gviz JSON with CSV fallback and Drive thumbnails
- apply safe image attributes and cache busting helpers

## Testing
- `npm test` (fails: ENOENT package.json)
- `npm run lint` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c8306713b08321add7e9e5285a614e