### PR TITLE
Use shared avatar placeholder

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,10 +1,9 @@
 // scripts/api.js
 import { log } from './logger.js';
+import { AVATAR_PLACEHOLDER } from './config.js';
 
 // Toggle network diagnostics
 const DEBUG_NETWORK = false;
-
-const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
 
 // ---------------------- Safe storage helpers ----------------------
 export function safeGet(storage, key) {
@@ -422,7 +421,7 @@ export async function getAvatarUrl(nick) {
   if (resp.status !== 'OK') throw new Error(resp.status || 'ERR_STATUS');
   rec = { url: resp.url || null, updatedAt: resp.updatedAt || Date.now() };
   avatarCache.set(nick, rec);
-    safeSet(window.__SESS, key, JSON.stringify(rec));
+  safeSet(window.__SESS, key, JSON.stringify(rec));
   return rec;
 }
 
@@ -435,7 +434,7 @@ export async function getPdfLinks(params) {
 }
 
 export function avatarSrcFromRecord(rec) {
-  const url = rec && rec.url ? rec.url : DEFAULT_AVATAR_URL;
+  const url = rec && rec.url ? rec.url : AVATAR_PLACEHOLDER;
   return url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
 }
 

--- a/scripts/avatar.js
+++ b/scripts/avatar.js
@@ -1,7 +1,6 @@
 import { getAvatarUrl } from './api.js';
 import { noteAvatarFailure } from './avatarAdmin.js';
-
-const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
+import { AVATAR_PLACEHOLDER } from './config.js';
 export async function setAvatar(img, nick, size = 40) {
   if (!img) return '';
   img.dataset.nick = nick;
@@ -16,8 +15,8 @@ export async function setAvatar(img, nick, size = 40) {
       noteAvatarFailure(nick, err);
     }
   }
-  const url = rec && rec.url ? rec.url : DEFAULT_AVATAR_URL;
-  img.onerror = () => { img.onerror = null; img.src = DEFAULT_AVATAR_URL; };
+  const url = rec && rec.url ? rec.url : AVATAR_PLACEHOLDER;
+  img.onerror = () => { img.onerror = null; img.src = AVATAR_PLACEHOLDER; };
   const src = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
   img.src = src;
   return src;

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -2,8 +2,9 @@
 import { log } from './logger.js';
 import { uploadAvatar } from './api.js';
 import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
+import { AVATAR_PLACEHOLDER } from './config.js';
 
-const DEFAULT_AVATAR_URL = 'assets/default_avatars/av0.png';
+const DEFAULT_AVATAR_DIR = AVATAR_PLACEHOLDER.replace(/\/[^/]*$/, '');
 
 export let avatarFailures = 0;
 
@@ -15,7 +16,7 @@ export function noteAvatarFailure(nick, reason) {
 }
 
 export function normalizeAvatarUrl(url = '') {
-  if (!url) return DEFAULT_AVATAR_URL;
+  if (!url) return AVATAR_PLACEHOLDER;
   if (url.includes('drive.google.com')) {
     const idMatch = url.match(/[?&]id=([^&]+)/) || url.match(/\/d\/([^/]+)/);
     if (idMatch) {
@@ -31,14 +32,14 @@ export function setImgSafe(img, url) {
   img.referrerPolicy = 'no-referrer';
   img.loading = 'lazy';
   img.decoding = 'async';
-  img.onerror = () => { img.onerror = null; img.src = DEFAULT_AVATAR_URL; };
+  img.onerror = () => { img.onerror = null; img.src = AVATAR_PLACEHOLDER; };
   const cacheSafe = src.startsWith('data:') || src.startsWith('blob:');
   const finalSrc = cacheSafe ? src : src + (src.includes('?') ? '&' : '?') + 't=' + Date.now();
   img.src = finalSrc;
 }
 
 export function applyAvatarToUI(nick, imageUrl) {
-  const url = imageUrl || DEFAULT_AVATAR_URL;
+  const url = imageUrl || AVATAR_PLACEHOLDER;
   const preview = document.querySelector(`#avatar-list .avatar-row[data-nick="${nick}"] img.avatar-img`);
   if (preview) setImgSafe(preview, url);
   document.querySelectorAll(`img[data-nick="${nick}"]`).forEach(img => {
@@ -47,13 +48,13 @@ export function applyAvatarToUI(nick, imageUrl) {
 }
 
 let defaultAvatars = [];
-async function loadDefaultAvatars(path = 'assets/default_avatars/list.json'){
+async function loadDefaultAvatars(path = `${DEFAULT_AVATAR_DIR}/list.json`){
   if(defaultAvatars.length) return;
   try{
     const res = await fetch(path);
     if(res.ok){
       const list = await res.json();
-      defaultAvatars = list.map(f => `assets/default_avatars/${f}`);
+      defaultAvatars = list.map(f => `${DEFAULT_AVATAR_DIR}/${f}`);
     }
   }catch(err){
     log('[ranking]', err);


### PR DESCRIPTION
## Summary
- replace local default avatar constants with the shared `AVATAR_PLACEHOLDER`
- derive admin default avatar asset paths from the shared placeholder directory

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c845c1fed88321abfb57a1bdb5336d