### PR TITLE
Ensure saveResult retries fallback with manual form encoding

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -282,12 +282,17 @@ export async function saveResult(data) {
 
   // 2) опційний прямий fallback на GAS
   const fallbackRaw = (typeof window !== 'undefined' ? window.GAS_FALLBACK_URL : '');
-  const needRetry = !result.ok && ['ERR_PROXY','ERR_NETWORK','ERR_JSON_PARSE','ERR_HTML'].includes(result.status);
+  const needRetry = !result.ok && ['ERR_PROXY', 'ERR_NETWORK', 'ERR_JSON_PARSE', 'ERR_HTML'].includes(result.status);
   if (needRetry && fallbackRaw) {
-    try {
-      const fb = normalizeProxyBase(String(fallbackRaw).trim(), { name: 'GAS_FALLBACK_URL' });
-      result = await attempt(fb.proxyOrigin); // у GAS кореневий exec без '/'
-    } catch (e) { /* ignore */ }
+    const trimmed = String(fallbackRaw).trim();
+    if (trimmed) {
+      let targetUrl = trimmed;
+      try {
+        const fb = normalizeProxyBase(trimmed, { name: 'GAS_FALLBACK_URL' });
+        targetUrl = fb.proxyOrigin; // у GAS кореневий exec без '/'
+      } catch (e) { /* ignore */ }
+      result = await attempt(targetUrl);
+    }
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- reuse a shared manual form-urlencoded POST helper for saveResult attempts
- keep the proxy retry flow while allowing raw fallback URLs when normalization fails

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc2396804483218a9441d46b17406d