### PR TITLE
Refactor avatar rendering to use API helpers

### DIFF
--- a/gameday.html
+++ b/gameday.html
@@ -174,9 +174,5 @@
   <script type="module" src="scripts/avatars.client.js?v=2025-09-19-avatars-1"></script>
   <script type="module" src="scripts/avatar.js?v=2025-09-19-4"></script>
   <script type="module" src="scripts/gameday.js?v=2025-09-19-4"></script>
-  <script type="module">
-    import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-19-avatars-1';
-    document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
-  </script>
-</body>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -358,9 +358,5 @@
     <script type="module" src="scripts/avatar.js?v=2025-09-19-4"></script>
     <script type="module" src="scripts/quickStats.js?v=2025-09-19-4"></script>
     <script type="module" src="scripts/ranking.js?v=2025-09-19-4"></script>
-    <script type="module">
-      import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-19-avatars-1';
-      document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
-    </script>
   </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -55,9 +55,5 @@
   </div>
   <script src="scripts/toast.js?v=2025-09-19-4"></script>
   <script type="module" src="scripts/profile.js?v=2025-09-19-4"></script>
-  <script type="module">
-    import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-19-avatars-1';
-    document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
-  </script>
-</body>
+  </body>
 </html>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -187,7 +187,7 @@ function buildAvatarProxyUrl(path) {
   return url + (url.includes('?') ? '&' : '?') + query;
 }
 
-function nickKey(value) {
+export function avatarNickKey(value) {
   const input = value == null ? '' : String(value);
   return input
     .replace(ZERO_WIDTH_CHARS_RE, '')
@@ -206,7 +206,7 @@ function isLikelyAvatarUrl(url) {
 
 function addAvatarRecord(map, nick, url) {
   if (!nick || !url) return;
-  const key = nickKey(nick);
+  const key = avatarNickKey(nick);
   const trimmedUrl = typeof url === 'string' ? url.trim() : '';
   if (!key || !isLikelyAvatarUrl(trimmedUrl)) return;
   if (!map.has(key)) map.set(key, trimmedUrl);
@@ -427,7 +427,7 @@ export function clearFetchCache(key) {
       avatarCache.clear();
     } else {
       avatarCache.delete(raw);
-      const canonical = nickKey(raw);
+      const canonical = avatarNickKey(raw);
       if (canonical && canonical !== raw) avatarCache.delete(canonical);
     }
   }
@@ -620,7 +620,7 @@ export async function fetchAvatarsMap({ force = false } = {}) {
 
 export async function fetchAvatarForNick(nick, { force = false } = {}) {
   const originalNick = typeof nick === 'string' ? nick.trim() : '';
-  const key = nickKey(originalNick);
+  const key = avatarNickKey(originalNick);
   if (!key) {
     return { url: null, updatedAt: Date.now() };
   }

--- a/scripts/avatar.js
+++ b/scripts/avatar.js
@@ -1,5 +1,6 @@
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-1';
-import { renderAllAvatars, nickKey } from './avatars.client.js?v=2025-09-19-avatars-1';
+import { avatarNickKey } from './api.js?v=2025-09-19-4';
+import { renderAllAvatars } from './avatars.client.js?v=2025-09-19-avatars-1';
 
 export async function setAvatar(img, nick, { width, height } = {}) {
   if (!img) return;
@@ -7,7 +8,7 @@ export async function setAvatar(img, nick, { width, height } = {}) {
   const label = typeof nick === 'string' ? nick : '';
   if (label) img.dataset.nick = label;
   else delete img.dataset.nick;
-  if (label) img.dataset.nickKey = nickKey(label);
+  if (label) img.dataset.nickKey = avatarNickKey(label);
   else delete img.dataset.nickKey;
 
   img.referrerPolicy = 'no-referrer';

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,8 +1,7 @@
 // scripts/avatarAdmin.js
 import { log } from './logger.js?v=2025-09-19-4';
-import { uploadAvatar, gasPost, toBase64NoPrefix, loadPlayers } from './api.js?v=2025-09-19-4';
+import { uploadAvatar, gasPost, toBase64NoPrefix, loadPlayers, avatarNickKey } from './api.js?v=2025-09-19-4';
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-1';
-import { nickKey } from './avatars.client.js?v=2025-09-19-avatars-1';
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024;
 const UPLOAD_ACTION = 'uploadAvatar';
@@ -63,12 +62,12 @@ export function setImgSafe(img, url, bust) {
 
 export function applyAvatarToUI(nick, imageUrl) {
   const url = imageUrl || AVATAR_PLACEHOLDER;
-  const key = nickKey(nick);
+  const key = avatarNickKey(nick);
   if (!key) return;
   document.querySelectorAll('img[data-nick], img[data-nick-key]').forEach(img => {
     if (!img) return;
     const candidate = img.dataset.nickKey || img.dataset.nick || '';
-    const currentKey = nickKey(candidate);
+    const currentKey = avatarNickKey(candidate);
     if (!currentKey || currentKey !== key) return;
     img.dataset.nickKey = currentKey;
     if (nick && !img.dataset.nick) img.dataset.nick = nick;

--- a/scripts/avatars.client.js
+++ b/scripts/avatars.client.js
@@ -1,71 +1,65 @@
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-1';
-import { fetchAvatarForNick, fetchAvatarsMap } from './api.js';
+import { avatarNickKey, fetchAvatarForNick, fetchAvatarsMap } from './api.js';
 
 const ZERO_WIDTH_CHARS_RE = /[\u200B-\u200D\u2060\uFEFF]/g;
 const WHITESPACE_RE = /\s+/g;
+const MAX_LOOKUPS = 4;
 
-export const nickKey = value => {
+let mapPromise = null;
+let lastSource = 'proxy';
+let lastUpdatedAt = null;
+
+function normalizeNickLabel(value) {
   const input = value == null ? '' : String(value);
-
   return input
     .replace(ZERO_WIDTH_CHARS_RE, '')
     .normalize('NFKC')
     .trim()
-    .replace(WHITESPACE_RE, ' ')
-    .toLowerCase();
-};
-
-function ensureNodeNickKey(img) {
-  if (!img || !img.dataset) return { nick: '', key: '' };
-  const datasetNick = typeof img.dataset.nick === 'string' ? img.dataset.nick : '';
-  const datasetKey = typeof img.dataset.nickKey === 'string' ? img.dataset.nickKey : '';
-  const candidate = datasetKey || datasetNick;
-  const key = candidate ? nickKey(candidate) : '';
-  if (key) img.dataset.nickKey = key;
-  else delete img.dataset.nickKey;
-  return { nick: datasetNick, key };
+    .replace(WHITESPACE_RE, ' ');
 }
 
-function syncNodeNick(img, nick) {
-  if (!img || !img.dataset) return { nick: '', key: '' };
-  const label = typeof nick === 'string' ? nick : '';
-  if (label) img.dataset.nick = label;
-  const datasetNick = typeof img.dataset.nick === 'string' ? img.dataset.nick : '';
-  const datasetKey = typeof img.dataset.nickKey === 'string' ? img.dataset.nickKey : '';
-  const candidate = datasetKey || datasetNick;
-  const key = candidate ? nickKey(candidate) : '';
-  if (key) img.dataset.nickKey = key;
-  else delete img.dataset.nickKey;
-  return { nick: datasetNick, key };
-}
+function resolveArgs(rootOrOptions, maybeOptions) {
+  const defaultRoot = typeof document !== 'undefined' ? document : null;
+  let root = rootOrOptions;
+  let options = maybeOptions;
 
-function getAvatarElements() {
-  return Array.from(document.querySelectorAll('img[data-nick], img[data-nick-key]'));
-}
-
-let mapPromise = null; // Promise<Map<string, string>>
-let lastSource = 'proxy';
-let lastUpdatedAt = null;
-
-async function fetchMap(force = false) {
-  try {
-    const { map, source, updatedAt } = await fetchAvatarsMap({ force });
-    lastSource = source || (map.size ? 'proxy' : 'none');
-    lastUpdatedAt = Number.isFinite(updatedAt) ? updatedAt : null;
-
-    if (map.size) {
-      console.log(`[avatars] source=${lastSource} size=${map.size}`);
-      return map;
-    }
-
-    console.warn('[avatars] WARN: avatar feed returned no rows; using placeholders only');
-    return map;
-  } catch (err) {
-    lastSource = 'error';
-    lastUpdatedAt = null;
-    console.warn('[avatars] avatar feed failed', err);
-    return new Map();
+  if (root && typeof root.querySelectorAll === 'function') {
+    // root provided explicitly
+  } else if (options && typeof options === 'object') {
+    root = defaultRoot;
+  } else if (root && typeof root === 'object') {
+    options = root;
+    root = defaultRoot;
+  } else {
+    root = defaultRoot;
+    options = {};
   }
+
+  if (!options || typeof options !== 'object') options = {};
+  if (!root || typeof root.querySelectorAll !== 'function') root = defaultRoot;
+
+  return { root: root || defaultRoot, options };
+}
+
+function ensureAvatarEntry(img) {
+  if (!img || !img.dataset) return { img, nick: '', key: '' };
+
+  const rawNick = typeof img.dataset.nick === 'string' ? img.dataset.nick : '';
+  const normalizedNick = normalizeNickLabel(rawNick);
+  if (normalizedNick) img.dataset.nick = normalizedNick;
+  else delete img.dataset.nick;
+
+  const datasetKey = typeof img.dataset.nickKey === 'string' ? img.dataset.nickKey : '';
+  const canonicalKey = datasetKey ? avatarNickKey(datasetKey) : avatarNickKey(normalizedNick);
+  if (canonicalKey) img.dataset.nickKey = canonicalKey;
+  else delete img.dataset.nickKey;
+
+  return { img, nick: normalizedNick, key: canonicalKey };
+}
+
+function queryAvatarElements(root) {
+  const scope = root && typeof root.querySelectorAll === 'function' ? root : document;
+  return Array.from(scope.querySelectorAll('img[data-nick], img[data-nick-key]'));
 }
 
 function withBust(src, bust) {
@@ -103,122 +97,102 @@ function isVisible(el) {
   return !!(el.offsetParent || el.getClientRects().length);
 }
 
-async function resolveMissingAvatars(map, entries, { bust } = {}) {
-  if (!(map instanceof Map) || !Array.isArray(entries) || !entries.length) return;
-
-  const items = entries
-    .map(entry => {
-      const nick = entry && typeof entry.nick === 'string' ? entry.nick : '';
-      const key = entry && entry.key ? nickKey(entry.key) : nickKey(nick);
-      const imgs = entry && Array.isArray(entry.imgs)
-        ? entry.imgs.filter(img => !!img)
-        : [];
-      const canonicalKey = key || nickKey(nick);
-      if (!canonicalKey || !imgs.length) return null;
-      return { nick, key: canonicalKey, imgs };
-    })
-    .filter(Boolean);
-
-  if (!items.length) return;
-
-  let index = 0;
-  const workerCount = Math.min(6, items.length);
-  const hasBust = bust !== undefined && bust !== null && bust !== '';
-  const defaultBust = hasBust ? bust : (lastUpdatedAt ?? Date.now());
-  let anySuccess = false;
-
-  const workers = Array.from({ length: workerCount }, () => (async function worker() {
-    while (true) {
-      const currentIndex = index++;
-      if (currentIndex >= items.length) break;
-      const { nick, key, imgs } = items[currentIndex];
-      try {
-        const lookupNick = nick || key;
-        const rec = await fetchAvatarForNick(lookupNick);
-        const url = rec && typeof rec.url === 'string' ? rec.url.trim() : '';
-        if (!url) continue;
-        const storeKey = nickKey(nick) || key;
-        if (!storeKey) continue;
-        map.set(storeKey, url);
-        anySuccess = true;
-        imgs.forEach(img => {
-          if (!img) return;
-          const { key: nodeKey } = syncNodeNick(img, nick);
-          if (nodeKey !== storeKey) img.dataset.nickKey = storeKey;
-          const recordBust = hasBust ? bust : (Number.isFinite(rec?.updatedAt) ? rec.updatedAt : defaultBust);
-          applyAvatar(img, url, recordBust);
-        });
-      } catch (err) {
-        console.warn('[avatars] fallback error', nick, err);
-      }
+async function fetchMap(force = false) {
+  try {
+    const result = await fetchAvatarsMap({ force });
+    const map = result?.map instanceof Map ? result.map : new Map();
+    lastSource = result?.source || (map.size ? 'proxy' : 'none');
+    lastUpdatedAt = Number.isFinite(result?.updatedAt) ? result.updatedAt : null;
+    if (map.size) {
+      console.log(`[avatars] source=${lastSource} size=${map.size}`);
+    } else {
+      console.warn('[avatars] WARN: avatar feed returned no rows; using placeholders only');
     }
-  })());
-
-  await Promise.all(workers);
-
-  if (anySuccess) {
-    if (lastSource === 'none') lastSource = 'gas-fallback';
-    mapPromise = Promise.resolve(map);
-  }
-}
-
-export async function renderAllAvatars({ bust } = {}) {
-  const map = await (mapPromise ??= fetchMap());
-  const imgs = getAvatarElements();
-  const missingByKey = new Map();
-  let mapped = 0;
-
-  imgs.forEach(img => {
-    const { nick, key } = ensureNodeNickKey(img);
-    const src = key ? map.get(key) : '';
-
-    if (src) {
-      mapped += 1;
-    } else if (key) {
-      let entry = missingByKey.get(key);
-      if (!entry) {
-        const fallbackNick = nick || key;
-        entry = { key, nick: fallbackNick, imgs: [], visible: false };
-        missingByKey.set(key, entry);
-      }
-      entry.imgs.push(img);
-      if (isVisible(img)) entry.visible = true;
-    }
-
-    applyAvatar(img, src, bust);
-  });
-
-  const missEntries = Array.from(missingByKey.values()).filter(entry => entry.visible);
-  const missList = missEntries.slice(0, 5)
-    .map(entry => entry.nick || '')
-    .filter(Boolean);
-  const missSummary = missList.length ? missList.join(',') : '-';
-  console.log(`[avatars] imgs=${imgs.length} mapped=${mapped} miss=${missSummary}`);
-
-  if (missEntries.length) {
-    await resolveMissingAvatars(map, missEntries, { bust });
-  }
-}
-
-export async function reloadAvatars({ bust = Date.now() } = {}) {
-  mapPromise = fetchMap(true);
-  await renderAllAvatars({ bust });
-}
-
-export function updateOneAvatar(nick, url, bust = Date.now()) {
-  const key = nickKey(nick);
-  if (!key) return;
-
-  mapPromise ??= Promise.resolve(new Map());
-  mapPromise = mapPromise.then(map => {
-    map.set(key, url || '');
-    getAvatarElements().forEach(img => {
-      const { key: nodeKey } = ensureNodeNickKey(img);
-      if (nodeKey !== key) return;
-      const { key: syncedKey } = syncNodeNick(img, nick);
-      if (syncedKey !== key) img.dataset.nickKey = key;
-      applyAvatar(img, url || '', bust);
-    });
     return map;
+  } catch (err) {
+    lastSource = 'error';
+    lastUpdatedAt = null;
+    console.warn('[avatars] avatar feed failed', err);
+    return new Map();
+  }
+}
+
+export async function renderAllAvatars(rootOrOptions, maybeOptions) {
+  const { root, options } = resolveArgs(rootOrOptions, maybeOptions);
+  const bustOption = options?.bust;
+  const imgs = queryAvatarElements(root);
+  if (!imgs.length) return;
+
+  const entries = imgs.map(ensureAvatarEntry);
+  entries.forEach(entry => applyAvatar(entry.img, '', bustOption));
+
+  const map = await (mapPromise ??= fetchMap());
+  const baseBust = bustOption ?? lastUpdatedAt ?? Date.now();
+
+  let directMatches = 0;
+  const missing = [];
+
+  for (const entry of entries) {
+    const src = entry.key ? map.get(entry.key) : '';
+    if (src) {
+      directMatches += 1;
+      applyAvatar(entry.img, src, baseBust);
+    } else if (entry.key) {
+      missing.push(entry);
+    }
+  }
+
+  const visibleMissing = missing.filter(item => isVisible(item.img));
+  const lookupCandidates = visibleMissing.slice(0, MAX_LOOKUPS);
+  let lookupMatches = 0;
+
+  for (const entry of lookupCandidates) {
+    const lookupNick = entry.nick || entry.key;
+    if (!lookupNick) continue;
+    try {
+      const record = await fetchAvatarForNick(lookupNick);
+      const url = record && typeof record.url === 'string' ? record.url.trim() : '';
+      if (!url) continue;
+      const recordBust = bustOption
+        ?? (Number.isFinite(record?.updatedAt) ? record.updatedAt : null)
+        ?? lastUpdatedAt
+        ?? Date.now();
+      const canonicalKey = entry.key || avatarNickKey(entry.nick || lookupNick);
+      if (canonicalKey) {
+        entry.img.dataset.nickKey = canonicalKey;
+        map.set(canonicalKey, url);
+      }
+      applyAvatar(entry.img, url, recordBust);
+      lookupMatches += 1;
+    } catch (err) {
+      console.warn('[avatars] fallback error', lookupNick, err);
+    }
+  }
+
+  const unresolved = visibleMissing
+    .filter(entry => {
+      const key = entry.key || avatarNickKey(entry.nick);
+      return !(key && map.get(key));
+    })
+    .slice(0, 5)
+    .map(entry => entry.nick || entry.key || '')
+    .filter(Boolean);
+
+  const missSummary = unresolved.length ? unresolved.join(',') : '-';
+  console.log(`[avatars] imgs=${imgs.length} map=${directMatches} lookup=${lookupMatches} miss=${missSummary} source=${lastSource}`);
+}
+
+export async function reloadAvatars(rootOrOptions, maybeOptions) {
+  const { root, options } = resolveArgs(rootOrOptions, maybeOptions);
+  const nextOptions = { ...options, bust: options?.bust ?? Date.now() };
+  mapPromise = fetchMap(true);
+  await renderAllAvatars(root, nextOptions);
+}
+
+if (typeof document !== 'undefined' && document?.addEventListener) {
+  document.addEventListener('DOMContentLoaded', () => {
+    renderAllAvatars(document).catch(err => {
+      console.warn('[avatars] initial render failed', err);
+    });
   });
 }

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,8 +1,8 @@
 import { log } from './logger.js?v=2025-09-19-4';
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-1';
-import { getPdfLinks, fetchOnce, CSV_URLS } from "./api.js?v=2025-09-19-4";
+import { getPdfLinks, fetchOnce, CSV_URLS, avatarNickKey } from "./api.js?v=2025-09-19-4";
 import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-4';
-import { renderAllAvatars, reloadAvatars, nickKey } from './avatars.client.js?v=2025-09-19-avatars-1';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-19-avatars-1';
 (function () {
   const CSV_TTL = 60 * 1000;
 
@@ -229,7 +229,7 @@ import { renderAllAvatars, reloadAvatars, nickKey } from './avatars.client.js?v=
       img.className='avatar-img';
       img.alt=p.nick;
       img.dataset.nick = p.nick;
-      img.dataset.nickKey = nickKey(p.nick);
+      img.dataset.nickKey = avatarNickKey(p.nick);
       img.src = AVATAR_PLACEHOLDER;
       img.onerror = () => {
         img.onerror = null;

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -10,10 +10,11 @@ import {
   issueAccessKey,
   getProfile,
   safeDel,
+  avatarNickKey,
 } from './api.js?v=2025-09-19-4';
 import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js?v=2025-09-19-4';
 import { refreshArenaTeams } from './scenario.js?v=2025-09-19-4';
-import { renderAllAvatars, reloadAvatars, nickKey } from './avatars.client.js?v=2025-09-19-avatars-1';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-19-avatars-1';
 import { balanceMode, recomputeAutoBalance } from './balance.js?v=2025-09-19-4';
 
 export let lobby = [];
@@ -292,7 +293,7 @@ function renderPlayerList(el, arr) {
     const div = document.createElement('div');
     div.className = 'player';
     div.dataset.nick = p.nick;
-    div.dataset.nickKey = nickKey(p.nick);
+    div.dataset.nickKey = avatarNickKey(p.nick);
     div.draggable = true;
 
     const img = document.createElement('img');
@@ -302,7 +303,7 @@ function renderPlayerList(el, arr) {
     img.width = 40;
     img.height = 40;
     img.dataset.nick = p.nick;
-    img.dataset.nickKey = nickKey(p.nick);
+    img.dataset.nickKey = avatarNickKey(p.nick);
     img.src = AVATAR_PLACEHOLDER;
     img.onerror = () => {
       img.onerror = null;
@@ -430,7 +431,7 @@ function renderLobby() {
     const issueBtn = document.createElement('button');
     issueBtn.className = 'btn-issue-key';
     issueBtn.dataset.nick = p.nick;
-    issueBtn.dataset.nickKey = nickKey(p.nick);
+    issueBtn.dataset.nickKey = avatarNickKey(p.nick);
     issueBtn.textContent = 'Видати ключ';
     tdBtn.appendChild(issueBtn);
     tr.appendChild(tdBtn);
@@ -510,7 +511,7 @@ function renderLobbyCards() {
     const issueBtn = document.createElement('button');
     issueBtn.className = 'btn-issue-key';
     issueBtn.dataset.nick = p.nick;
-    issueBtn.dataset.nickKey = nickKey(p.nick);
+    issueBtn.dataset.nickKey = avatarNickKey(p.nick);
     issueBtn.textContent = 'Видати ключ';
     const accessSpan = document.createElement('span');
     accessSpan.className = 'access-key';

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,7 +1,7 @@
 import { log } from './logger.js?v=2025-09-19-4';
-import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, safeSet, safeGet } from './api.js?v=2025-09-19-4';
+import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, safeSet, safeGet, avatarNickKey } from './api.js?v=2025-09-19-4';
 import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-4';
-import { renderAllAvatars, reloadAvatars, nickKey } from './avatars.client.js?v=2025-09-19-avatars-1';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-19-avatars-1';
 import { noteAvatarFailure } from './avatarAdmin.js?v=2025-09-19-4';
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-1';
 
@@ -39,7 +39,7 @@ function parseQuery(search) {
 async function updateAvatar(nick) {
   const avatarEl = document.getElementById('avatar');
   avatarEl.dataset.nick = nick;
-  avatarEl.dataset.nickKey = nickKey(nick);
+  avatarEl.dataset.nickKey = avatarNickKey(nick);
   avatarEl.alt = nick;
   avatarEl.referrerPolicy = 'no-referrer';
   avatarEl.decoding = 'async';

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,9 +1,9 @@
 import { log } from './logger.js?v=2025-09-19-4';
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-1';
-import { fetchOnce, CSV_URLS, normalizeLeague } from "./api.js?v=2025-09-19-4";
+import { fetchOnce, CSV_URLS, normalizeLeague, avatarNickKey } from "./api.js?v=2025-09-19-4";
 import { LEAGUE } from "./constants.js?v=2025-09-19-4";
 import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-4';
-import { renderAllAvatars, reloadAvatars, nickKey } from './avatars.client.js?v=2025-09-19-avatars-1';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-19-avatars-1';
 
 const CSV_TTL = 60 * 1000;
 
@@ -218,7 +218,7 @@ function createRow(p, i) {
   img.loading = "lazy";
   img.width = img.height = 32;
   img.dataset.nick = p.nickname;
-  img.dataset.nickKey = nickKey(p.nickname);
+  img.dataset.nickKey = avatarNickKey(p.nickname);
   img.src = AVATAR_PLACEHOLDER;
   img.onerror = () => {
     img.onerror = null;

--- a/sunday.html
+++ b/sunday.html
@@ -360,9 +360,5 @@
     <script type="module" src="scripts/avatar.js?v=2025-09-19-4"></script>
     <script type="module" src="scripts/quickStats.js?v=2025-09-19-4"></script>
     <script type="module" src="scripts/ranking.js?v=2025-09-19-4"></script>
-    <script type="module">
-      import { renderAllAvatars } from './scripts/avatars.client.js?v=2025-09-19-avatars-1';
-      document.addEventListener('DOMContentLoaded', () => renderAllAvatars());
-    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the avatar client with the new API-driven workflow that normalizes data attributes, seeds placeholders, performs limited lookups, and self-initializes on DOMContentLoaded
- expose the shared avatarNickKey helper from the API module and update all consumers to rely on it alongside the revised renderAllAvatars signature
- drop redundant inline DOMContentLoaded hooks from HTML pages now that the client module handles initial rendering directly

## Testing
- `node tests/saveResultFallback.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68cf18f535148321901d7e589bb4db80