### PR TITLE
Revamp avatar client loader

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -212,7 +212,7 @@
   <script type="module" src="./scripts/logger.js?v=2025-09-19-avatars-3"></script>
   <script type="module" src="./scripts/config.js?v=2025-09-19-avatars-3"></script>
   <script type="module" src="./scripts/api.js?v=2025-09-19-avatars-3"></script>
-  <script type="module" src="./scripts/avatars.client.js?v=2025-09-19-avatars-3"></script>
+  <script type="module" src="./scripts/avatars.client.js"></script>
   <script type="module" src="./scripts/balanceUtils.js?v=2025-09-19-avatars-3"></script>
   <script type="module" src="./scripts/teams.js?v=2025-09-19-avatars-3"></script>
   <script type="module" src="./scripts/lobby.js?v=2025-09-19-avatars-3"></script>

--- a/gameday.html
+++ b/gameday.html
@@ -172,7 +172,7 @@
   <script type="module" src="scripts/config.js?v=2025-09-19-avatars-2"></script>
   <script type="module" src="scripts/logger.js?v=2025-09-19-avatars-2"></script>
   <script type="module" src="scripts/api.js?v=2025-09-19-avatars-2"></script>
-  <script type="module" src="scripts/avatars.client.js?v=2025-09-19-avatars-2"></script>
+  <script type="module" src="scripts/avatars.client.js"></script>
   <script type="module" src="scripts/gameday.js?v=2025-09-19-avatars-2"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@
     <script type="module" src="scripts/logger.js?v=2025-09-19-avatars-3"></script>
     <script type="module" src="scripts/config.js?v=2025-09-19-avatars-3"></script>
     <script type="module" src="scripts/api.js?v=2025-09-19-avatars-3"></script>
-    <script type="module" src="scripts/avatars.client.js?v=2025-09-19-avatars-3"></script>
+    <script type="module" src="scripts/avatars.client.js"></script>
     <script type="module" src="scripts/quickStats.js?v=2025-09-19-avatars-3"></script>
     <script type="module" src="scripts/ranking.js?v=2025-09-19-avatars-3"></script>
   </body>

--- a/scripts/avatar.js
+++ b/scripts/avatar.js
@@ -1,6 +1,6 @@
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-2';
 import { avatarNickKey } from './api.js?v=2025-09-19-avatars-2';
-import { renderAllAvatars } from './avatars.client.js?v=2025-09-19-avatars-2';
+import { renderAllAvatars } from './avatars.client.js';
 
 export async function setAvatar(img, nick, { width, height } = {}) {
   if (!img) return;

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,15 +1,15 @@
 // scripts/avatarAdmin.js
 import { log } from './logger.js?v=2025-09-19-avatars-2';
-import { uploadAvatar, loadPlayers, fetchAvatarForNick } from './api.js?v=2025-09-19-avatars-2';
+import { uploadAvatar, loadPlayers, fetchAvatarForNick, avatarNickKey } from './api.js?v=2025-09-19-avatars-2';
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-2';
-import { reloadAvatars, norm } from './avatars.client.js?v=2025-09-19-avatars-2';
+import { reloadAvatars } from './avatars.client.js';
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024;
 
 export let avatarFailures = 0;
 
 function nickKey(value) {
-  return norm(value);
+  return avatarNickKey(value);
 }
 
 export function noteAvatarFailure(nick, reason) {

--- a/scripts/avatars.client.js
+++ b/scripts/avatars.client.js
@@ -1,212 +1,38 @@
-import {
-  AVATAR_PLACEHOLDER,
-  AVATAR_CACHE_BUST,
-  AVATAR_WORKER_BASE,
-  ASSETS_VER
-} from './config.js?v=2025-09-19-avatars-2';
+import { AVATAR_WORKER_BASE, AVATAR_PLACEHOLDER } from './config.js';
 
-const ZERO_WIDTH_CHARS_RE = /[\u200B-\u200D\u2060\uFEFF]/g;
-const COMBINING_MARKS_RE = /[\u0300-\u036f\u1ab0-\u1aff\u1dc0-\u1dff\u20d0-\u20ff\uFE20-\uFE2F]/g;
-const WHITESPACE_RE = /\s+/g;
+const RAW_BASE = typeof AVATAR_WORKER_BASE === 'string' ? AVATAR_WORKER_BASE.trim() : '';
+const NORMALIZED_BASE = RAW_BASE ? RAW_BASE.replace(/\/+$/, '') : '';
+const FEED = NORMALIZED_BASE ? `${NORMALIZED_BASE}/avatars` : '';
+const BY_NICK = FEED ? `${FEED}/` : '';
 
-const HOMOGRAPH_MAP = Object.freeze({
-  '\u0131': 'i', // dotless i → i
-  '\u03b1': 'a', // greek alpha → a
-  '\u03b5': 'e', // greek epsilon → e
-  '\u03ba': 'k', // greek kappa → k
-  '\u03bf': 'o', // greek omicron → o
-  '\u03c1': 'p', // greek rho → p
-  '\u03c5': 'y', // greek upsilon → y
-  '\u03c7': 'x', // greek chi → x
-  '\u0430': 'a', // cyrillic a → a
-  '\u0435': 'e', // cyrillic ie → e
-  '\u043a': 'k', // cyrillic ka → k
-  '\u043e': 'o', // cyrillic o → o
-  '\u0440': 'p', // cyrillic er → p
-  '\u0441': 'c', // cyrillic es → c
-  '\u0443': 'y', // cyrillic u → y
-  '\u0445': 'x', // cyrillic ha → x
-  '\u0454': 'e', // cyrillic ie → e
-  '\u0456': 'i', // cyrillic i → i
-  '\u0457': 'i'  // cyrillic yi → i
-});
-
-const HOMOGRAPH_PATTERN = (() => {
-  const chars = Object.keys(HOMOGRAPH_MAP);
-  if (!chars.length) return null;
-  const escaped = chars.map(ch => ch.replace(/[\\\]\[\-]/g, '\\$&')).join('');
-  return new RegExp(`[${escaped}]`, 'gu');
-})();
-
-const runtimeRoot = typeof window !== 'undefined' ? window : globalThis;
-const headerTemplate = {};
-if (runtimeRoot && runtimeRoot.AVATAR_HEADERS && typeof runtimeRoot.AVATAR_HEADERS === 'object') {
-  Object.assign(headerTemplate, runtimeRoot.AVATAR_HEADERS);
-}
-const originHeader = runtimeRoot?.location?.origin ? String(runtimeRoot.location.origin) : '';
-if (originHeader && !headerTemplate['x-avatar-origin']) headerTemplate['x-avatar-origin'] = originHeader;
-const assetVersion = trimConfigValue(ASSETS_VER) || trimConfigValue(AVATAR_CACHE_BUST);
-if (assetVersion && !headerTemplate['x-avatar-version']) headerTemplate['x-avatar-version'] = assetVersion;
-if (!headerTemplate['x-avatar-proxy']) headerTemplate['x-avatar-proxy'] = 'laser-tag-ranking';
-const AV_HEADERS = Object.freeze(headerTemplate);
-
-const WORKER_BASE_URL = prepareWorkerBase(AVATAR_WORKER_BASE);
-const AVATAR_COLLECTION_URL = buildWorkerUrl(WORKER_BASE_URL, 'avatars');
-const FEED_ENDPOINT = AVATAR_COLLECTION_URL;
-const AVATAR_ENDPOINT = ensureTrailingSlash(AVATAR_COLLECTION_URL);
-const CACHE_BUST_SEED = trimConfigValue(AVATAR_CACHE_BUST);
-
-const state = {
-  mapping: Object.create(null),
-  updatedAt: 0,
-  lastSync: 0
-};
-
+const mapping = new Map();
+let lastUpdated = 0;
 let feedPromise = null;
 let feedPromiseIsFresh = false;
-const nickRequests = new Map();
+const pendingByKey = new Map();
 
-export function norm(value) {
+function norm(value) {
   if (value == null) return '';
-  const input = String(value);
-  const trimmed = input.trim().toLowerCase();
-  if (!trimmed) return '';
-  const decomposed = trimmed.normalize('NFKD');
-  const withoutMarks = decomposed.replace(COMBINING_MARKS_RE, '');
-  const withoutZeroWidth = withoutMarks.replace(ZERO_WIDTH_CHARS_RE, '');
-  const collapsed = withoutZeroWidth.replace(WHITESPACE_RE, ' ').trim();
-  if (!collapsed) return '';
-  const replaced = HOMOGRAPH_PATTERN
-    ? collapsed.replace(HOMOGRAPH_PATTERN, ch => HOMOGRAPH_MAP[ch] || '')
-    : collapsed;
-  return replaced;
+  return String(value).trim().toLowerCase();
 }
 
-function trimConfigValue(value) {
-  return typeof value === 'string' ? value.trim() : '';
+function bustUrl(url, stamp = Date.now()) {
+  const base = typeof url === 'string' ? url.trim() : '';
+  if (!base) return '';
+  const value = typeof stamp === 'number' && Number.isFinite(stamp) ? stamp : Date.now();
+  const separator = base.includes('?') ? '&' : '?';
+  return `${base}${separator}t=${value}`;
 }
 
-function ensureTrailingSlash(url) {
-  if (!url) return url;
-  return url.endsWith('/') ? url : `${url}/`;
-}
-
-function prepareWorkerBase(rawBase) {
-  const trimmed = trimConfigValue(rawBase);
-  if (!trimmed) return '';
-  try {
-    const urlObj = new URL(trimmed);
-    urlObj.search = '';
-    if (!urlObj.pathname.endsWith('/')) urlObj.pathname += '/';
-    return urlObj.toString();
-  } catch {
-    return '';
-  }
-}
-
-function buildWorkerUrl(baseUrl, relativePath = '') {
-  if (!baseUrl) return '';
-  const segment = typeof relativePath === 'string' ? relativePath.trim() : '';
-  if (!segment) return baseUrl;
-  try {
-    const normalized = segment.startsWith('/') ? segment.slice(1) : segment;
-    const resolved = new URL(normalized, baseUrl);
-    return resolved.toString();
-  } catch {
-    return '';
-  }
-}
-
-function buildCacheBust(...parts) {
-  const tokens = [];
-  for (const part of parts) {
-    if (typeof part === 'number') {
-      if (Number.isFinite(part) && part > 0) tokens.push(String(part));
-    } else {
-      const value = trimConfigValue(part);
-      if (value) tokens.push(value);
-    }
-  }
-  return tokens.join('-');
-}
-
-function appendCacheBust(url, bustValue) {
-  if (!url) return url;
-  const trimmed = trimConfigValue(bustValue);
-  if (!trimmed) return url;
-  try {
-    const u = new URL(url);
-    u.searchParams.set('t', trimmed);
-    return u.toString();
-  } catch {
-    const separator = url.includes('?') ? '&' : '?';
-    return `${url}${separator}t=${encodeURIComponent(trimmed)}`;
-  }
-}
-
-function resolveUpdatedAt(headers, fallback = Date.now()) {
-  if (!headers || typeof headers.get !== 'function') return fallback;
-  const direct = headers.get('x-avatar-updated-at') || headers.get('x-updated-at');
-  if (direct) {
-    const numeric = Number(direct);
-    if (Number.isFinite(numeric) && numeric > 0) return numeric;
-    const parsed = Date.parse(direct);
+function extractUpdatedAt(input) {
+  if (typeof input === 'number' && Number.isFinite(input)) return input;
+  if (typeof input === 'string') {
+    const numeric = Number(input);
+    if (Number.isFinite(numeric)) return numeric;
+    const parsed = Date.parse(input);
     if (!Number.isNaN(parsed)) return parsed;
   }
-  const lastModified = headers.get('last-modified');
-  if (lastModified) {
-    const parsed = Date.parse(lastModified);
-    if (!Number.isNaN(parsed)) return parsed;
-  }
-  return fallback;
-}
-
-function sanitizeMapping(rawMapping) {
-  const mapping = Object.create(null);
-  if (!rawMapping || typeof rawMapping !== 'object') return mapping;
-  for (const [rawKey, rawUrl] of Object.entries(rawMapping)) {
-    const key = norm(rawKey);
-    const url = typeof rawUrl === 'string' ? rawUrl.trim() : '';
-    if (key && url) mapping[key] = url;
-  }
-  return mapping;
-}
-
-function sanitizeEntries(entries) {
-  const mapping = Object.create(null);
-  if (!Array.isArray(entries)) return mapping;
-  for (const entry of entries) {
-    if (!entry || entry.length < 2) continue;
-    const [nick, url] = entry;
-    const key = norm(nick);
-    const trimmed = typeof url === 'string' ? url.trim() : '';
-    if (key && trimmed) mapping[key] = trimmed;
-  }
-  return mapping;
-}
-
-function parseFeedPayload(raw, headers) {
-  if (!raw || typeof raw !== 'object') return null;
-
-  let mapping = null;
-  if (raw.mapping && typeof raw.mapping === 'object') {
-    mapping = sanitizeMapping(raw.mapping);
-  } else if (Array.isArray(raw.entries)) {
-    mapping = sanitizeEntries(raw.entries);
-  }
-
-  if (!mapping) mapping = Object.create(null);
-  const updatedAt = Number.isFinite(raw.updatedAt) ? raw.updatedAt : resolveUpdatedAt(headers, Date.now());
-  return { mapping, updatedAt };
-}
-
-function replaceMapping(nextMapping, updatedAt) {
-  state.mapping = Object.create(null);
-  for (const [key, url] of Object.entries(nextMapping || {})) {
-    state.mapping[key] = url;
-  }
-  state.updatedAt = Number.isFinite(updatedAt) ? updatedAt : Date.now();
-  state.lastSync = Date.now();
+  return 0;
 }
 
 function resolveRoot(root) {
@@ -215,16 +41,19 @@ function resolveRoot(root) {
   return null;
 }
 
-function ensureImageElement(target) {
-  if (!target) return null;
-  if (target.tagName && target.tagName.toLowerCase() === 'img') return target;
-  if (typeof target.querySelector === 'function') {
-    const existing = target.querySelector('img[data-nick]') || target.querySelector('img.avatar') || target.querySelector('img');
-    if (existing) return existing;
-    const created = target.ownerDocument?.createElement('img') || document?.createElement?.('img');
-    if (!created) return null;
+function ensureImageElement(node) {
+  if (!node) return null;
+  if (node.tagName && node.tagName.toLowerCase() === 'img') return node;
+  if (typeof node.querySelector === 'function') {
+    const found = node.querySelector('img.avatar')
+      || node.querySelector('img[data-nick]')
+      || node.querySelector('img');
+    if (found) return found;
+    const doc = node.ownerDocument || (typeof document !== 'undefined' ? document : null);
+    if (!doc) return null;
+    const created = doc.createElement('img');
     created.classList.add('avatar');
-    target.prepend(created);
+    node.prepend(created);
     return created;
   }
   return null;
@@ -241,61 +70,45 @@ function seedPlaceholder(img, nick) {
   }
 }
 
-function applyImage(img, url, bustSource) {
-  if (!img) return;
-  const stamp = Number.isFinite(bustSource) ? bustSource : Date.now();
-  const bust = buildCacheBust(CACHE_BUST_SEED, stamp);
-  const baseUrl = typeof url === 'string' && url ? url : '';
-  if (!baseUrl) {
-    img.onerror = null;
-    img.src = AVATAR_PLACEHOLDER;
-    return;
-  }
-  const fallback = appendCacheBust(AVATAR_PLACEHOLDER, bust) || AVATAR_PLACEHOLDER;
-  const target = appendCacheBust(baseUrl, bust) || baseUrl;
-  img.onerror = () => {
-    img.onerror = null;
-    img.src = fallback;
-  };
-  img.src = target;
-}
-
 function prepareTarget(node) {
   const img = ensureImageElement(node);
   if (!img) return null;
 
-  const containerNick = typeof node?.dataset?.nick === 'string' ? node.dataset.nick : '';
-  const imageNick = typeof img.dataset?.nick === 'string' ? img.dataset.nick : '';
-  const rawNick = imageNick || containerNick || '';
-  const trimmed = rawNick.trim();
+  const rawNick = (() => {
+    if (typeof img.dataset?.nick === 'string' && img.dataset.nick.trim()) return img.dataset.nick;
+    if (node !== img && typeof node.dataset?.nick === 'string' && node.dataset.nick.trim()) return node.dataset.nick;
+    const imgAttr = typeof img.getAttribute === 'function' ? img.getAttribute('data-nick') : '';
+    const nodeAttr = node !== img && typeof node.getAttribute === 'function' ? node.getAttribute('data-nick') : '';
+    return imgAttr || nodeAttr || '';
+  })();
 
-  if (node !== img && containerNick !== trimmed) {
-    if (trimmed) node.dataset.nick = trimmed;
-    else delete node.dataset.nick;
+  const nick = rawNick.trim();
+
+  if (nick) {
+    img.dataset.nick = nick;
+    if (node !== img) node.dataset.nick = nick;
+  } else {
+    delete img.dataset.nick;
+    if (node !== img) delete node.dataset.nick;
   }
 
-  if (imageNick !== trimmed) {
-    if (trimmed) img.dataset.nick = trimmed;
-    else delete img.dataset.nick;
-  }
-
-  const key = norm(trimmed);
+  const key = norm(nick);
   if (key) img.dataset.nickKey = key;
   else delete img.dataset.nickKey;
 
-  seedPlaceholder(img, trimmed);
-  return { img, nick: trimmed, key };
+  seedPlaceholder(img, nick);
+  return { img, nick, key };
 }
 
 function collectTargets(scope) {
   const seen = new Set();
-  const result = [];
+  const targets = [];
 
   scope.querySelectorAll('img[data-nick]').forEach(img => {
     const entry = prepareTarget(img);
     if (entry && !seen.has(entry.img)) {
       seen.add(entry.img);
-      result.push(entry);
+      targets.push(entry);
     }
   });
 
@@ -303,196 +116,209 @@ function collectTargets(scope) {
     const entry = prepareTarget(node);
     if (entry && !seen.has(entry.img)) {
       seen.add(entry.img);
-      result.push(entry);
+      targets.push(entry);
     }
   });
 
-  return result;
+  return targets;
 }
 
-async function loadFeed({ fresh = false } = {}) {
+function applyFeedPayload(payload) {
+  if (!payload || typeof payload !== 'object') return;
+
+  const next = new Map();
+  let shouldReplace = false;
+  if (Array.isArray(payload.entries)) {
+    shouldReplace = true;
+    for (const entry of payload.entries) {
+      if (!entry || entry.length < 2) continue;
+      const key = norm(entry[0]);
+      const url = typeof entry[1] === 'string' ? entry[1].trim() : '';
+      if (key && url) next.set(key, url);
+    }
+  } else {
+    const mappingSource = typeof payload.mapping === 'object' && payload.mapping
+      ? payload.mapping
+      : (typeof payload.avatars === 'object' && payload.avatars ? payload.avatars : null);
+    if (mappingSource) {
+      shouldReplace = true;
+      for (const [nick, url] of Object.entries(mappingSource)) {
+        const key = norm(nick);
+        const value = typeof url === 'string' ? url.trim() : '';
+        if (key && value) next.set(key, value);
+      }
+    }
+  }
+
+  if (!next.size && !Array.isArray(payload.entries) && typeof payload === 'object') {
+    const fallback = Object.entries(payload).filter(([k]) => k !== 'updatedAt');
+    if (fallback.length) shouldReplace = true;
+    for (const [nick, url] of fallback) {
+      const key = norm(nick);
+      const value = typeof url === 'string' ? url.trim() : '';
+      if (key && value) next.set(key, value);
+    }
+  }
+
+  if (shouldReplace) {
+    mapping.clear();
+    for (const [key, url] of next.entries()) {
+      mapping.set(key, url);
+    }
+  }
+
+  const updated = extractUpdatedAt(payload.updatedAt);
+  if (updated) lastUpdated = updated;
+  else if (shouldReplace) lastUpdated = Date.now();
+}
+
+async function loadFeed(fresh = false) {
+  if (!FEED) return mapping;
+  if (!fresh && lastUpdated && !feedPromise) return mapping;
+
   if (feedPromise) {
-    if (!fresh || feedPromiseIsFresh) return feedPromise;
+    if (fresh && !feedPromiseIsFresh) {
+      return feedPromise.finally(() => loadFeed(true));
+    }
+    return feedPromise;
   }
 
-  if (!fresh && state.lastSync && Date.now() - state.lastSync < 30_000) {
-    return state.mapping;
-  }
-
-  const request = (async () => {
-    if (!FEED_ENDPOINT) return state.mapping;
-
-    const bust = buildCacheBust(CACHE_BUST_SEED, fresh ? Date.now() : '');
-    const targetUrl = appendCacheBust(FEED_ENDPOINT, bust);
-
-    let response;
+  const url = fresh ? bustUrl(FEED, Date.now()) : FEED;
+  feedPromiseIsFresh = fresh;
+  feedPromise = (async () => {
     try {
-      response = await fetch(targetUrl, {
-        method: 'GET',
-        headers: { ...AV_HEADERS, 'Cache-Control': 'no-cache' }
-      });
+      const response = await fetch(url, { cache: 'no-store' });
+      if (!response || !response.ok) {
+        console.warn('[avatars] feed status', response?.status);
+        return mapping;
+      }
+      let data = null;
+      try {
+        data = await response.json();
+      } catch (err) {
+        console.warn('[avatars] feed parse failed', err);
+        data = null;
+      }
+      if (data) applyFeedPayload(data);
     } catch (err) {
       console.warn('[avatars] feed fetch failed', err);
-      return state.mapping;
-    }
-
-    if (!response || !response.ok) {
-      console.warn('[avatars] feed status', response?.status);
-      return state.mapping;
-    }
-
-    let data = null;
-    try {
-      data = await response.json();
-    } catch (err) {
-      console.warn('[avatars] feed parse failed', err);
-      data = null;
-    }
-
-    const parsed = parseFeedPayload(data, response.headers);
-    if (parsed) {
-      replaceMapping(parsed.mapping, parsed.updatedAt);
-      const size = Object.keys(state.mapping).length;
-      console.log(`[avatars] feed size=${size} updatedAt=${state.updatedAt}`);
-    }
-
-    return state.mapping;
-  })();
-
-  feedPromise = request;
-  feedPromiseIsFresh = fresh;
-
-  try {
-    return await request;
-  } finally {
-    if (feedPromise === request) {
+    } finally {
       feedPromise = null;
       feedPromiseIsFresh = false;
     }
-  }
+    return mapping;
+  })();
+
+  return feedPromise;
 }
 
-async function fetchAvatarRecord(nick, { fresh = false } = {}) {
-  const original = typeof nick === 'string' ? nick.trim() : '';
-  const key = norm(original);
-  if (!key) {
-    return { url: '', updatedAt: Date.now() };
+function setImage(img, url, stamp) {
+  if (!img) return;
+  const cacheStamp = typeof stamp === 'number' && Number.isFinite(stamp) ? stamp : Date.now();
+  const targetUrl = url ? bustUrl(url, cacheStamp) : '';
+  const fallbackUrl = bustUrl(AVATAR_PLACEHOLDER, cacheStamp) || AVATAR_PLACEHOLDER;
+  img.onerror = () => {
+    img.onerror = null;
+    img.src = fallbackUrl;
+  };
+  img.src = targetUrl || fallbackUrl;
+}
+
+async function fetchAvatarForEntry(entry) {
+  if (!entry || !entry.key || !entry.nick || !BY_NICK) {
+    setImage(entry?.img, '', lastUpdated);
+    return;
   }
 
-  if (!fresh) {
-    const cached = state.mapping[key];
-    if (cached) return { url: cached, updatedAt: state.updatedAt || Date.now() };
-    if (nickRequests.has(key)) return nickRequests.get(key);
+  if (mapping.has(entry.key)) {
+    setImage(entry.img, mapping.get(entry.key), lastUpdated);
+    return;
   }
 
-  if (!AVATAR_ENDPOINT) {
-    return { url: '', updatedAt: Date.now() };
+  if (pendingByKey.has(entry.key)) {
+    await pendingByKey.get(entry.key);
+    const cached = mapping.get(entry.key) || '';
+    setImage(entry.img, cached, lastUpdated);
+    return;
   }
 
   const request = (async () => {
-    const bust = buildCacheBust(CACHE_BUST_SEED, Date.now());
-    const target = appendCacheBust(`${AVATAR_ENDPOINT}${encodeURIComponent(original)}`, bust);
-
-    let response;
+    const url = bustUrl(`${BY_NICK}${encodeURIComponent(entry.nick)}`, Date.now());
     try {
-      response = await fetch(target, {
-        method: 'GET',
-        headers: { ...AV_HEADERS, 'Cache-Control': 'no-cache' }
-      });
+      const response = await fetch(url, { cache: 'no-store' });
+      if (!response || !response.ok) {
+        console.warn('[avatars] nick status', response?.status);
+        return;
+      }
+      let data = null;
+      try {
+        data = await response.json();
+      } catch (err) {
+        console.warn('[avatars] nick parse failed', err);
+        data = null;
+      }
+      const resolvedUrl = typeof data?.url === 'string' ? data.url.trim() : '';
+      const updated = extractUpdatedAt(data?.updatedAt) || Date.now();
+      if (resolvedUrl) {
+        mapping.set(entry.key, resolvedUrl);
+        lastUpdated = updated;
+        setImage(entry.img, resolvedUrl, updated);
+        return;
+      }
     } catch (err) {
       console.warn('[avatars] nick fetch failed', err);
-      return { url: '', updatedAt: Date.now() };
     }
-
-    if (!response || !response.ok) {
-      console.warn('[avatars] nick status', response?.status);
-      return { url: '', updatedAt: Date.now() };
-    }
-
-    let data = null;
-    try {
-      data = await response.json();
-    } catch (err) {
-      console.warn('[avatars] nick parse failed', err);
-      data = null;
-    }
-
-    const rawUrl = data && typeof data.url === 'string' ? data.url.trim() : '';
-    const updatedAtCandidate = Number.isFinite(data?.updatedAt) ? data.updatedAt : resolveUpdatedAt(response.headers, Date.now());
-    if (rawUrl) {
-      state.mapping[key] = rawUrl;
-      state.updatedAt = Math.max(state.updatedAt, updatedAtCandidate);
-      state.lastSync = Date.now();
-    }
-
-    return { url: rawUrl, updatedAt: updatedAtCandidate };
+    setImage(entry.img, '', Date.now());
   })();
 
-  nickRequests.set(key, request);
+  pendingByKey.set(entry.key, request);
   try {
-    return await request;
+    await request;
   } finally {
-    if (nickRequests.get(key) === request) {
-      nickRequests.delete(key);
+    if (pendingByKey.get(entry.key) === request) {
+      pendingByKey.delete(entry.key);
     }
   }
 }
 
-async function resolveMiss(entry, fallbackBust) {
-  const record = await fetchAvatarRecord(entry.nick);
-  const url = record?.url || '';
-  const bust = Number.isFinite(record?.updatedAt) ? record.updatedAt : fallbackBust;
-  if (entry.key && url) entry.img.dataset.nickKey = entry.key;
-  applyImage(entry.img, url, bust);
-}
-
-export async function renderAllAvatars(root) {
+export async function renderAllAvatars(root = typeof document !== 'undefined' ? document : undefined) {
   const scope = resolveRoot(root);
   if (!scope) return;
 
   const targets = collectTargets(scope);
-  if (!targets.length) return;
+  if (!targets.length) {
+    console.log('[avatars] imgs=0');
+    return;
+  }
 
-  await loadFeed({ fresh: false });
+  await loadFeed(false);
 
-  const fallbackBust = state.updatedAt || Date.now();
-  const pending = [];
-
+  const jobs = [];
   for (const entry of targets) {
     if (!entry.key) {
-      applyImage(entry.img, '', fallbackBust);
+      setImage(entry.img, '', lastUpdated);
       continue;
     }
 
-    const url = state.mapping[entry.key];
-    if (url) {
-      applyImage(entry.img, url, state.updatedAt);
+    const cached = mapping.get(entry.key) || '';
+    if (cached) {
+      setImage(entry.img, cached, lastUpdated);
       continue;
     }
 
-    if (!AVATAR_ENDPOINT) {
-      applyImage(entry.img, '', fallbackBust);
-      continue;
-    }
-
-    pending.push(resolveMiss(entry, fallbackBust));
+    jobs.push(fetchAvatarForEntry(entry));
   }
 
-  if (pending.length) {
-    await Promise.allSettled(pending);
+  if (jobs.length) {
+    await Promise.allSettled(jobs);
   }
+
+  console.log(`[avatars] imgs=${targets.length}`);
 }
 
-export async function reloadAvatars(options = {}) {
-  const { root = undefined, fresh = false } = options || {};
-  await loadFeed({ fresh: Boolean(fresh) });
+export async function reloadAvatars(root = typeof document !== 'undefined' ? document : undefined) {
+  await loadFeed(true);
   await renderAllAvatars(root);
-}
-
-export function getAvatarUrlSync(nick) {
-  const key = norm(nick);
-  if (!key) return '';
-  return state.mapping[key] || '';
 }
 
 if (typeof document !== 'undefined' && document.addEventListener) {
@@ -502,4 +328,3 @@ if (typeof document !== 'undefined' && document.addEventListener) {
     });
   });
 }
-

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -2,7 +2,7 @@ import { log } from './logger.js?v=2025-09-19-avatars-2';
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-2';
 import { getPdfLinks, fetchOnce, CSV_URLS, avatarNickKey } from "./api.js?v=2025-09-19-avatars-2";
 import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-avatars-2';
-import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-19-avatars-2';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
 (function () {
   const CSV_TTL = 60 * 1000;
 

--- a/scripts/lobby.js
+++ b/scripts/lobby.js
@@ -13,7 +13,7 @@ import {
 } from './api.js?v=2025-09-19-avatars-2';
 import { saveLobbyState, loadLobbyState, getLobbyStorageKey } from './state.js?v=2025-09-19-avatars-2';
 import { refreshArenaTeams } from './scenario.js?v=2025-09-19-avatars-2';
-import { renderAllAvatars, reloadAvatars } from './avatars.client.js?v=2025-09-19-avatars-2';
+import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
 import { balanceMode, recomputeAutoBalance } from './balance.js?v=2025-09-19-avatars-2';
 
 export let lobby = [];

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,7 +1,7 @@
 import { log } from './logger.js?v=2025-09-19-avatars-2';
 import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, safeSet, safeGet, avatarNickKey, fetchAvatarForNick } from './api.js?v=2025-09-19-avatars-2';
 import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-avatars-2';
-import * as Avatars from './avatars.client.js?v=2025-09-19-avatars-2';
+import * as Avatars from './avatars.client.js';
 import { noteAvatarFailure, setImgSafe, updateInlineAvatarImages } from './avatarAdmin.js?v=2025-09-19-avatars-2';
 import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-2';
 
@@ -249,7 +249,7 @@ async function loadProfile(nick, key = '') {
 
       try {
         if (typeof Avatars.reloadAvatars === 'function') {
-          await Avatars.reloadAvatars({ fresh: true });
+          await Avatars.reloadAvatars();
         }
         if (typeof Avatars.renderAllAvatars === 'function') {
           await Avatars.renderAllAvatars();

--- a/sunday.html
+++ b/sunday.html
@@ -357,7 +357,7 @@
     <script type="module" src="scripts/config.js?v=2025-09-19-avatars-2"></script>
     <script type="module" src="scripts/logger.js?v=2025-09-19-avatars-2"></script>
     <script type="module" src="scripts/api.js?v=2025-09-19-avatars-2"></script>
-    <script type="module" src="scripts/avatars.client.js?v=2025-09-19-avatars-2"></script>
+    <script type="module" src="scripts/avatars.client.js"></script>
     <script type="module" src="scripts/quickStats.js?v=2025-09-19-avatars-2"></script>
     <script type="module" src="scripts/ranking.js?v=2025-09-19-avatars-2"></script>
   </body>


### PR DESCRIPTION
## Summary
- replace the avatar client with the new minimal loader that seeds placeholders, hydrates from the feed, fetches misses per nick, and logs the rendered count
- drop legacy exports and versioned import specifiers while updating callers and HTML entry points to the new avatar client module

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cfd62a74948321b8cb8fdbc42948b1