### PR TITLE
Add balance mode toggles and auto-balance guard

### DIFF
--- a/scripts/balance.js
+++ b/scripts/balance.js
@@ -1,0 +1,58 @@
+// scripts/balance.js
+
+export let balanceMode = localStorage.getItem('balancerMode') || 'auto';
+
+let recomputeHandler = null;
+
+export function getBalanceMode() {
+  return balanceMode;
+}
+
+export function registerRecomputeAutoBalance(fn) {
+  recomputeHandler = typeof fn === 'function' ? fn : null;
+}
+
+export function recomputeAutoBalance() {
+  if (typeof recomputeHandler === 'function') {
+    recomputeHandler();
+  }
+}
+
+export function applyModeUI() {
+  const autoBtn = document.getElementById('mode-auto');
+  const manualBtn = document.getElementById('mode-manual');
+
+  if (autoBtn) {
+    autoBtn.classList.toggle('btn-primary', balanceMode === 'auto');
+  }
+  if (manualBtn) {
+    manualBtn.classList.toggle('btn-primary', balanceMode === 'manual');
+  }
+  if (document.body) {
+    document.body.dataset.balanceMode = balanceMode;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const autoBtn = document.getElementById('mode-auto');
+  const manualBtn = document.getElementById('mode-manual');
+
+  if (autoBtn) {
+    autoBtn.addEventListener('click', () => {
+      balanceMode = 'auto';
+      localStorage.setItem('balancerMode', balanceMode);
+      applyModeUI();
+      recomputeAutoBalance();
+    });
+  }
+
+  if (manualBtn) {
+    manualBtn.addEventListener('click', () => {
+      balanceMode = 'manual';
+      localStorage.setItem('balancerMode', balanceMode);
+      applyModeUI();
+    });
+  }
+
+  applyModeUI();
+});

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -13,12 +13,19 @@ import {
 import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js?v=2025-09-18-9';
 import { refreshArenaTeams } from './scenario.js?v=2025-09-18-9';
 import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-18-9';
+import { balanceMode, recomputeAutoBalance } from './balance.js?v=2025-09-18-9';
 
 export let lobby = [];
 let players = [], filtered = [], selected = [], manualCount = 0;
 const ABONEMENT_TYPES = ['none', 'lite', 'full'];
 
   let uiLeague = 'sundaygames';
+
+function maybeAutoRebalance() {
+  if (balanceMode === 'auto') {
+    recomputeAutoBalance();
+  }
+}
 
 function updatePlayersDatalist() {
   const dl = document.getElementById('players-datalist');
@@ -67,6 +74,7 @@ async function addPlayer(nick){
   renderLobbyCards();
   renderAllAvatars();
   renderSelect(filtered);
+  maybeAutoRebalance();
 }
 
 // Ініціалізує лоббі новим набором гравців
@@ -87,6 +95,7 @@ async function addPlayer(nick){
   renderLobby();
   renderLobbyCards();
   renderAllAvatars();
+  maybeAutoRebalance();
 }
 
 export function updateLobbyState(updates){
@@ -110,6 +119,7 @@ export function updateLobbyState(updates){
   renderLobby();
   renderLobbyCards();
   renderAllAvatars();
+  maybeAutoRebalance();
 }
 
 // Рендер списку доступних гравців
@@ -539,6 +549,7 @@ function onLobbyAction(e) {
       renderLobbyCards();
       renderAllAvatars();
       renderSelect(filtered);
+      maybeAutoRebalance();
       return;
     }
 
@@ -551,6 +562,7 @@ function onLobbyAction(e) {
       renderAllAvatars();
       renderSelect(filtered);
       refreshArenaTeams();
+      maybeAutoRebalance();
       return;
     }
 

--- a/scripts/scenario.js
+++ b/scripts/scenario.js
@@ -3,6 +3,11 @@
 import { teams, initTeams }          from './teams.js?v=2025-09-18-9';
 import { autoBalance2, autoBalanceN } from './balanceUtils.js?v=2025-09-18-9';
 import { lobby, setManualCount }      from './lobby.js?v=2025-09-18-9';
+import {
+  balanceMode,
+  registerRecomputeAutoBalance,
+  recomputeAutoBalance as triggerRecomputeAutoBalance,
+} from './balance.js?v=2025-09-18-9';
 
 let scenarioArea, btnAuto, btnManual, teamSizeSel;
 let arenaSelect, arenaCheckboxes, btnStart;
@@ -36,8 +41,13 @@ function updateStartButton() {
 }
 
 /** Авто-баланс: N=2 чи N>2 */
-function handleAuto() {
+export function recomputeAutoBalance() {
+  if (balanceMode !== 'auto') return;
+  if (!teamSizeSel || !arenaSelect || !arenaCheckboxes || !btnStart) return;
+
   const n = +teamSizeSel.value;
+  if (!Number.isInteger(n) || n <= 0) return;
+
   setManualCount(n);    // сповіщаємо lobby.js, скільки кнопок “→…” малювати
   let data;
   if (n === 2) {
@@ -50,6 +60,10 @@ function handleAuto() {
   arenaSelect.classList.remove('hidden');
   renderArenaCheckboxes();
   updateStartButton();
+}
+
+function handleAuto() {
+  triggerRecomputeAutoBalance();
 }
 
 /** Ручне формування команд */
@@ -83,6 +97,8 @@ document.addEventListener('DOMContentLoaded', () => {
     console.error('scenario.js: не знайдено обовʼязкові елементи');
     return;
   }
+
+  registerRecomputeAutoBalance(recomputeAutoBalance);
 
   btnAuto.addEventListener('click',   handleAuto);
   btnManual.addEventListener('click', handleManual);


### PR DESCRIPTION
## Summary
- add a dedicated balance controller that tracks the persisted mode and updates UI controls
- guard the scenario auto-balancer behind the active mode and register a shared recompute hook
- trigger automatic rebalancing from lobby mutations only when auto mode is enabled

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc91eef3348321a363f282a8b98a3b