### PR TITLE
Add shared version constant for balancer release

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -2,4 +2,5 @@ export const GAS_PROXY_BASE = 'https://laser-proxy.vartaclub.workers.dev';
 export const AVATAR_WORKER_BASE = 'https://avatarsproxy.vartaclub.workers.dev';
 export const AVATAR_CACHE_BUST = '2025-09-19-avatars-2';
 export const AVATAR_PLACEHOLDER = 'assets/default_avatars/av0.png';
-export const ASSETS_VER = AVATAR_CACHE_BUST;
+export const VER = '2025-09-19-balance-1';
+export const ASSETS_VER = VER || AVATAR_CACHE_BUST;


### PR DESCRIPTION
## Summary
- add the global VER constant so balancer-related scripts can import the current release version
- base the ASSETS_VER cache-busting token on the new version string while keeping the avatar fallback

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cfe5f195f883218c1a775e59beb2ef