### PR TITLE
Update GAS fallback URL in balance page

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -191,7 +191,7 @@
     // Optional overrides for proxy endpoints (edit if needed)
     // window.PROXY_ORIGIN = 'http://localhost:8787';
     window.GAS_FALLBACK_URL =
-      'https://script.google.com/macros/s/AKfycbyusB7-h9LsA3f2IHdgz6VQjSfrBqi-sm0itCpABPdJVJXN-6wUFU_vSFrFofqHS7lvaA/exec';
+      'https://script.google.com/macros/s/AKfycbzhQgbHauvk-ekGVHGRMUnEk-Rt-9M3QI_Jw-bjkRF4jAqpPtXQSDw3BsmivTHdvUY7Gw/exec';
   </script>
   <script type="module" src="./scripts/config.js?v=2025-09-18-9"></script>
   <script type="module" src="scripts/api.js?v=2025-09-18-9"></script>


### PR DESCRIPTION
## Summary
- replace the balance page's inline GAS fallback URL with the updated endpoint

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc8faac3b083218b0a405628c72ccc