### PR TITLE
Reorder avatar module loading and update client integration

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -212,7 +212,7 @@
   <script type="module" src="./scripts/config.js?v=2025-09-19-avatars-2"></script>
   <script type="module" src="./scripts/logger.js?v=2025-09-19-avatars-2"></script>
   <script type="module" src="./scripts/api.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/avatar.js?v=2025-09-19-avatars-2"></script>
+  <script type="module" src="./scripts/avatars.client.js?v=2025-09-19-avatars-2"></script>
   <script type="module" src="./scripts/balanceUtils.js?v=2025-09-19-avatars-2"></script>
   <script type="module" src="./scripts/teams.js?v=2025-09-19-avatars-2"></script>
   <script type="module" src="./scripts/lobby.js?v=2025-09-19-avatars-2"></script>

--- a/gameday.html
+++ b/gameday.html
@@ -172,7 +172,7 @@
   <script type="module" src="scripts/config.js?v=2025-09-19-avatars-2"></script>
   <script type="module" src="scripts/logger.js?v=2025-09-19-avatars-2"></script>
   <script type="module" src="scripts/api.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="scripts/avatar.js?v=2025-09-19-avatars-2"></script>
+  <script type="module" src="scripts/avatars.client.js?v=2025-09-19-avatars-2"></script>
   <script type="module" src="scripts/gameday.js?v=2025-09-19-avatars-2"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@
     <script type="module" src="scripts/config.js?v=2025-09-19-avatars-2"></script>
     <script type="module" src="scripts/logger.js?v=2025-09-19-avatars-2"></script>
     <script type="module" src="scripts/api.js?v=2025-09-19-avatars-2"></script>
-    <script type="module" src="scripts/avatar.js?v=2025-09-19-avatars-2"></script>
+    <script type="module" src="scripts/avatars.client.js?v=2025-09-19-avatars-2"></script>
     <script type="module" src="scripts/quickStats.js?v=2025-09-19-avatars-2"></script>
     <script type="module" src="scripts/ranking.js?v=2025-09-19-avatars-2"></script>
   </body>

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -2,6 +2,7 @@
 import { log } from './logger.js?v=2025-09-19-avatars-2';
 import { uploadAvatar, gasPost, toBase64NoPrefix, loadPlayers, avatarNickKey, fetchAvatarForNick } from './api.js?v=2025-09-19-avatars-2';
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-2';
+import { reloadAvatars, updateOneAvatar } from './avatars.client.js?v=2025-09-19-avatars-2';
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024;
 const UPLOAD_ACTION = 'uploadAvatar';
@@ -113,7 +114,6 @@ const state = {
 };
 
 let formReady = false;
-let avatarModulePromise = null;
 let statusHideTimer = null;
 
 function setStatus(message, options = {}) {
@@ -258,20 +258,10 @@ async function populatePlayersDatalist(league) {
   }
 }
 
-async function ensureAvatarsModule() {
-  if (!avatarModulePromise) {
-    avatarModulePromise = import('./avatars.client.js?v=2025-09-19-avatars-2');
-  }
-  return avatarModulePromise;
-}
-
 async function reloadAvatarsSafe(options) {
   try {
-    const mod = await ensureAvatarsModule();
-    if (mod && typeof mod.reloadAvatars === 'function') {
-      const fresh = Boolean(options?.fresh ?? options?.bust);
-      await mod.reloadAvatars({ fresh });
-    }
+    const fresh = Boolean(options?.fresh ?? options?.bust);
+    await reloadAvatars({ fresh });
   } catch (err) {
     log('[avatarAdmin]', err);
     throw err;
@@ -280,9 +270,8 @@ async function reloadAvatarsSafe(options) {
 
 async function updateAvatarSafe(nick, url, bust) {
   try {
-    const mod = await ensureAvatarsModule();
-    if (mod && typeof mod.updateOneAvatar === 'function') {
-      mod.updateOneAvatar(nick, url, bust);
+    if (typeof updateOneAvatar === 'function') {
+      updateOneAvatar(nick, url, bust);
     }
   } catch (err) {
     log('[avatarAdmin]', err);

--- a/sunday.html
+++ b/sunday.html
@@ -357,7 +357,7 @@
     <script type="module" src="scripts/config.js?v=2025-09-19-avatars-2"></script>
     <script type="module" src="scripts/logger.js?v=2025-09-19-avatars-2"></script>
     <script type="module" src="scripts/api.js?v=2025-09-19-avatars-2"></script>
-    <script type="module" src="scripts/avatar.js?v=2025-09-19-avatars-2"></script>
+    <script type="module" src="scripts/avatars.client.js?v=2025-09-19-avatars-2"></script>
     <script type="module" src="scripts/quickStats.js?v=2025-09-19-avatars-2"></script>
     <script type="module" src="scripts/ranking.js?v=2025-09-19-avatars-2"></script>
   </body>


### PR DESCRIPTION
## Summary
- reorder avatar-enabled pages so module scripts load config, logger, api, avatars.client, then their page code with the new asset version
- expose updateOneAvatar and switch avatarAdmin to static avatars.client imports to avoid dynamic re-imports

## Testing
- node --test tests/saveResultFallback.test.mjs *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2fc6d0808321862fb47f9f481b76