### PR TITLE
Add responsive grid layout for avatar admin form

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -150,25 +150,31 @@
       <p class="text-muted">Оберіть лігу та гравця, щоб завантажити новий аватар. Підтримуються PNG і JPG до 2&nbsp;МБ.</p>
       <form id="avatar-admin-form" class="form-grid" autocomplete="off">
         <div class="col col--controls">
-          <label for="league-select-lg">Ліга</label>
-          <select id="league-select-lg">
-            <option value="kids">Молодша ліга</option>
-            <option value="sundaygames">Старша ліга</option>
-          </select>
+          <div class="row-inline">
+            <label for="league-select-lg">Ліга</label>
+            <select id="league-select-lg" class="select-lg">
+              <option value="kids">Молодша ліга</option>
+              <option value="sundaygames">Старша ліга</option>
+            </select>
+          </div>
 
-          <label for="avatar-nick">Гравець</label>
-          <input
-            type="text"
-            id="avatar-nick"
-            name="avatar-nick"
-            placeholder="Введіть нік або ID"
-            list="players-datalist"
-            autocomplete="off"
-          >
+          <div class="row-inline">
+            <label for="avatar-nick">Гравець</label>
+            <input
+              type="text"
+              id="avatar-nick"
+              name="avatar-nick"
+              placeholder="Введіть нік або ID"
+              list="players-datalist"
+              autocomplete="off"
+            >
+          </div>
           <datalist id="players-datalist"></datalist>
 
-          <label for="avatar-file">Файл аватара</label>
-          <input type="file" id="avatar-file" name="avatar-file" accept="image/*">
+          <div class="row-inline">
+            <label for="avatar-file">Файл аватара</label>
+            <input type="file" id="avatar-file" name="avatar-file" accept="image/*">
+          </div>
 
           <div class="form-actions">
             <button type="button" id="avatar-upload" disabled>Завантажити аватар</button>

--- a/balancer.css
+++ b/balancer.css
@@ -50,7 +50,7 @@ button:hover{background:var(--accent-dark);}button:disabled{background:var(--tex
 .mode-switch .btn:hover{background:#2a2a2a;}
 .mode-switch .btn.btn-primary{background:var(--accent);color:#fff;border-color:var(--accent);}
 .mode-switch .btn.btn-primary:hover{background:var(--accent-dark);}
-#avatar-admin .form-grid{display:flex;flex-wrap:wrap;gap:1.5rem;align-items:flex-start;}
+#avatar-admin .form-grid{display:grid;grid-template-columns:minmax(0,1fr) 240px;gap:1.5rem;align-items:flex-start;}
 #avatar-admin .col{display:flex;flex-direction:column;gap:0.75rem;}
 #avatar-admin .col--controls{flex:1 1 260px;}
 #avatar-admin .col--preview{flex:0 0 200px;}

--- a/styles/balance.css
+++ b/styles/balance.css
@@ -4,6 +4,60 @@
   --bal-card-bg: var(--card-bg, #242424);
 }
 
+.form-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 240px;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.select-lg {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #2e2e2e;
+  background: var(--bal-card-bg);
+  color: inherit;
+  font-size: 1rem;
+}
+
+.row-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  width: 100%;
+}
+
+.row-inline > * {
+  flex: 1 1 auto;
+}
+
+.row-inline label {
+  flex: 0 0 auto;
+  font-weight: 600;
+  min-width: 120px;
+}
+
+.preview-box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed #2e2e2e;
+  border-radius: 12px;
+  min-height: 180px;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+#avatar-preview {
+  width: 160px;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+
 .bal__panel {
   display: flex;
   flex-direction: column;
@@ -98,6 +152,12 @@
 .bal__players { display: none; }
 .only-mobile { display: none; }
 .only-desktop { display: inline-block; }
+
+@media (max-width: 1023px) {
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+}
 
 @media (max-width: 768px) {
   .only-mobile { display: block; }


### PR DESCRIPTION
## Summary
- add shared utility styles for the avatar admin form grid, large select, row layout, and preview elements with a tablet breakpoint
- update the balance admin markup to use the new helper classes for the league, player, and file inputs
- switch the avatar admin panel layout to CSS grid for consistent behavior across desktop and smaller screens

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cca07231c08321a7d8707068490939