### PR TITLE
Add manual/auto mode control panel to balance page

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -53,6 +53,14 @@
       </div>
     </section>
 
+    <section class="panel">
+      <div class="panel__controls">
+        <button type="button" id="mode-auto">Авто-баланс</button>
+        <button type="button" id="mode-manual">Ручне формування</button>
+      </div>
+      <small>Оберіть автоматичний режим для швидкого розподілу або ручний, щоб налаштувати склади команд самостійно.</small>
+    </section>
+
     <section class="bal__card blc-accordion open" id="sec-lobby">
       <h2 class="bal__acc-head">Лоббі дня</h2>
       <div class="bal__acc-body">

--- a/styles/balance.css
+++ b/styles/balance.css
@@ -32,6 +32,26 @@
   gap: 8px;
 }
 
+.panel {
+  background: var(--bal-card-bg);
+  border-radius: 8px;
+  padding: var(--bal-gap);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panel__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.panel small {
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
 .player__avatar {
   width: 40px;
   height: 40px;

--- a/styles/balance.mobile.css
+++ b/styles/balance.mobile.css
@@ -17,6 +17,14 @@
     padding: 8px;
   }
 
+  .panel__controls {
+    flex-direction: column;
+  }
+
+  .panel__controls button {
+    width: 100%;
+  }
+
   #btn-load,
   #ui-clear-lobby,
   #btn-clear-lobby {


### PR DESCRIPTION
## Summary
- add the new panel block with auto/manual mode buttons to the balance controls
- style the panel and its buttons for desktop and mobile layouts

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc895af818832184bf2d1b01eb2260