### PR TITLE
Update avatar worker endpoints

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,5 +1,8 @@
 export const GAS_BASE_URL = 'https://script.google.com/macros/s/AKfycbzhQgbHauvk-ekGVHGRMUnEk-Rt-9M3QI_Jw-bjkRF4jAqpPtXQSDw3BsmivTHdvUY7Gw/exec';
 export const GAS_JSON_URL = GAS_BASE_URL;
-export const AVATARS_BASE = 'https://avatarsproxy.vartaclub.workers.dev';
+export const AVATAR_WORKER_BASE = 'https://avatarsproxy.vartaclub.workers.dev';
+export const AVATARS_FEED = 'https://avatarsproxy.vartaclub.workers.dev/feed';
+export const AVATAR_BY_NICK = 'https://avatarsproxy.vartaclub.workers.dev/avatar';
+export const AVATAR_CACHE_BUST = '2025-09-19-avatars-2';
 export const AVATAR_PLACEHOLDER = 'assets/default_avatars/av0.png';
-export const ASSETS_VER = '2025-09-19-avatars-2';
+export const ASSETS_VER = AVATAR_CACHE_BUST;


### PR DESCRIPTION
## Summary
- replace the legacy avatar base URL export with explicit worker endpoints and cache-bust constant
- normalize worker URLs in the avatar API helpers and use the new feed/nick endpoints when fetching data

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cfbfac979c8321805bfeb81428456d