### PR TITLE
Initialize proxy defaults for game-saving pages

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -165,6 +165,12 @@
   <script src="scripts/toast.js"></script>
 
   <!-- ES-модулі -->
+  <script>
+    // Optional overrides for proxy endpoints (edit if needed)
+    // window.PROXY_ORIGIN = 'http://localhost:8787';
+    // window.GAS_FALLBACK_URL = 'https://script.google.com/...';
+  </script>
+  <script type="module" src="./scripts/config.js"></script>
   <script type="module" src="scripts/api.js"></script>
   <script type="module" src="scripts/pdfParser.js"></script>
   <script type="module" src="scripts/sortUtils.js"></script>

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,3 +1,18 @@
+const DEFAULT_PROXY_ORIGIN = 'https://laser-proxy.vartaclub.workers.dev';
+const DEFAULT_GAS_FALLBACK_URL = '';
+
+const root = typeof window !== 'undefined' ? window : globalThis;
+
+if (root && typeof root === 'object') {
+  const rawProxyOrigin =
+    typeof root.PROXY_ORIGIN === 'string' ? root.PROXY_ORIGIN.trim() : '';
+  const rawFallbackUrl =
+    typeof root.GAS_FALLBACK_URL === 'string' ? root.GAS_FALLBACK_URL.trim() : '';
+
+  root.PROXY_ORIGIN = rawProxyOrigin || DEFAULT_PROXY_ORIGIN;
+  root.GAS_FALLBACK_URL = rawFallbackUrl || DEFAULT_GAS_FALLBACK_URL;
+}
+
 export const AVATARS_SHEET_ID = '19VYkNmFJCArLFDngYLkpkxF0LYqvDz78yF1oqLT7Ukw';
 export const AVATARS_GID = '2027704717';
 export const AVATAR_PLACEHOLDER = '/assets/default_avatars/av0.png';


### PR DESCRIPTION
## Summary
- set default values for `window.PROXY_ORIGIN` and `window.GAS_FALLBACK_URL` while keeping existing avatar exports in `scripts/config.js`
- add an inline override block and load `scripts/config.js` before `scripts/api.js` on the balance page so overrides run ahead of the API module

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf1a37320832182c4ad366bb10979