### PR TITLE
Add saveResult logging for form encoding usage

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -260,6 +260,7 @@ export async function saveResult(data) {
   const body = toFormUrlEncoded(payload);
   const headers = { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' };
 
+  console.log('[saveResult] using toFormUrlEncoded, ver=2025-09-18-2');
   const attempt = async (targetUrl) => {
     try {
       const res = await fetch(targetUrl, { method: 'POST', headers, body });


### PR DESCRIPTION
## Summary
- log a console message in saveResult before attempting the POST request so we can trace form-urlencoded submissions

## Testing
- npm test *(fails: no package.json available)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4ca1fbc88321bae4373709775110