### PR TITLE
Log save game errors in console

### DIFF
--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -158,7 +158,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const res = await saveResult(data);
       if (res.status !== 'OK') {
-        const msg = 'Помилка збереження: ' + (res.status || res);
+        const message = res.status || res;
+        console.error('Save game error: ' + message);
+        const msg = 'Помилка збереження: ' + message;
         if (typeof showToast === 'function') showToast(msg); else alert(msg);
         return;
       }


### PR DESCRIPTION
## Summary
- log backend save errors from `saveGame` to the console before user notification

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdcf0b0908321900372a834005db6