### PR TITLE
Improve arena save error messaging

### DIFF
--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -158,7 +158,26 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const res = await saveResult(data);
       if (res.status !== 'OK') {
-        const message = res.status || res;
+        let message;
+        if (res && typeof res === 'object') {
+          message = res.message || res.error || res.details || (res.status && res.status !== 'OK' ? res.status : undefined);
+        } else if (typeof res === 'string') {
+          message = res;
+        }
+        if (!message && res && typeof res === 'object' && res.status) {
+          message = res.status;
+        }
+        if (!message) {
+          try {
+            message = JSON.stringify(res);
+          } catch {
+            message = String(res);
+          }
+        }
+        if (!message) {
+          message = 'Невідома помилка';
+        }
+
         console.error('Save game error: ' + message);
         const msg = 'Помилка збереження: ' + message;
         if (typeof showToast === 'function') showToast(msg); else alert(msg);


### PR DESCRIPTION
## Summary
- surface backend-provided error details when arena save calls fail
- reuse the same detailed message for console errors and operator-facing toasts

## Testing
- npm test *(fails: missing package.json in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cbed7714208321804f0b7d47130d66