### PR TITLE
Update GAS fallback URL and test

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -168,7 +168,8 @@
   <script>
     // Optional overrides for proxy endpoints (edit if needed)
     // window.PROXY_ORIGIN = 'http://localhost:8787';
-    // window.GAS_FALLBACK_URL = 'https://script.google.com/...';
+    window.GAS_FALLBACK_URL =
+      'https://script.google.com/macros/s/AKfycbyusB7-h9LsA3f2IHdgz6VQjSfrBqi-sm0itCpABPdJVJXN-6wUFU_vSFrFofqHS7lvaA/exec';
   </script>
   <script type="module" src="./scripts/config.js"></script>
   <script type="module" src="scripts/api.js"></script>

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,5 +1,6 @@
 const DEFAULT_PROXY_ORIGIN = 'https://laser-proxy.vartaclub.workers.dev';
-const DEFAULT_GAS_FALLBACK_URL = '';
+const DEFAULT_GAS_FALLBACK_URL =
+  'https://script.google.com/macros/s/AKfycbyusB7-h9LsA3f2IHdgz6VQjSfrBqi-sm0itCpABPdJVJXN-6wUFU_vSFrFofqHS7lvaA/exec';
 
 const root = typeof window !== 'undefined' ? window : globalThis;
 

--- a/tests/saveResultFallback.test.mjs
+++ b/tests/saveResultFallback.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+
+const FALLBACK_URL =
+  'https://script.google.com/macros/s/AKfycbyusB7-h9LsA3f2IHdgz6VQjSfrBqi-sm0itCpABPdJVJXN-6wUFU_vSFrFofqHS7lvaA/exec';
+
+const sessionStore = new Map();
+const fakeWindow = {
+  location: { hostname: 'example.com', origin: 'https://example.com' },
+  __SESS: {
+    getItem(key) {
+      return sessionStore.has(key) ? sessionStore.get(key) : null;
+    },
+    setItem(key, value) {
+      sessionStore.set(key, value);
+    },
+    removeItem(key) {
+      sessionStore.delete(key);
+    }
+  },
+  addEventListener() {},
+  removeEventListener() {}
+};
+fakeWindow.window = fakeWindow;
+
+globalThis.window = fakeWindow;
+globalThis.location = fakeWindow.location;
+
+const calls = [];
+const createResponse = ({ ok, status, contentType, body }) => ({
+  ok,
+  status,
+  headers: {
+    get(name) {
+      return name && name.toLowerCase() === 'content-type' ? contentType : null;
+    }
+  },
+  async text() {
+    return body;
+  }
+});
+
+globalThis.fetch = async (url, options) => {
+  calls.push({ url, options });
+  if (calls.length === 1) {
+    return createResponse({
+      ok: false,
+      status: 502,
+      contentType: 'text/html',
+      body: '<html>Bad Gateway</html>'
+    });
+  }
+  if (url === FALLBACK_URL) {
+    return createResponse({
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'OK', players: [] })
+    });
+  }
+  throw new Error(`Unexpected URL: ${url}`);
+};
+
+fakeWindow.fetch = (...args) => globalThis.fetch(...args);
+
+const { saveResult, PROXY_ORIGIN } = await import('../scripts/api.js');
+
+assert.equal(window.GAS_FALLBACK_URL, FALLBACK_URL);
+
+const result = await saveResult({ action: 'saveResult', league: 'sundaygames' });
+
+assert.equal(result.ok, true);
+assert.equal(result.status, 'OK');
+assert.equal(result.message, 'OK');
+
+assert.equal(calls.length, 2);
+assert.equal(calls[0].url, PROXY_ORIGIN);
+assert.equal(calls[1].url, FALLBACK_URL);
+
+console.log('✅ saveResult fallback test passed');


### PR DESCRIPTION
## Summary
- point default GAS fallback URL at the new Apps Script endpoint
- align the balance page override with the new fallback URL
- add a regression test covering the saveResult retry path using the new endpoint

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc105129988321815131a8bf04cc11