### PR TITLE
Improve avatar nick normalization

### DIFF
--- a/scripts/avatars.client.js
+++ b/scripts/avatars.client.js
@@ -4,14 +4,16 @@ import { getAvatarUrl } from './api.js';
 const ZERO_WIDTH_CHARS_RE = /[\u200B-\u200D\u2060\uFEFF]/g;
 const WHITESPACE_RE = /\s+/g;
 
-export const nickKey = value => (
-  String(value || '')
+export const nickKey = value => {
+  const input = value == null ? '' : String(value);
+
+  return input
     .replace(ZERO_WIDTH_CHARS_RE, '')
     .normalize('NFKC')
     .trim()
     .replace(WHITESPACE_RE, ' ')
-    .toLowerCase()
-);
+    .toLowerCase();
+};
 
 const jsonUrl = `https://docs.google.com/spreadsheets/d/${AVATARS_SHEET_ID}/gviz/tq?tqx=out:json&gid=${AVATARS_GID}`;
 const csvUrl = `https://docs.google.com/spreadsheets/d/${AVATARS_SHEET_ID}/gviz/tq?tqx=out:csv&gid=${AVATARS_GID}`;


### PR DESCRIPTION
## Summary
- harden the `nickKey` helper to normalize falsy and zero-width characters before computing avatar map keys

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cd7438f97c8321b606fa7d2b43d84e