### PR TITLE
Reorder module scripts and bump version suffixes

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="styles/balance.mobile.css">
   <script
     type="module"
-    src="scripts/polyfills.js?v=2025-09-19-avatars-2"
+    src="scripts/polyfills.js?v=2025-09-19-avatars-3"
   ></script>
 </head>
 <body class="bal">
@@ -200,28 +200,28 @@
   <div class="bal__overlay" id="ui-overlay" hidden></div>
 
   <!-- PDF.js -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js?v=2025-09-19-avatars-2"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js?v=2025-09-19-avatars-3"></script>
   <script>
     pdfjsLib.GlobalWorkerOptions.workerSrc =
       'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js';
   </script>
 
-  <script src="scripts/toast.js?v=2025-09-19-avatars-2"></script>
+  <script src="scripts/toast.js?v=2025-09-19-avatars-3"></script>
 
   <!-- ES-модулі -->
-  <script type="module" src="./scripts/config.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/logger.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/api.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/avatars.client.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/balanceUtils.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/teams.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/lobby.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/arena.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/avatarAdmin.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/main.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/sortUtils.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/scenario.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="./scripts/pdfParser.js?v=2025-09-19-avatars-2"></script>
+  <script type="module" src="./scripts/logger.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/config.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/api.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/avatars.client.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/balanceUtils.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/teams.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/lobby.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/arena.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/avatarAdmin.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/main.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/sortUtils.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/scenario.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/pdfParser.js?v=2025-09-19-avatars-3"></script>
 </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -11,10 +11,10 @@
     />
     <script
       type="module"
-      src="scripts/polyfills.js?v=2025-09-19-avatars-2"
+      src="scripts/polyfills.js?v=2025-09-19-avatars-3"
     ></script>
     <!-- PapaParse для CSV -->
-    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-19-avatars-2"></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js?v=2025-09-19-avatars-3"></script>
     <style>
       /* Reset & Base */
       * {
@@ -351,12 +351,12 @@
         <div id="stats-body"></div>
       </div>
     </div>
-    <script src="scripts/toast.js?v=2025-09-19-avatars-2"></script>
-    <script type="module" src="scripts/config.js?v=2025-09-19-avatars-2"></script>
-    <script type="module" src="scripts/logger.js?v=2025-09-19-avatars-2"></script>
-    <script type="module" src="scripts/api.js?v=2025-09-19-avatars-2"></script>
-    <script type="module" src="scripts/avatars.client.js?v=2025-09-19-avatars-2"></script>
-    <script type="module" src="scripts/quickStats.js?v=2025-09-19-avatars-2"></script>
-    <script type="module" src="scripts/ranking.js?v=2025-09-19-avatars-2"></script>
+    <script src="scripts/toast.js?v=2025-09-19-avatars-3"></script>
+    <script type="module" src="scripts/logger.js?v=2025-09-19-avatars-3"></script>
+    <script type="module" src="scripts/config.js?v=2025-09-19-avatars-3"></script>
+    <script type="module" src="scripts/api.js?v=2025-09-19-avatars-3"></script>
+    <script type="module" src="scripts/avatars.client.js?v=2025-09-19-avatars-3"></script>
+    <script type="module" src="scripts/quickStats.js?v=2025-09-19-avatars-3"></script>
+    <script type="module" src="scripts/ranking.js?v=2025-09-19-avatars-3"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- reorder module script tags in index.html and balance.html so logger loads before config, API, and avatar client modules
- bump all cache-busting query parameters on included scripts to v=2025-09-19-avatars-3 on both pages

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfc3f93b688321a8929cea20f5f679