### PR TITLE
Use shared avatar map helpers

### DIFF
--- a/scripts/avatar.js
+++ b/scripts/avatar.js
@@ -1,21 +1,21 @@
-import { getAvatarUrl } from './api.js?v=2025-09-18-12';
 import { noteAvatarFailure } from './avatarAdmin.js?v=2025-09-18-12';
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-18-12';
+import { ensureAvatarMap, getAvatarUrlFromMap } from './avatars.client.js?v=2025-09-18-12';
+
 export async function setAvatar(img, nick, size = 40) {
   if (!img) return '';
   img.dataset.nick = nick;
   img.loading = 'lazy';
   img.width = size;
   img.height = size;
-  let rec;
-  for (let attempt = 0; attempt < 2 && !rec; attempt++) {
-    try {
-      rec = await getAvatarUrl(nick);
-    } catch (err) {
-      noteAvatarFailure(nick, err);
-    }
+  let url = '';
+  try {
+    await ensureAvatarMap();
+    url = getAvatarUrlFromMap(nick);
+  } catch (err) {
+    noteAvatarFailure(nick, err);
   }
-  const url = rec && rec.url ? rec.url : AVATAR_PLACEHOLDER;
+  if (!url) url = AVATAR_PLACEHOLDER;
   img.onerror = () => { img.onerror = null; img.src = AVATAR_PLACEHOLDER; };
   const src = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
   img.src = src;

--- a/scripts/avatars.client.js
+++ b/scripts/avatars.client.js
@@ -2,6 +2,14 @@ import { AVATAR_PLACEHOLDER, AVATARS_SHEET_ID, AVATARS_GID } from './config.js?v
 
 let mapPromise;
 const AVMAP = new Map();
+
+/**
+ * Avatar map helpers for other modules.
+ *
+ * `ensureAvatarMap` wraps the internal fetch lifecycle so callers can await a
+ * populated avatar map. `getAvatarUrlFromMap` provides safe lookups from the
+ * cached map using a nickname key.
+ */
 let loadSeq = 0;
 
 function gvizJsonUrl() {
@@ -159,6 +167,16 @@ function ensureMap({ bust } = {}) {
     return loadMap({ bust });
   }
   return mapPromise;
+}
+
+export function ensureAvatarMap(options) {
+  return ensureMap(options || {});
+}
+
+export function getAvatarUrlFromMap(nick) {
+  const key = nickKey(nick || '');
+  if (!key) return '';
+  return AVMAP.get(key) || '';
 }
 
 function paintAvatarImage(img, baseUrl, bust, nickLabel) {


### PR DESCRIPTION
## Summary
- add exported wrappers around the avatar map loader and lookup helpers
- switch the avatar setter to use the shared map instead of the GAS endpoint
- document the new exports for module consumers

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cd38e798dc8321b9f86f18ac7eeb09