### PR TITLE
Add updateAbonement helper for lobby updates

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -385,6 +385,37 @@ export async function getPdfLinks(params) {
   return resp.links || {};
 }
 
+export async function updateAbonement({ nick, league, type }) {
+  const payload = {
+    action: 'updateAbonement',
+    nick,
+    league: normalizeLeague(league),
+    type: String(type || '').toLowerCase()
+  };
+
+  let res;
+  try {
+    res = await fetch(PROXY_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+  } catch (err) {
+    log('[ranking]', err);
+    const e = new Error('Proxy unreachable');
+    e.cause = err;
+    throw e;
+  }
+
+  if (!res.ok) {
+    const err = new Error(res.statusText || `HTTP ${res.status}`);
+    err.status = res.status;
+    throw err;
+  }
+
+  return res.json ? res.json() : res.text();
+}
+
 // ===== Optional small helpers (UI aliases) =====
 window.uiLeagueToCsv = window.uiLeagueToCsv || function(v){ return String(v).toLowerCase()==='kids' ? 'kids' : 'sundaygames'; };
 window.uiLeagueToGas = window.uiLeagueToGas || function(v){ return String(v).toLowerCase()==='kids' ? 'kids' : 'sundaygames'; };


### PR DESCRIPTION
## Summary
- add an updateAbonement helper in scripts/api.js to send abonement updates through the proxy
- normalize league and abonement type in the payload and forward JSON requests to the worker proxy

## Testing
- node tests/saveResultFallback.test.mjs *(fails: existing assertion expects proxy origin without trailing slash)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1c4859708321b01021d5c4da595c