### PR TITLE
Refactor avatar admin section markup

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -150,14 +150,24 @@
       <h2 class="bal__acc-head">Керування аватарами</h2>
       <section id="avatar-admin" class="card">
         <div class="bal__acc-body">
-          <p class="text-muted">Обери мініатюру для гравця, натисни «Зберегти аватари» та зображення оновиться автоматично.</p>
-          <table class="table avatar-table">
-            <tbody id="avatar-list"></tbody>
-          </table>
-          <div class="actions">
-            <button id="save-avatars" disabled>Зберегти аватари</button>
-            <span id="avatar-status" class="text-muted hidden" style="align-self:center;">Аватари оновлено</span>
-          </div>
+          <p class="text-muted">Обери гравця, завантаж його новий аватар та переглянь результат перед збереженням.</p>
+          <form class="avatar-form" id="avatar-admin-form">
+            <div class="form-field">
+              <label for="avatar-nick">Нік гравця</label>
+              <input type="text" id="avatar-nick" name="avatar-nick" placeholder="Введи нік або ID" autocomplete="off">
+            </div>
+            <div class="form-field">
+              <label for="avatar-file">Файл аватара</label>
+              <input type="file" id="avatar-file" name="avatar-file" accept="image/*">
+            </div>
+            <div class="form-actions">
+              <button type="button" id="avatar-upload" disabled>Завантажити аватар</button>
+              <button type="button" id="avatars-refresh">Оновити аватари</button>
+            </div>
+            <div class="avatar-preview" aria-live="polite">
+              <img id="avatar-preview" src="assets/default_avatars/av0.png" alt="Попередній перегляд аватара" hidden>
+            </div>
+          </form>
         </div>
       </section>
     </section>


### PR DESCRIPTION
## Summary
- replace the avatar management accordion content with the new single-form layout
- remove the legacy avatar table, actions row, and status indicator so only the refreshed controls remain

## Testing
- npm test *(fails: missing package.json in static site repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8a47d64c8321b732f6be5e007a3e