### PR TITLE
Reorder balance module loading on balancer page

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -194,20 +194,19 @@
       'https://script.google.com/macros/s/AKfycbzhQgbHauvk-ekGVHGRMUnEk-Rt-9M3QI_Jw-bjkRF4jAqpPtXQSDw3BsmivTHdvUY7Gw/exec';
   </script>
   <script type="module" src="./scripts/config.js?v=2025-09-18-9"></script>
-  <script type="module" src="scripts/api.js?v=2025-09-18-9"></script>
-  <script type="module" src="scripts/pdfParser.js?v=2025-09-18-9"></script>
-  <script type="module" src="scripts/sortUtils.js?v=2025-09-18-9"></script>
-  <script type="module" src="scripts/balanceUtils.js?v=2025-09-18-9"></script>
-  <script type="module" src="scripts/lobby.js?v=2025-09-18-9"></script>
-  <script type="module" src="scripts/teams.js?v=2025-09-18-9"></script>
-  <script type="module" src="scripts/scenario.js?v=2025-09-18-9"></script>
-  <script type="module" src="scripts/arena.js?v=2025-09-18-9"></script>
-  <script type="module" src="scripts/avatarAdmin.js?v=2025-09-18-9"></script>
-  <script type="module" src="scripts/main.js?v=2025-09-18-9"></script>
-  <script type="module">
-    import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-18-9';
-    document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
-  </script>
+  <script type="module" src="./scripts/logger.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/balanceUtils.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/sortUtils.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/lobby.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/teams.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/scenario.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/arena.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/api.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/avatars.client.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/avatar.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/avatarAdmin.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/main.js?v=2025-09-18-9"></script>
+  <script type="module" src="./scripts/pdfParser.js?v=2025-09-18-9"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- reorder the balance page module scripts to follow the client-specified sequence and keep cache-busted URLs
- convert the avatar rendering modules to dedicated script tags and retain supplemental pdf parser loading

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc902f3fd48321884d90798159a612