### PR TITLE
Refactor state management for lobby and balance

### DIFF
--- a/scripts/balance.js
+++ b/scripts/balance.js
@@ -1,11 +1,11 @@
 // scripts/balance.js
 
-export let balanceMode = localStorage.getItem('balancerMode') || 'auto';
+import { state, setBalanceMode } from './state.js?v=2025-09-19-avatars-2';
 
 let recomputeHandler = null;
 
 export function getBalanceMode() {
-  return balanceMode;
+  return state.balanceMode;
 }
 
 export function registerRecomputeAutoBalance(fn) {
@@ -27,13 +27,13 @@ export function applyModeUI() {
   const manualBtn = document.getElementById('mode-manual');
 
   if (autoBtn) {
-    autoBtn.classList.toggle('btn-primary', balanceMode === 'auto');
+    autoBtn.classList.toggle('btn-primary', state.balanceMode === 'auto');
   }
   if (manualBtn) {
-    manualBtn.classList.toggle('btn-primary', balanceMode === 'manual');
+    manualBtn.classList.toggle('btn-primary', state.balanceMode === 'manual');
   }
   if (document.body) {
-    document.body.dataset.balanceMode = balanceMode;
+    document.body.dataset.balanceMode = state.balanceMode;
   }
 }
 
@@ -43,8 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (autoBtn) {
     autoBtn.addEventListener('click', async () => {
-      balanceMode = 'auto';
-      localStorage.setItem('balancerMode', balanceMode);
+      setBalanceMode('auto');
       applyModeUI();
       await recomputeAutoBalance();
     });
@@ -52,8 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (manualBtn) {
     manualBtn.addEventListener('click', () => {
-      balanceMode = 'manual';
-      localStorage.setItem('balancerMode', balanceMode);
+      setBalanceMode('manual');
       applyModeUI();
     });
   }

--- a/scripts/scenario.js
+++ b/scripts/scenario.js
@@ -3,8 +3,8 @@
 import { teams, initTeams }          from './teams.js?v=2025-09-19-avatars-2';
 import { autoBalance2, autoBalanceN } from './balanceUtils.js?v=2025-09-19-avatars-2';
 import { lobby, setManualCount }      from './lobby.js?v=2025-09-19-avatars-2';
+import { state }                      from './state.js?v=2025-09-19-avatars-2';
 import {
-  balanceMode,
   registerRecomputeAutoBalance,
   recomputeAutoBalance as triggerRecomputeAutoBalance,
 } from './balance.js?v=2025-09-19-avatars-2';
@@ -42,7 +42,7 @@ function updateStartButton() {
 
 /** Авто-баланс: N=2 чи N>2 */
 export async function recomputeAutoBalance() {
-  if (balanceMode !== 'auto') return;
+  if (state.balanceMode !== 'auto') return;
   if (!teamSizeSel || !arenaSelect || !arenaCheckboxes || !btnStart) return;
 
   const n = +teamSizeSel.value;

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -1,23 +1,123 @@
 import { log } from './logger.js?v=2025-09-19-avatars-2';
 import { safeSet, safeGet } from './api.js?v=2025-09-19-avatars-2';
-export function getLobbyStorageKey(date, league){
-  const d = date || document.getElementById('date')?.value || new Date().toISOString().slice(0,10);
-  const sel = document.getElementById('league');
-  const l = league || sel?.value || '';
+
+const DEFAULT_LEAGUE = 'sundaygames';
+const BALANCE_KEY = 'balancerMode';
+
+function normalizeLeague(league) {
+  return String(league || '').toLowerCase() === 'kids' ? 'kids' : DEFAULT_LEAGUE;
+}
+
+function normalizeBalanceMode(mode) {
+  return mode === 'manual' ? 'manual' : 'auto';
+}
+
+function resolveLocalStorage() {
+  try {
+    if (typeof window !== 'undefined' && window && window.localStorage) {
+      return window.localStorage;
+    }
+  } catch (err) {
+    log('[ranking]', err);
+  }
+  try {
+    if (typeof localStorage !== 'undefined') {
+      return localStorage;
+    }
+  } catch (err) {
+    log('[ranking]', err);
+  }
+  return null;
+}
+
+const localStore = resolveLocalStorage();
+
+function readStoredBalanceMode() {
+  const stored = safeGet(localStore, BALANCE_KEY);
+  return normalizeBalanceMode(stored);
+}
+
+export const state = {
+  league: DEFAULT_LEAGUE,
+  balanceMode: readStoredBalanceMode(),
+  teamsCount: 0,
+  lobbyPlayers: [],
+  teams: {},
+};
+
+export function setLeague(league) {
+  state.league = normalizeLeague(league ?? state.league);
+  return state.league;
+}
+
+export function setBalanceMode(mode) {
+  state.balanceMode = normalizeBalanceMode(mode);
+  safeSet(localStore, BALANCE_KEY, state.balanceMode);
+  return state.balanceMode;
+}
+
+export function setTeamsCount(count) {
+  const numeric = Number(count);
+  state.teamsCount = Number.isInteger(numeric) && numeric > 0 ? numeric : 0;
+  return state.teamsCount;
+}
+
+export function setLobbyPlayers(players) {
+  state.lobbyPlayers.length = 0;
+  if (Array.isArray(players)) {
+    state.lobbyPlayers.push(...players);
+  }
+  return state.lobbyPlayers;
+}
+
+export function setTeams(teamsMap = {}) {
+  Object.keys(state.teams).forEach(key => {
+    delete state.teams[key];
+  });
+  if (teamsMap && typeof teamsMap === 'object') {
+    Object.entries(teamsMap).forEach(([key, list]) => {
+      state.teams[key] = Array.isArray(list) ? [...list] : [];
+    });
+  }
+  return state.teams;
+}
+
+function resolveLeague(value) {
+  return normalizeLeague(value ?? state.league);
+}
+
+export function getLobbyStorageKey(date, league) {
+  const doc = typeof document !== 'undefined' ? document : null;
+  const d = date || doc?.getElementById('date')?.value || new Date().toISOString().slice(0, 10);
+  const sel = doc?.getElementById('league');
+  const l = resolveLeague(league ?? sel?.value);
   return `lobby::${d}::${l}`;
 }
 
-export function saveLobbyState({lobby, teams, manualCount, league}){
-  const key = getLobbyStorageKey(undefined, league);
-  safeSet(localStorage, key, JSON.stringify({lobby, teams, manualCount}));
+export function saveLobbyState(snapshot = {}) {
+  const lobbyPlayers = snapshot.lobbyPlayers ?? snapshot.lobby ?? state.lobbyPlayers;
+  const teams = snapshot.teams ?? state.teams;
+  const teamsCount = snapshot.teamsCount ?? snapshot.manualCount ?? state.teamsCount;
+  const league = resolveLeague(snapshot.league);
+  const key = getLobbyStorageKey(snapshot.date, league);
+  safeSet(localStore, key, JSON.stringify({
+    lobby: lobbyPlayers,
+    teams,
+    manualCount: teamsCount,
+  }));
 }
 
-export function loadLobbyState(league){
+export function loadLobbyState(league) {
   const key = getLobbyStorageKey(undefined, league);
-  const data = safeGet(localStorage, key);
+  const data = safeGet(localStore, key);
   if (!data) return null;
   try {
-    return JSON.parse(data);
+    const parsed = JSON.parse(data);
+    return {
+      lobbyPlayers: Array.isArray(parsed?.lobby) ? parsed.lobby : [],
+      teams: parsed?.teams && typeof parsed.teams === 'object' ? parsed.teams : {},
+      teamsCount: Number.isInteger(parsed?.manualCount) ? parsed.manualCount : 0,
+    };
   } catch (err) {
     log('[ranking]', err);
     return null;

--- a/scripts/teams.js
+++ b/scripts/teams.js
@@ -1,17 +1,21 @@
-import { saveLobbyState } from './state.js?v=2025-09-19-avatars-2';
-import { lobby } from './lobby.js?v=2025-09-19-avatars-2';
+import { state, setTeamsCount, setTeams, saveLobbyState } from './state.js?v=2025-09-19-avatars-2';
 
-export let teams = {};
+export const teams = state.teams;
 
-export function initTeams(n, data) {
+export function initTeams(n, data = {}) {
   const area = document.getElementById('teams-area');
+  if (!area) return;
+
   area.innerHTML = '';
   area.classList.remove('hidden');
-  teams = {};
-  for (let i=1;i<=n;i++){
-    const arr = data[i]||[];
-    teams[i] = arr;
-    const sum = arr.reduce((s,p)=>s+p.pts,0);
+
+  setTeamsCount(n);
+  setTeams({});
+
+  for (let i = 1; i <= state.teamsCount; i++) {
+    const arr = Array.isArray(data?.[i]) ? [...data[i]] : [];
+    state.teams[i] = arr;
+    const sum = arr.reduce((s, p) => s + (Number(p.pts) || 0), 0);
     const div = document.createElement('div');
     div.className = `card team-box team-${i}`;
     div.innerHTML = `
@@ -19,9 +23,10 @@ export function initTeams(n, data) {
         <input type="checkbox" class="team-select" data-team="${i}">
         Команда ${i} (∑ ${sum})
       </label>
-      <ul>${arr.map(p=>`<li class="rank-${p.rank}">${p.nick} (${p.pts})</li>`).join('')}</ul>
+      <ul>${arr.map(p => `<li class="rank-${p.rank}">${p.nick} (${p.pts})</li>`).join('')}</ul>
     `;
     area.append(div);
   }
-  saveLobbyState({lobby, teams, manualCount: n});
+
+  saveLobbyState();
 }


### PR DESCRIPTION
## Summary
- add a shared state object with helper setters and storage utilities
- update lobby, teams, scenario, and balance modules to consume the central state

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cfeadab8bc8321b18f7e281ae0f23c