### PR TITLE
Refactor proxy endpoints for GAS and avatars

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,8 +1,5 @@
-export const GAS_BASE_URL = 'https://script.google.com/macros/s/AKfycbzhQgbHauvk-ekGVHGRMUnEk-Rt-9M3QI_Jw-bjkRF4jAqpPtXQSDw3BsmivTHdvUY7Gw/exec';
-export const GAS_JSON_URL = GAS_BASE_URL;
+export const GAS_PROXY_BASE = 'https://laser-proxy.vartaclub.workers.dev';
 export const AVATAR_WORKER_BASE = 'https://avatarsproxy.vartaclub.workers.dev';
-export const AVATARS_FEED = 'https://avatarsproxy.vartaclub.workers.dev/feed';
-export const AVATAR_BY_NICK = 'https://avatarsproxy.vartaclub.workers.dev/avatar';
 export const AVATAR_CACHE_BUST = '2025-09-19-avatars-2';
 export const AVATAR_PLACEHOLDER = 'assets/default_avatars/av0.png';
 export const ASSETS_VER = AVATAR_CACHE_BUST;

--- a/tests/saveResultFallback.test.mjs
+++ b/tests/saveResultFallback.test.mjs
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 
-const { GAS_BASE_URL } = await import('../scripts/config.js');
-const FALLBACK_URL = GAS_BASE_URL;
+let FALLBACK_URL = '';
 
 const sessionStore = new Map();
 const fakeWindow = {
@@ -49,7 +48,7 @@ globalThis.fetch = async (url, options) => {
       body: '<html>Bad Gateway</html>'
     });
   }
-  if (url === FALLBACK_URL) {
+  if (FALLBACK_URL && url === FALLBACK_URL) {
     return createResponse({
       ok: true,
       status: 200,
@@ -62,7 +61,11 @@ globalThis.fetch = async (url, options) => {
 
 fakeWindow.fetch = (...args) => globalThis.fetch(...args);
 
-const { saveResult, PROXY_ORIGIN } = await import('../scripts/api.js');
+const { saveResult, PROXY_ORIGIN, GAS_PROXY_ORIGIN } = await import('../scripts/api.js');
+
+FALLBACK_URL = GAS_PROXY_ORIGIN;
+
+assert.ok(FALLBACK_URL);
 
 assert.equal(window.GAS_FALLBACK_URL, undefined);
 


### PR DESCRIPTION
## Summary
- switch configuration to the new GAS proxy base and compute avatar endpoints from the worker base
- update the API helpers to derive avatar URLs, expose the proxy fallback origin, and post JSON through the proxy
- refresh the avatar client module to share the new base helpers and feed path logic
- adjust the saveResult fallback test to target the proxy origin instead of the legacy GAS URL

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cfcedb5eb08321a2b28b5d25b35df6