### PR TITLE
Add URLSearchParams polyfill for legacy browsers

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -7,6 +7,10 @@
   <link rel="stylesheet" href="balancer.css">
   <link rel="stylesheet" href="styles/balance.css">
   <link rel="stylesheet" href="styles/balance.mobile.css">
+  <script
+    type="module"
+    src="scripts/polyfills.js?v=2025-09-12-1"
+  ></script>
 </head>
 <body class="bal">
   <header>

--- a/gameday.html
+++ b/gameday.html
@@ -6,6 +6,10 @@
   <title>Ігровий день | Лазертаг</title>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="assets/tv.css">
+  <script
+    type="module"
+    src="scripts/polyfills.js?v=2025-09-12-1"
+  ></script>
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
       href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
       rel="stylesheet"
     />
+    <script
+      type="module"
+      src="scripts/polyfills.js?v=2025-09-12-1"
+    ></script>
     <!-- PapaParse для CSV -->
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
     <style>

--- a/profile.html
+++ b/profile.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Профіль гравця | Лазертаг</title>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
+  <script
+    type="module"
+    src="scripts/polyfills.js?v=2025-09-12-1"
+  ></script>
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
   <style>
     *{box-sizing:border-box;margin:0;padding:0;}

--- a/register.html
+++ b/register.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Реєстрація | Лазертаг</title>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
+  <script
+    type="module"
+    src="scripts/polyfills.js?v=2025-09-12-1"
+  ></script>
   <style>
     * { box-sizing:border-box; margin:0; padding:0; }
     body {

--- a/scripts/polyfills.js
+++ b/scripts/polyfills.js
@@ -1,0 +1,167 @@
+(() => {
+  const globalScope =
+    typeof globalThis !== "undefined"
+      ? globalThis
+      : typeof window !== "undefined"
+      ? window
+      : typeof self !== "undefined"
+      ? self
+      : this;
+
+  if (typeof globalScope.URLSearchParams === "function") {
+    return;
+  }
+
+  const replacePlus = /\+/g;
+
+  const decode = (input) => {
+    try {
+      return decodeURIComponent(String(input).replace(replacePlus, " "));
+    } catch (error) {
+      return String(input);
+    }
+  };
+
+  const encode = (input) =>
+    encodeURIComponent(String(input)).replace(/%20/g, "+");
+
+  class URLSearchParamsShim {
+    constructor(init = "") {
+      this._entries = [];
+
+      if (init instanceof URLSearchParamsShim) {
+        for (const [key, value] of init._entries) {
+          this.append(key, value);
+        }
+      } else if (typeof init === "string") {
+        this._fromString(init);
+      } else if (Array.isArray(init)) {
+        for (const pair of init) {
+          if (!pair) continue;
+          const [key, value] = pair;
+          this.append(key, value);
+        }
+      } else if (init && typeof init === "object") {
+        for (const key of Object.keys(init)) {
+          this.append(key, init[key]);
+        }
+      }
+    }
+
+    _fromString(str) {
+      const input = String(str).replace(/^\?/, "");
+      if (!input) {
+        return;
+      }
+
+      const segments = input.split("&");
+      for (const segment of segments) {
+        if (!segment) continue;
+        const eqIndex = segment.indexOf("=");
+        let key;
+        let value;
+        if (eqIndex === -1) {
+          key = decode(segment);
+          value = "";
+        } else {
+          key = decode(segment.slice(0, eqIndex));
+          value = decode(segment.slice(eqIndex + 1));
+        }
+        this.append(key, value);
+      }
+    }
+
+    append(name, value = "") {
+      this._entries.push({ name: String(name), value: String(value) });
+    }
+
+    delete(name) {
+      const key = String(name);
+      this._entries = this._entries.filter((entry) => entry.name !== key);
+    }
+
+    get(name) {
+      const key = String(name);
+      const found = this._entries.find((entry) => entry.name === key);
+      return found ? found.value : null;
+    }
+
+    getAll(name) {
+      const key = String(name);
+      return this._entries
+        .filter((entry) => entry.name === key)
+        .map((entry) => entry.value);
+    }
+
+    has(name) {
+      const key = String(name);
+      return this._entries.some((entry) => entry.name === key);
+    }
+
+    set(name, value = "") {
+      const key = String(name);
+      const val = String(value);
+      let replaced = false;
+      const next = [];
+      for (const entry of this._entries) {
+        if (entry.name === key) {
+          if (!replaced) {
+            next.push({ name: key, value: val });
+            replaced = true;
+          }
+        } else {
+          next.push(entry);
+        }
+      }
+      if (!replaced) {
+        next.push({ name: key, value: val });
+      }
+      this._entries = next;
+    }
+
+    sort() {
+      this._entries.sort((a, b) => {
+        if (a.name === b.name) {
+          return 0;
+        }
+        return a.name < b.name ? -1 : 1;
+      });
+    }
+
+    forEach(callback, thisArg) {
+      for (const [key, value] of this) {
+        callback.call(thisArg, value, key, this);
+      }
+    }
+
+    *entries() {
+      for (const entry of this._entries) {
+        yield [entry.name, entry.value];
+      }
+    }
+
+    *keys() {
+      for (const entry of this._entries) {
+        yield entry.name;
+      }
+    }
+
+    *values() {
+      for (const entry of this._entries) {
+        yield entry.value;
+      }
+    }
+
+    [Symbol.iterator]() {
+      return this.entries();
+    }
+
+    toString() {
+      return this._entries
+        .map((entry) => `${encode(entry.name)}=${encode(entry.value)}`)
+        .join("&");
+    }
+  }
+
+  globalScope.URLSearchParams = URLSearchParamsShim;
+})();

--- a/sunday.html
+++ b/sunday.html
@@ -9,6 +9,10 @@
       href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
       rel="stylesheet"
     />
+    <script
+      type="module"
+      src="scripts/polyfills.js?v=2025-09-12-1"
+    ></script>
     <!-- PapaParse для CSV -->
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
     <style>


### PR DESCRIPTION
## Summary
- add a small URLSearchParams shim that populates globalThis when the native API is unavailable
- include the new module ahead of other scripts on pages that rely on ES modules so the shim is ready

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc2a63c29c8321a8ebd96f2ea984cb