### PR TITLE
Add cache-busting version suffix to HTML scripts

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -160,13 +160,13 @@
   <div class="bal__overlay" id="ui-overlay" hidden></div>
 
   <!-- PDF.js -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js?v=2025-09-12-1"></script>
   <script>
     pdfjsLib.GlobalWorkerOptions.workerSrc =
       'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js';
   </script>
 
-  <script src="scripts/toast.js"></script>
+  <script src="scripts/toast.js?v=2025-09-12-1"></script>
 
   <!-- ES-модулі -->
   <script>
@@ -175,19 +175,19 @@
     window.GAS_FALLBACK_URL =
       'https://script.google.com/macros/s/AKfycbyusB7-h9LsA3f2IHdgz6VQjSfrBqi-sm0itCpABPdJVJXN-6wUFU_vSFrFofqHS7lvaA/exec';
   </script>
-  <script type="module" src="./scripts/config.js"></script>
-  <script type="module" src="scripts/api.js"></script>
-  <script type="module" src="scripts/pdfParser.js"></script>
-  <script type="module" src="scripts/sortUtils.js"></script>
-  <script type="module" src="scripts/balanceUtils.js"></script>
-  <script type="module" src="scripts/lobby.js"></script>
-  <script type="module" src="scripts/teams.js"></script>
-  <script type="module" src="scripts/scenario.js"></script>
-  <script type="module" src="scripts/arena.js"></script>
-  <script type="module" src="scripts/avatarAdmin.js"></script>
-  <script type="module" src="scripts/main.js"></script>
+  <script type="module" src="./scripts/config.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/api.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/pdfParser.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/sortUtils.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/balanceUtils.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/lobby.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/teams.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/scenario.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/arena.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/avatarAdmin.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/main.js?v=2025-09-12-1"></script>
   <script type="module">
-    import { renderAllAvatars } from './scripts/avatars.client.js';
+    import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-12-1';
     document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
   </script>
 </body>

--- a/gameday.html
+++ b/gameday.html
@@ -10,7 +10,7 @@
     type="module"
     src="scripts/polyfills.js?v=2025-09-12-1"
   ></script>
-  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-12-1"></script>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
@@ -168,9 +168,9 @@
     </section>
     </div>
   </div>
-  <script type="module" src="scripts/gameday.js"></script>
+  <script type="module" src="scripts/gameday.js?v=2025-09-12-1"></script>
   <script type="module">
-    import { renderAllAvatars } from './scripts/avatars.client.js';
+    import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-12-1';
     document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
       src="scripts/polyfills.js?v=2025-09-12-1"
     ></script>
     <!-- PapaParse для CSV -->
-    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-12-1"></script>
     <style>
       /* Reset & Base */
       * {
@@ -351,12 +351,12 @@
         <div id="stats-body"></div>
       </div>
     </div>
-    <script src="scripts/toast.js"></script>
-    <script type="module" src="scripts/api.js"></script>
-    <script type="module" src="scripts/quickStats.js"></script>
-    <script type="module" src="scripts/ranking.js"></script>
+    <script src="scripts/toast.js?v=2025-09-12-1"></script>
+    <script type="module" src="scripts/api.js?v=2025-09-12-1"></script>
+    <script type="module" src="scripts/quickStats.js?v=2025-09-12-1"></script>
+    <script type="module" src="scripts/ranking.js?v=2025-09-12-1"></script>
     <script type="module">
-      import { renderAllAvatars } from './scripts/avatars.client.js';
+      import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-12-1';
       document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
     </script>
   </body>

--- a/profile.html
+++ b/profile.html
@@ -9,7 +9,7 @@
     type="module"
     src="scripts/polyfills.js?v=2025-09-12-1"
   ></script>
-  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-12-1"></script>
   <style>
     *{box-sizing:border-box;margin:0;padding:0;}
     body{
@@ -53,10 +53,10 @@
       <tbody id="games-body"></tbody>
     </table>
   </div>
-  <script src="scripts/toast.js"></script>
-  <script type="module" src="scripts/profile.js"></script>
+  <script src="scripts/toast.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/profile.js?v=2025-09-12-1"></script>
   <script type="module">
-    import { renderAllAvatars } from './scripts/avatars.client.js';
+    import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-12-1';
     document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
   </script>
 </body>

--- a/register.html
+++ b/register.html
@@ -63,7 +63,7 @@
       <div id="reg-status" class="status"></div>
     </form>
   </div>
-  <script src="scripts/toast.js"></script>
-  <script type="module" src="scripts/register.js"></script>
+  <script src="scripts/toast.js?v=2025-09-12-1"></script>
+  <script type="module" src="scripts/register.js?v=2025-09-12-1"></script>
 </body>
 </html>

--- a/sunday.html
+++ b/sunday.html
@@ -14,7 +14,7 @@
       src="scripts/polyfills.js?v=2025-09-12-1"
     ></script>
     <!-- PapaParse для CSV -->
-    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-12-1"></script>
     <style>
       /* Базові стилі */
       * {
@@ -353,9 +353,9 @@
         <div id="stats-body"></div>
       </div>
     </div>
-    <script src="scripts/toast.js"></script>
-    <script type="module" src="scripts/api.js"></script>
-    <script type="module" src="scripts/quickStats.js"></script>
-    <script type="module" src="scripts/ranking.js"></script>
+    <script src="scripts/toast.js?v=2025-09-12-1"></script>
+    <script type="module" src="scripts/api.js?v=2025-09-12-1"></script>
+    <script type="module" src="scripts/quickStats.js?v=2025-09-12-1"></script>
+    <script type="module" src="scripts/ranking.js?v=2025-09-12-1"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- append the ?v=2025-09-12-1 query parameter to all script includes across the public HTML pages
- update inline renderAllAvatars imports to reference the versioned avatars.client.js module

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc2c111c7c8321b9c0eea5c20e32d2