### PR TITLE
Update avatar admin panel markup

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -120,7 +120,6 @@
 
     <section id="arena-area" class="bal__card card hidden">
       <h2>Арена: <span id="arena-vs"></span></h2>
-      <datalist id="players-datalist"></datalist>
       <div class="field">
         <label for="mvp1">MVP:</label>
         <input id="mvp1" list="players-datalist" required>
@@ -146,34 +145,44 @@
       </div>
     </section>
 
-    <section class="bal__card blc-accordion" id="sec-avatar-admin">
-      <h2 class="bal__acc-head">Керування аватарами</h2>
-      <section id="avatar-admin" class="card">
-        <div class="bal__acc-body">
-          <p class="text-muted">Обери гравця, завантаж його новий аватар та переглянь результат перед збереженням.</p>
-          <form class="avatar-form" id="avatar-admin-form">
-            <div class="row">
-              <div class="form-fields">
-                <div class="form-field">
-                  <label for="avatar-nick">Нік гравця</label>
-                  <input type="text" id="avatar-nick" name="avatar-nick" placeholder="Введи нік або ID" autocomplete="off">
-                </div>
-                <div class="form-field">
-                  <label for="avatar-file">Файл аватара</label>
-                  <input type="file" id="avatar-file" name="avatar-file" accept="image/*">
-                </div>
-                <div class="form-actions">
-                  <button type="button" id="avatar-upload" disabled>Завантажити аватар</button>
-                  <button type="button" id="avatars-refresh">Оновити аватари</button>
-                </div>
-              </div>
-              <div class="avatar-preview" aria-live="polite">
-                <img id="avatar-preview" src="assets/default_avatars/av0.png" alt="Попередній перегляд аватара" hidden>
-              </div>
-            </div>
-          </form>
+    <section class="panel" id="avatar-admin">
+      <h2>Керування аватарами</h2>
+      <p class="text-muted">Оберіть лігу та гравця, щоб завантажити новий аватар. Підтримуються PNG і JPG до 2&nbsp;МБ.</p>
+      <form id="avatar-admin-form" class="form-grid" autocomplete="off">
+        <div class="col col--controls">
+          <label for="league-select-lg">Ліга</label>
+          <select id="league-select-lg">
+            <option value="kids">Молодша ліга</option>
+            <option value="sundaygames">Старша ліга</option>
+          </select>
+
+          <label for="avatar-nick">Гравець</label>
+          <input
+            type="text"
+            id="avatar-nick"
+            name="avatar-nick"
+            placeholder="Введіть нік або ID"
+            list="players-datalist"
+            autocomplete="off"
+          >
+          <datalist id="players-datalist"></datalist>
+
+          <label for="avatar-file">Файл аватара</label>
+          <input type="file" id="avatar-file" name="avatar-file" accept="image/*">
+
+          <div class="form-actions">
+            <button type="button" id="avatar-upload" disabled>Завантажити аватар</button>
+            <button type="button" id="avatars-refresh">Оновити аватари</button>
+          </div>
+
+          <p id="avatar-status" class="text-muted" role="status" aria-live="polite"></p>
         </div>
-      </section>
+        <div class="col col--preview" aria-live="polite">
+          <div class="preview-box">
+            <img id="avatar-preview" alt="Попередній перегляд аватара" hidden>
+          </div>
+        </div>
+      </form>
     </section>
   </div>
 

--- a/balancer.css
+++ b/balancer.css
@@ -50,11 +50,15 @@ button:hover{background:var(--accent-dark);}button:disabled{background:var(--tex
 .mode-switch .btn:hover{background:#2a2a2a;}
 .mode-switch .btn.btn-primary{background:var(--accent);color:#fff;border-color:var(--accent);}
 .mode-switch .btn.btn-primary:hover{background:var(--accent-dark);}
-#avatar-admin .row{display:flex;flex-wrap:wrap;gap:1.5rem;align-items:flex-start;}
-#avatar-admin .form-fields{flex:1 1 260px;display:flex;flex-direction:column;gap:0.75rem;}
+#avatar-admin .form-grid{display:flex;flex-wrap:wrap;gap:1.5rem;align-items:flex-start;}
+#avatar-admin .col{display:flex;flex-direction:column;gap:0.75rem;}
+#avatar-admin .col--controls{flex:1 1 260px;}
+#avatar-admin .col--preview{flex:0 0 200px;}
+#avatar-admin label{font-weight:600;}
 #avatar-admin .form-actions{display:flex;flex-wrap:wrap;gap:0.5rem;}
-#avatar-admin .avatar-preview{flex:0 0 180px;display:flex;align-items:center;justify-content:center;border:1px dashed #2e2e2e;border-radius:12px;min-height:180px;padding:0.75rem;background:rgba(255,255,255,0.02);}
-#avatar-admin .avatar-preview img{width:160px;height:160px;object-fit:cover;border-radius:10px;box-shadow:0 4px 12px rgba(0,0,0,0.35);}
+#avatar-admin .preview-box{display:flex;align-items:center;justify-content:center;border:1px dashed #2e2e2e;border-radius:12px;min-height:180px;padding:0.75rem;background:rgba(255,255,255,0.02);}
+#avatar-admin .preview-box img{width:160px;height:160px;object-fit:cover;border-radius:10px;box-shadow:0 4px 12px rgba(0,0,0,0.35);}
+#avatar-admin #avatar-status{min-height:1.2rem;}
 .header .nav {
   position: relative;
   width: 100%;

--- a/styles/balance.css
+++ b/styles/balance.css
@@ -124,7 +124,7 @@
     text-align: center;
   }
 
-  #avatar-admin .row {
+  #avatar-admin .form-grid {
     flex-direction: column;
     gap: 1rem;
   }
@@ -137,14 +137,18 @@
     width: 100%;
   }
 
-  #avatar-admin .avatar-preview {
+  #avatar-admin .col--preview {
+    width: 100%;
+  }
+
+  #avatar-admin .preview-box {
     width: 100%;
     min-height: 160px;
     padding: 1rem;
     justify-content: flex-start;
   }
 
-  #avatar-admin .avatar-preview img {
+  #avatar-admin .preview-box img {
     width: 120px;
     height: 120px;
   }


### PR DESCRIPTION
## Summary
- replace the old accordion-based avatar admin block with the new panel markup and required controls
- expose league selection, datalist lookup, status message slot, and preview container without a default src
- update shared and responsive styles to support the new `.form-grid` / `.col` structure

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc9e42ac8483219eaac64ab7706407