### PR TITLE
Append cache-busting version to module imports

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,6 +1,6 @@
 // scripts/api.js
-import { log } from './logger.js';
-import { AVATAR_PLACEHOLDER } from './config.js';
+import { log } from './logger.js?v=2025-09-12-1';
+import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-12-1';
 
 // ==================== DIAGNOSTICS ====================
 const DEBUG_NETWORK = false;

--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -1,10 +1,10 @@
 // scripts/arena.js
-import { log } from './logger.js';
+import { log } from './logger.js?v=2025-09-12-1';
 
-import { saveResult, saveDetailedStats, normalizeLeague, safeSet } from './api.js';
-import { parseGamePdf }                   from './pdfParser.js';
-import { updateLobbyState }               from './lobby.js';
-import { teams }                          from './teams.js';
+import { saveResult, saveDetailedStats, normalizeLeague, safeSet } from './api.js?v=2025-09-12-1';
+import { parseGamePdf }                   from './pdfParser.js?v=2025-09-12-1';
+import { updateLobbyState }               from './lobby.js?v=2025-09-12-1';
+import { teams }                          from './teams.js?v=2025-09-12-1';
 
 // Дочекаємося, поки DOM завантажиться
 document.addEventListener('DOMContentLoaded', () => {

--- a/scripts/avatar.js
+++ b/scripts/avatar.js
@@ -1,6 +1,6 @@
-import { getAvatarUrl } from './api.js';
-import { noteAvatarFailure } from './avatarAdmin.js';
-import { AVATAR_PLACEHOLDER } from './config.js';
+import { getAvatarUrl } from './api.js?v=2025-09-12-1';
+import { noteAvatarFailure } from './avatarAdmin.js?v=2025-09-12-1';
+import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-12-1';
 export async function setAvatar(img, nick, size = 40) {
   if (!img) return '';
   img.dataset.nick = nick;

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,8 +1,8 @@
 // scripts/avatarAdmin.js
-import { log } from './logger.js';
-import { uploadAvatar } from './api.js';
-import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
-import { AVATAR_PLACEHOLDER } from './config.js';
+import { log } from './logger.js?v=2025-09-12-1';
+import { uploadAvatar } from './api.js?v=2025-09-12-1';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-12-1';
+import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-12-1';
 
 const DEFAULT_AVATAR_DIR = AVATAR_PLACEHOLDER.replace(/\/[^/]*$/, '');
 

--- a/scripts/avatars.client.js
+++ b/scripts/avatars.client.js
@@ -1,4 +1,4 @@
-import { AVATAR_PLACEHOLDER, AVATARS_SHEET_ID, AVATARS_GID } from './config.js';
+import { AVATAR_PLACEHOLDER, AVATARS_SHEET_ID, AVATARS_GID } from './config.js?v=2025-09-12-1';
 
 let mapPromise;
 

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,7 +1,7 @@
-import { log } from './logger.js';
-import { getPdfLinks, fetchOnce, CSV_URLS } from "./api.js";
-import { rankLetterForPoints } from './rankUtils.js';
-import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
+import { log } from './logger.js?v=2025-09-12-1';
+import { getPdfLinks, fetchOnce, CSV_URLS } from "./api.js?v=2025-09-12-1";
+import { rankLetterForPoints } from './rankUtils.js?v=2025-09-12-1';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-12-1';
 (function () {
   const CSV_TTL = 60 * 1000;
 

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -1,18 +1,18 @@
 // scripts/lobby.js
-import { log } from './logger.js';
+import { log } from './logger.js?v=2025-09-12-1';
 
-import { initTeams, teams } from './teams.js';
-import { sortByName, sortByPtsDesc } from './sortUtils.js';
+import { initTeams, teams } from './teams.js?v=2025-09-12-1';
+import { sortByName, sortByPtsDesc } from './sortUtils.js?v=2025-09-12-1';
 import {
   updateAbonement,
   adminCreatePlayer,
   issueAccessKey,
   getProfile,
   safeDel,
-} from './api.js';
-import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js';
-import { refreshArenaTeams } from './scenario.js';
-import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
+} from './api.js?v=2025-09-12-1';
+import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js?v=2025-09-12-1';
+import { refreshArenaTeams } from './scenario.js?v=2025-09-12-1';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-12-1';
 
 export let lobby = [];
 let players = [], filtered = [], selected = [], manualCount = 0;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,10 +1,10 @@
 // scripts/main.js
-import { log } from './logger.js';
+import { log } from './logger.js?v=2025-09-12-1';
 
-import { loadPlayers, safeGet, safeSet } from './api.js';
-import { initLobby }   from './lobby.js';
-import { initScenario } from './scenario.js';
-import { initAvatarAdmin } from './avatarAdmin.js';
+import { loadPlayers, safeGet, safeSet } from './api.js?v=2025-09-12-1';
+import { initLobby }   from './lobby.js?v=2025-09-12-1';
+import { initScenario } from './scenario.js?v=2025-09-12-1';
+import { initAvatarAdmin } from './avatarAdmin.js?v=2025-09-12-1';
 
 const CACHE_VERSION = window.CACHE_VERSION || '1';
 

--- a/scripts/playerStats.js
+++ b/scripts/playerStats.js
@@ -1,5 +1,5 @@
-import { log } from './logger.js';
-import { fetchPlayerStats } from './api.js';
+import { log } from './logger.js?v=2025-09-12-1';
+import { fetchPlayerStats } from './api.js?v=2025-09-12-1';
 
 function init(){
   const modal = document.getElementById('stats-modal');

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,8 +1,8 @@
-import { log } from './logger.js';
-import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, safeSet, safeGet } from './api.js';
-import { rankLetterForPoints } from './rankUtils.js';
-import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
-import { noteAvatarFailure } from './avatarAdmin.js';
+import { log } from './logger.js?v=2025-09-12-1';
+import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, safeSet, safeGet } from './api.js?v=2025-09-12-1';
+import { rankLetterForPoints } from './rankUtils.js?v=2025-09-12-1';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-12-1';
+import { noteAvatarFailure } from './avatarAdmin.js?v=2025-09-12-1';
 
 let gameLimit = 0;
 let gamesLeftEl = null;

--- a/scripts/quickStats.js
+++ b/scripts/quickStats.js
@@ -1,6 +1,6 @@
 // Quick stats popover
-import { log } from './logger.js';
-import { safeGet, safeSet } from './api.js';
+import { log } from './logger.js?v=2025-09-12-1';
+import { safeGet, safeSet } from './api.js?v=2025-09-12-1';
 const STYLE_ID = "quick-stats-style";
 if (!document.getElementById(STYLE_ID)) {
   const style = document.createElement("style");

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,8 +1,8 @@
-import { log } from './logger.js';
-import { fetchOnce, CSV_URLS, normalizeLeague } from "./api.js";
-import { LEAGUE } from "./constants.js";
-import { rankLetterForPoints } from './rankUtils.js';
-import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
+import { log } from './logger.js?v=2025-09-12-1';
+import { fetchOnce, CSV_URLS, normalizeLeague } from "./api.js?v=2025-09-12-1";
+import { LEAGUE } from "./constants.js?v=2025-09-12-1";
+import { rankLetterForPoints } from './rankUtils.js?v=2025-09-12-1';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-12-1';
 
 const CSV_TTL = 60 * 1000;
 

--- a/scripts/register.js
+++ b/scripts/register.js
@@ -1,5 +1,5 @@
-import { log } from './logger.js';
-import { registerPlayer } from './api.js';
+import { log } from './logger.js?v=2025-09-12-1';
+import { registerPlayer } from './api.js?v=2025-09-12-1';
 
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('reg-form');

--- a/scripts/scenario.js
+++ b/scripts/scenario.js
@@ -1,8 +1,8 @@
 // scripts/scenario.js
 
-import { teams, initTeams }          from './teams.js';
-import { autoBalance2, autoBalanceN } from './balanceUtils.js';
-import { lobby, setManualCount }      from './lobby.js';
+import { teams, initTeams }          from './teams.js?v=2025-09-12-1';
+import { autoBalance2, autoBalanceN } from './balanceUtils.js?v=2025-09-12-1';
+import { lobby, setManualCount }      from './lobby.js?v=2025-09-12-1';
 
 let scenarioArea, btnAuto, btnManual, teamSizeSel;
 let arenaSelect, arenaCheckboxes, btnStart;

--- a/scripts/script-kids.js
+++ b/scripts/script-kids.js
@@ -1,6 +1,6 @@
-import { log } from './logger.js';
-import { CSV_URLS } from "./api.js";
-import { rankLetterForPoints } from './rankUtils.js';
+import { log } from './logger.js?v=2025-09-12-1';
+import { CSV_URLS } from "./api.js?v=2025-09-12-1";
+import { rankLetterForPoints } from './rankUtils.js?v=2025-09-12-1';
 
 const csvUrl = CSV_URLS.kids.ranking;
 

--- a/scripts/script-sunday.js
+++ b/scripts/script-sunday.js
@@ -1,6 +1,6 @@
-import { log } from './logger.js';
-import { CSV_URLS } from "./api.js";
-import { rankLetterForPoints } from './rankUtils.js';
+import { log } from './logger.js?v=2025-09-12-1';
+import { CSV_URLS } from "./api.js?v=2025-09-12-1";
+import { rankLetterForPoints } from './rankUtils.js?v=2025-09-12-1';
 
 const csvUrl = CSV_URLS.sundaygames.ranking;
 

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -1,5 +1,5 @@
-import { log } from './logger.js';
-import { safeSet, safeGet } from './api.js';
+import { log } from './logger.js?v=2025-09-12-1';
+import { safeSet, safeGet } from './api.js?v=2025-09-12-1';
 export function getLobbyStorageKey(date, league){
   const d = date || document.getElementById('date')?.value || new Date().toISOString().slice(0,10);
   const sel = document.getElementById('league');

--- a/scripts/teams.js
+++ b/scripts/teams.js
@@ -1,5 +1,5 @@
-import { saveLobbyState } from './state.js';
-import { lobby } from './lobby.js';
+import { saveLobbyState } from './state.js?v=2025-09-12-1';
+import { lobby } from './lobby.js?v=2025-09-12-1';
 
 export let teams = {};
 


### PR DESCRIPTION
## Summary
- append the ?v=2025-09-12-1 cache-busting query to every local module import in the scripts bundle
- ensure dependent entry points such as main.js, arena.js, and profile.js now pull updated modules

## Testing
- not run (static site with no automated test suite)

------
https://chatgpt.com/codex/tasks/task_e_68cc2ff58ca88321aa4ad33c97ebde84