### PR TITLE
Add avatar styling and desktop layout tweaks

### DIFF
--- a/styles/balance.css
+++ b/styles/balance.css
@@ -130,6 +130,16 @@
   object-fit: cover;
 }
 
+img.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: #111;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
 .btn--danger {
   background: var(--danger);
   color: #fff;
@@ -179,7 +189,8 @@
     gap: clamp(24px, 3vw, 40px);
   }
 
-  .left-col {
+  .left-col,
+  .left-panel {
     position: sticky;
     top: 72px;
     align-self: flex-start;
@@ -187,8 +198,16 @@
     width: 100%;
   }
 
-  .left-col .bal__panel {
+  .left-col .bal__panel,
+  .left-panel .bal__panel {
     max-width: 100%;
+  }
+
+  .mode-switch {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: clamp(12px, 1vw, 16px);
+    margin: 0;
   }
 
   .right-col {


### PR DESCRIPTION
## Summary
- add a shared `img.avatar` style so avatar listings get consistent sizing and framing
- extend the desktop layout media query to cover `.left-panel` and tune the `.mode-switch` layout

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cf1ea4983c83218818ee22368e00e5