### PR TITLE
Ensure lobby avatar rendering awaits worker updates

### DIFF
--- a/scripts/arena.js
+++ b/scripts/arena.js
@@ -173,7 +173,7 @@ document.addEventListener('DOMContentLoaded', () => {
       window.lastMatchId = res.matchId || Date.now();
 
       if (Array.isArray(res.players)) {
-        updateLobbyState(res.players);
+        await updateLobbyState(res.players);
       }
 
       const successMessage = message || 'Гру успішно збережено та рейтинги оновлено';

--- a/scripts/balance.js
+++ b/scripts/balance.js
@@ -12,9 +12,13 @@ export function registerRecomputeAutoBalance(fn) {
   recomputeHandler = typeof fn === 'function' ? fn : null;
 }
 
-export function recomputeAutoBalance() {
+export async function recomputeAutoBalance() {
   if (typeof recomputeHandler === 'function') {
-    recomputeHandler();
+    try {
+      await recomputeHandler();
+    } catch (err) {
+      console.error('[balance] recompute failed', err);
+    }
   }
 }
 
@@ -38,11 +42,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const manualBtn = document.getElementById('mode-manual');
 
   if (autoBtn) {
-    autoBtn.addEventListener('click', () => {
+    autoBtn.addEventListener('click', async () => {
       balanceMode = 'auto';
       localStorage.setItem('balancerMode', balanceMode);
       applyModeUI();
-      recomputeAutoBalance();
+      await recomputeAutoBalance();
     });
   }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -57,7 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
         safeSet(window.__SESS, cacheKey, JSON.stringify(players));
       }
 
-      initLobby(players, csvLeague);          // Рендер лоббі
+      await initLobby(players, csvLeague);          // Рендер лоббі
       document.getElementById('sec-player-picker')?.classList.add('open');
       await initAvatarAdmin(players, selLeague.value);    // Рендер аватарів
       scenArea.classList.remove('hidden'); // Показ блоку «Режим гри»
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // При зміні ліги — очищуємо поточне лоббі та ховаємо сценарій
   selLeague.addEventListener('change', async () => {
     const csvLeague = window.uiLeagueToCsv(selLeague.value);
-    initLobby([], csvLeague);               // Порожнє лоббі
+    await initLobby([], csvLeague);               // Порожнє лоббі
     await initAvatarAdmin([], selLeague.value);
     scenArea.classList.add('hidden');
     document.getElementById('ui-panel').hidden = false;

--- a/scripts/scenario.js
+++ b/scripts/scenario.js
@@ -41,14 +41,19 @@ function updateStartButton() {
 }
 
 /** Авто-баланс: N=2 чи N>2 */
-export function recomputeAutoBalance() {
+export async function recomputeAutoBalance() {
   if (balanceMode !== 'auto') return;
   if (!teamSizeSel || !arenaSelect || !arenaCheckboxes || !btnStart) return;
 
   const n = +teamSizeSel.value;
   if (!Number.isInteger(n) || n <= 0) return;
 
-  setManualCount(n);    // сповіщаємо lobby.js, скільки кнопок “→…” малювати
+  try {
+    await setManualCount(n);    // сповіщаємо lobby.js, скільки кнопок “→…” малювати
+  } catch (err) {
+    console.error('recomputeAutoBalance: failed to set manual count', err);
+    return;
+  }
   let data;
   if (n === 2) {
     const { A, B } = autoBalance2(lobby);
@@ -62,14 +67,23 @@ export function recomputeAutoBalance() {
   updateStartButton();
 }
 
-function handleAuto() {
-  triggerRecomputeAutoBalance();
+async function handleAuto() {
+  try {
+    await triggerRecomputeAutoBalance();
+  } catch (err) {
+    console.error('handleAuto: recompute failed', err);
+  }
 }
 
 /** Ручне формування команд */
-function handleManual() {
+async function handleManual() {
   const n = +teamSizeSel.value;
-  setManualCount(n);    // скільки кнопок “→…” робити біля кожного гравця лоббі
+  try {
+    await setManualCount(n);    // скільки кнопок “→…” робити біля кожного гравця лоббі
+  } catch (err) {
+    console.error('handleManual: failed to set manual count', err);
+    return;
+  }
   initTeams(n, {});     // створює пусті масиви teams[1]…teams[n]
   arenaSelect.classList.remove('hidden');
   renderArenaCheckboxes();


### PR DESCRIPTION
## Summary
- remove lobby-side avatarNickKey usage and keep avatar <img> elements seeded only with data-nick and the placeholder source
- await renderAllAvatars with the players root across lobby flows, propagating async handling through lobby helpers and related scenario/balance logic
- update main and arena flows to await the async lobby APIs so worker-delivered avatar updates remain in sync

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cfc6283bac832199000004ee7a3c40