### PR TITLE
Update avatar placeholder path

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -16,4 +16,4 @@ if (root && typeof root === 'object') {
 
 export const AVATARS_SHEET_ID = '19VYkNmFJCArLFDngYLkpkxF0LYqvDz78yF1oqLT7Ukw';
 export const AVATARS_GID = '2027704717';
-export const AVATAR_PLACEHOLDER = '/assets/default_avatars/av0.png';
+export const AVATAR_PLACEHOLDER = 'assets/default_avatars/av0.png';

--- a/tests/saveResultFallback.test.mjs
+++ b/tests/saveResultFallback.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 
 const FALLBACK_URL =
-  'https://script.google.com/macros/s/AKfycbyusB7-h9LsA3f2IHdgz6VQjSfrBqi-sm0itCpABPdJVJXN-6wUFU_vSFrFofqHS7lvaA/exec';
+  'https://script.google.com/macros/s/AKfycbzhQgbHauvk-ekGVHGRMUnEk-Rt-9M3QI_Jw-bjkRF4jAqpPtXQSDw3BsmivTHdvUY7Gw/exec';
 
 const sessionStore = new Map();
 const fakeWindow = {


### PR DESCRIPTION
## Summary
- point the avatar placeholder constant to the assets/default_avatars directory without a leading slash
- align the fallback URL test fixture with the actual configured default value

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc79a5c7888321a3abdd886258e684