### PR TITLE
Treat proxy ERR status as retryable

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -282,7 +282,7 @@ export async function saveResult(data) {
 
   // 2) опційний прямий fallback на GAS
   const fallbackRaw = (typeof window !== 'undefined' ? window.GAS_FALLBACK_URL : '');
-  const needRetry = !result.ok && ['ERR_PROXY', 'ERR_NETWORK', 'ERR_JSON_PARSE', 'ERR_HTML'].includes(result.status);
+  const needRetry = !result.ok && ['ERR', 'ERR_PROXY', 'ERR_NETWORK', 'ERR_JSON_PARSE', 'ERR_HTML'].includes(result.status);
   if (needRetry && fallbackRaw) {
     const trimmed = String(fallbackRaw).trim();
     if (trimmed) {


### PR DESCRIPTION
## Summary
- treat Worker responses with status ERR as retryable when deciding to use the GAS fallback

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc269e94448321809054f9debe9a5b