### PR TITLE
Fix CSV feeds to ASCII URLs

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -126,11 +126,11 @@ function toFormUrlEncoded(obj) {
 export const CSV_URLS = {
   kids: {
     ranking: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv',
-    games:   'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPз7SQGpKkyFwз4NQjsN8hz2jAFAhl-jtRdYVAXgr36sН4RSoQSpEN/pub?gid=249347260&single=true&output=csv'
+    games:   'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv'
   },
   sundaygames: {
-    ranking: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPз7SQGpKkyFwз4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv',
-    games:   'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPз7SQGpKkyFwз4NQjsN8hz2jAFAhl-jtRdYVAXgr36sН4RSoQSpEN/pub?gid=249347260&single=true&output=csv'
+    ranking: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv',
+    games:   'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=249347260&single=true&output=csv'
   }
 };
 


### PR DESCRIPTION
## Summary
- replace the kids and sundaygames CSV feed URLs in scripts/api.js with the ASCII-only variants to avoid embedded Cyrillic characters

## Testing
- node tests/saveResultFallback.test.mjs *(fails: AssertionError [ERR_ASSERTION]: Expected values to be strictly equal)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1de1ec68832188d9f61d8519e661