### PR TITLE
Update cache-busting version to 2025-09-19-3

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="styles/balance.mobile.css">
   <script
     type="module"
-    src="scripts/polyfills.js?v=2025-09-30-01"
+    src="scripts/polyfills.js?v=2025-09-19-3"
   ></script>
 </head>
 <body class="bal">
@@ -200,29 +200,29 @@
   <div class="bal__overlay" id="ui-overlay" hidden></div>
 
   <!-- PDF.js -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js?v=2025-09-30-01"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js?v=2025-09-19-3"></script>
   <script>
     pdfjsLib.GlobalWorkerOptions.workerSrc =
       'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js';
   </script>
 
-  <script src="scripts/toast.js?v=2025-09-30-01"></script>
+  <script src="scripts/toast.js?v=2025-09-19-3"></script>
 
   <!-- ES-модулі -->
-  <script type="module" src="./scripts/config.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/api.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/avatars.client.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/avatar.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/logger.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/balanceUtils.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/teams.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/lobby.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/arena.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/avatarAdmin.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/main.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/sortUtils.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/scenario.js?v=2025-09-30-01"></script>
-  <script type="module" src="./scripts/pdfParser.js?v=2025-09-30-01"></script>
+  <script type="module" src="./scripts/config.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/api.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/avatars.client.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/avatar.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/logger.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/balanceUtils.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/teams.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/lobby.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/arena.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/avatarAdmin.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/main.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/sortUtils.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/scenario.js?v=2025-09-19-3"></script>
+  <script type="module" src="./scripts/pdfParser.js?v=2025-09-19-3"></script>
 </body>
 </html>
 

--- a/gameday.html
+++ b/gameday.html
@@ -8,9 +8,9 @@
   <link rel="stylesheet" href="assets/tv.css">
   <script
     type="module"
-    src="scripts/polyfills.js?v=2025-09-30-01"
+    src="scripts/polyfills.js?v=2025-09-19-3"
   ></script>
-  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-30-01"></script>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-19-3"></script>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
@@ -168,14 +168,14 @@
     </section>
     </div>
   </div>
-  <script src="scripts/toast.js?v=2025-09-30-01"></script>
-  <script type="module" src="scripts/config.js?v=2025-09-30-01"></script>
-  <script type="module" src="scripts/api.js?v=2025-09-30-01"></script>
-  <script type="module" src="scripts/avatars.client.js?v=2025-09-30-01"></script>
-  <script type="module" src="scripts/avatar.js?v=2025-09-30-01"></script>
-  <script type="module" src="scripts/gameday.js?v=2025-09-30-01"></script>
+  <script src="scripts/toast.js?v=2025-09-19-3"></script>
+  <script type="module" src="scripts/config.js?v=2025-09-19-3"></script>
+  <script type="module" src="scripts/api.js?v=2025-09-19-3"></script>
+  <script type="module" src="scripts/avatars.client.js?v=2025-09-19-3"></script>
+  <script type="module" src="scripts/avatar.js?v=2025-09-19-3"></script>
+  <script type="module" src="scripts/gameday.js?v=2025-09-19-3"></script>
   <script type="module">
-    import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-30-01';
+    import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-19-3';
     document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -11,10 +11,10 @@
     />
     <script
       type="module"
-      src="scripts/polyfills.js?v=2025-09-30-01"
+      src="scripts/polyfills.js?v=2025-09-19-3"
     ></script>
     <!-- PapaParse для CSV -->
-    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-30-01"></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-19-3"></script>
     <style>
       /* Reset & Base */
       * {
@@ -351,15 +351,15 @@
         <div id="stats-body"></div>
       </div>
     </div>
-    <script src="scripts/toast.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/config.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/api.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/avatars.client.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/avatar.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/quickStats.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/ranking.js?v=2025-09-30-01"></script>
+    <script src="scripts/toast.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/config.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/api.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/avatars.client.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/avatar.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/quickStats.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/ranking.js?v=2025-09-19-3"></script>
     <script type="module">
-      import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-30-01';
+      import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-19-3';
       document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
     </script>
   </body>

--- a/profile.html
+++ b/profile.html
@@ -7,9 +7,9 @@
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
   <script
     type="module"
-    src="scripts/polyfills.js?v=2025-09-30-01"
+    src="scripts/polyfills.js?v=2025-09-19-3"
   ></script>
-  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-30-01"></script>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-19-3"></script>
   <style>
     *{box-sizing:border-box;margin:0;padding:0;}
     body{
@@ -53,10 +53,10 @@
       <tbody id="games-body"></tbody>
     </table>
   </div>
-  <script src="scripts/toast.js?v=2025-09-30-01"></script>
-  <script type="module" src="scripts/profile.js?v=2025-09-30-01"></script>
+  <script src="scripts/toast.js?v=2025-09-19-3"></script>
+  <script type="module" src="scripts/profile.js?v=2025-09-19-3"></script>
   <script type="module">
-    import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-30-01';
+    import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-19-3';
     document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
   </script>
 </body>

--- a/register.html
+++ b/register.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
   <script
     type="module"
-    src="scripts/polyfills.js?v=2025-09-30-01"
+    src="scripts/polyfills.js?v=2025-09-19-3"
   ></script>
   <style>
     * { box-sizing:border-box; margin:0; padding:0; }
@@ -63,7 +63,7 @@
       <div id="reg-status" class="status"></div>
     </form>
   </div>
-  <script src="scripts/toast.js?v=2025-09-30-01"></script>
-  <script type="module" src="scripts/register.js?v=2025-09-30-01"></script>
+  <script src="scripts/toast.js?v=2025-09-19-3"></script>
+  <script type="module" src="scripts/register.js?v=2025-09-19-3"></script>
 </body>
 </html>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,6 +1,6 @@
 // scripts/api.js
-import { log } from './logger.js?v=2025-09-30-01';
-import { AVATAR_PLACEHOLDER, DEFAULT_GAS_FALLBACK_URL } from './config.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { AVATAR_PLACEHOLDER, DEFAULT_GAS_FALLBACK_URL } from './config.js?v=2025-09-19-3';
 
 // ==================== DIAGNOSTICS ====================
 const DEBUG_NETWORK = false;
@@ -260,7 +260,7 @@ export async function saveResult(data) {
   const body = toFormUrlEncoded(payload);
   const headers = { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' };
 
-  console.log('[saveResult] v=2025-09-30-01');
+  console.log('[saveResult] v=2025-09-19-3');
   const attempt = async (targetUrl) => {
     try {
       const res = await fetch(targetUrl, { method: 'POST', headers, body });

--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -1,10 +1,10 @@
 // scripts/arena.js
-import { log } from './logger.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
 
-import { saveResult, saveDetailedStats, normalizeLeague, safeSet } from './api.js?v=2025-09-30-01';
-import { parseGamePdf }                   from './pdfParser.js?v=2025-09-30-01';
-import { updateLobbyState }               from './lobby.js?v=2025-09-30-01';
-import { teams }                          from './teams.js?v=2025-09-30-01';
+import { saveResult, saveDetailedStats, normalizeLeague, safeSet } from './api.js?v=2025-09-19-3';
+import { parseGamePdf }                   from './pdfParser.js?v=2025-09-19-3';
+import { updateLobbyState }               from './lobby.js?v=2025-09-19-3';
+import { teams }                          from './teams.js?v=2025-09-19-3';
 
 // Дочекаємося, поки DOM завантажиться
 document.addEventListener('DOMContentLoaded', () => {

--- a/scripts/avatar.js
+++ b/scripts/avatar.js
@@ -1,5 +1,5 @@
-import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-30-01';
-import { renderAllAvatars } from './avatars.client.js?v=2025-09-30-01';
+import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-3';
+import { renderAllAvatars } from './avatars.client.js?v=2025-09-19-3';
 
 export async function setAvatar(img, nick, { width, height } = {}) {
   if (!img) return;

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,7 +1,7 @@
 // scripts/avatarAdmin.js
-import { log } from './logger.js?v=2025-09-30-01';
-import { uploadAvatar, gasPost, toBase64NoPrefix, loadPlayers } from './api.js?v=2025-09-30-01';
-import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { uploadAvatar, gasPost, toBase64NoPrefix, loadPlayers } from './api.js?v=2025-09-19-3';
+import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-3';
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024;
 const UPLOAD_ACTION = 'uploadAvatar';
@@ -224,7 +224,7 @@ async function populatePlayersDatalist(league) {
 
 async function ensureAvatarsModule() {
   if (!avatarModulePromise) {
-    avatarModulePromise = import('./avatars.client.js?v=2025-09-30-01');
+    avatarModulePromise = import('./avatars.client.js?v=2025-09-19-3');
   }
   return avatarModulePromise;
 }

--- a/scripts/avatars.client.js
+++ b/scripts/avatars.client.js
@@ -1,5 +1,5 @@
-import { AVATARS_SHEET_ID, AVATARS_GID, AVATAR_PLACEHOLDER } from './config.js?v=2025-09-30-01';
-import { getAvatarUrl } from './api.js?v=2025-09-30-01';
+import { AVATARS_SHEET_ID, AVATARS_GID, AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-3';
+import { getAvatarUrl } from './api.js?v=2025-09-19-3';
 
 export const nickKey = value => String(value || '').trim().toLowerCase();
 

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,8 +1,8 @@
-import { log } from './logger.js?v=2025-09-30-01';
-import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-30-01';
-import { getPdfLinks, fetchOnce, CSV_URLS } from "./api.js?v=2025-09-30-01";
-import { rankLetterForPoints } from './rankUtils.js?v=2025-09-30-01';
-import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-3';
+import { getPdfLinks, fetchOnce, CSV_URLS } from "./api.js?v=2025-09-19-3";
+import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-3';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-19-3';
 (function () {
   const CSV_TTL = 60 * 1000;
 

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -1,20 +1,20 @@
 // scripts/lobby.js
-import { log } from './logger.js?v=2025-09-30-01';
-import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-3';
 
-import { initTeams, teams } from './teams.js?v=2025-09-30-01';
-import { sortByName, sortByPtsDesc } from './sortUtils.js?v=2025-09-30-01';
+import { initTeams, teams } from './teams.js?v=2025-09-19-3';
+import { sortByName, sortByPtsDesc } from './sortUtils.js?v=2025-09-19-3';
 import {
   updateAbonement,
   adminCreatePlayer,
   issueAccessKey,
   getProfile,
   safeDel,
-} from './api.js?v=2025-09-30-01';
-import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js?v=2025-09-30-01';
-import { refreshArenaTeams } from './scenario.js?v=2025-09-30-01';
-import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-30-01';
-import { balanceMode, recomputeAutoBalance } from './balance.js?v=2025-09-30-01';
+} from './api.js?v=2025-09-19-3';
+import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js?v=2025-09-19-3';
+import { refreshArenaTeams } from './scenario.js?v=2025-09-19-3';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-19-3';
+import { balanceMode, recomputeAutoBalance } from './balance.js?v=2025-09-19-3';
 
 export let lobby = [];
 let players = [], filtered = [], selected = [], manualCount = 0;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,10 +1,10 @@
 // scripts/main.js
-import { log } from './logger.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
 
-import { loadPlayers, safeGet, safeSet } from './api.js?v=2025-09-30-01';
-import { initLobby }   from './lobby.js?v=2025-09-30-01';
-import { initScenario } from './scenario.js?v=2025-09-30-01';
-import { initAvatarAdmin } from './avatarAdmin.js?v=2025-09-30-01';
+import { loadPlayers, safeGet, safeSet } from './api.js?v=2025-09-19-3';
+import { initLobby }   from './lobby.js?v=2025-09-19-3';
+import { initScenario } from './scenario.js?v=2025-09-19-3';
+import { initAvatarAdmin } from './avatarAdmin.js?v=2025-09-19-3';
 
 const CACHE_VERSION = window.CACHE_VERSION || '1';
 

--- a/scripts/playerStats.js
+++ b/scripts/playerStats.js
@@ -1,5 +1,5 @@
-import { log } from './logger.js?v=2025-09-30-01';
-import { fetchPlayerStats } from './api.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { fetchPlayerStats } from './api.js?v=2025-09-19-3';
 
 function init(){
   const modal = document.getElementById('stats-modal');

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,9 +1,9 @@
-import { log } from './logger.js?v=2025-09-30-01';
-import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, safeSet, safeGet } from './api.js?v=2025-09-30-01';
-import { rankLetterForPoints } from './rankUtils.js?v=2025-09-30-01';
-import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-30-01';
-import { noteAvatarFailure } from './avatarAdmin.js?v=2025-09-30-01';
-import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, safeSet, safeGet } from './api.js?v=2025-09-19-3';
+import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-3';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-19-3';
+import { noteAvatarFailure } from './avatarAdmin.js?v=2025-09-19-3';
+import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-3';
 
 let gameLimit = 0;
 let gamesLeftEl = null;

--- a/scripts/quickStats.js
+++ b/scripts/quickStats.js
@@ -1,6 +1,6 @@
 // Quick stats popover
-import { log } from './logger.js?v=2025-09-30-01';
-import { safeGet, safeSet } from './api.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { safeGet, safeSet } from './api.js?v=2025-09-19-3';
 const STYLE_ID = "quick-stats-style";
 if (!document.getElementById(STYLE_ID)) {
   const style = document.createElement("style");

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,9 +1,9 @@
-import { log } from './logger.js?v=2025-09-30-01';
-import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-30-01';
-import { fetchOnce, CSV_URLS, normalizeLeague } from "./api.js?v=2025-09-30-01";
-import { LEAGUE } from "./constants.js?v=2025-09-30-01";
-import { rankLetterForPoints } from './rankUtils.js?v=2025-09-30-01';
-import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-3';
+import { fetchOnce, CSV_URLS, normalizeLeague } from "./api.js?v=2025-09-19-3";
+import { LEAGUE } from "./constants.js?v=2025-09-19-3";
+import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-3';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-19-3';
 
 const CSV_TTL = 60 * 1000;
 

--- a/scripts/register.js
+++ b/scripts/register.js
@@ -1,5 +1,5 @@
-import { log } from './logger.js?v=2025-09-30-01';
-import { registerPlayer } from './api.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { registerPlayer } from './api.js?v=2025-09-19-3';
 
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('reg-form');

--- a/scripts/scenario.js
+++ b/scripts/scenario.js
@@ -1,13 +1,13 @@
 // scripts/scenario.js
 
-import { teams, initTeams }          from './teams.js?v=2025-09-30-01';
-import { autoBalance2, autoBalanceN } from './balanceUtils.js?v=2025-09-30-01';
-import { lobby, setManualCount }      from './lobby.js?v=2025-09-30-01';
+import { teams, initTeams }          from './teams.js?v=2025-09-19-3';
+import { autoBalance2, autoBalanceN } from './balanceUtils.js?v=2025-09-19-3';
+import { lobby, setManualCount }      from './lobby.js?v=2025-09-19-3';
 import {
   balanceMode,
   registerRecomputeAutoBalance,
   recomputeAutoBalance as triggerRecomputeAutoBalance,
-} from './balance.js?v=2025-09-30-01';
+} from './balance.js?v=2025-09-19-3';
 
 let scenarioArea, btnAuto, btnManual, teamSizeSel;
 let arenaSelect, arenaCheckboxes, btnStart;

--- a/scripts/script-kids.js
+++ b/scripts/script-kids.js
@@ -1,6 +1,6 @@
-import { log } from './logger.js?v=2025-09-30-01';
-import { CSV_URLS } from "./api.js?v=2025-09-30-01";
-import { rankLetterForPoints } from './rankUtils.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { CSV_URLS } from "./api.js?v=2025-09-19-3";
+import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-3';
 
 const csvUrl = CSV_URLS.kids.ranking;
 

--- a/scripts/script-sunday.js
+++ b/scripts/script-sunday.js
@@ -1,6 +1,6 @@
-import { log } from './logger.js?v=2025-09-30-01';
-import { CSV_URLS } from "./api.js?v=2025-09-30-01";
-import { rankLetterForPoints } from './rankUtils.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { CSV_URLS } from "./api.js?v=2025-09-19-3";
+import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-3';
 
 const csvUrl = CSV_URLS.sundaygames.ranking;
 

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -1,5 +1,5 @@
-import { log } from './logger.js?v=2025-09-30-01';
-import { safeSet, safeGet } from './api.js?v=2025-09-30-01';
+import { log } from './logger.js?v=2025-09-19-3';
+import { safeSet, safeGet } from './api.js?v=2025-09-19-3';
 export function getLobbyStorageKey(date, league){
   const d = date || document.getElementById('date')?.value || new Date().toISOString().slice(0,10);
   const sel = document.getElementById('league');

--- a/scripts/teams.js
+++ b/scripts/teams.js
@@ -1,5 +1,5 @@
-import { saveLobbyState } from './state.js?v=2025-09-30-01';
-import { lobby } from './lobby.js?v=2025-09-30-01';
+import { saveLobbyState } from './state.js?v=2025-09-19-3';
+import { lobby } from './lobby.js?v=2025-09-19-3';
 
 export let teams = {};
 

--- a/sunday.html
+++ b/sunday.html
@@ -11,10 +11,10 @@
     />
     <script
       type="module"
-      src="scripts/polyfills.js?v=2025-09-30-01"
+      src="scripts/polyfills.js?v=2025-09-19-3"
     ></script>
     <!-- PapaParse для CSV -->
-    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-30-01"></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-19-3"></script>
     <style>
       /* Базові стилі */
       * {
@@ -353,15 +353,15 @@
         <div id="stats-body"></div>
       </div>
     </div>
-    <script src="scripts/toast.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/config.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/api.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/avatars.client.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/avatar.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/quickStats.js?v=2025-09-30-01"></script>
-    <script type="module" src="scripts/ranking.js?v=2025-09-30-01"></script>
+    <script src="scripts/toast.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/config.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/api.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/avatars.client.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/avatar.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/quickStats.js?v=2025-09-19-3"></script>
+    <script type="module" src="scripts/ranking.js?v=2025-09-19-3"></script>
     <script type="module">
-      import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-30-01';
+      import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-19-3';
       document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
     </script>
   </body>


### PR DESCRIPTION
## Summary
- replace cache-busting query parameters on HTML script tags with ?v=2025-09-19-3
- update ES module imports across client scripts to use the new cache-busting version
- align the saveResult diagnostic log with the new version identifier

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cd5d19818c8321810a2e757497e5c2