### PR TITLE
Implement lobby balancing workflow

### DIFF
--- a/scripts/balance.js
+++ b/scripts/balance.js
@@ -1,8 +1,19 @@
 // scripts/balance.js
 
-import { state, setBalanceMode } from './state.js?v=2025-09-19-avatars-2';
+import { loadPlayers, saveResult } from './api.js?v=2025-09-19-avatars-2';
+import { autoBalance2 as autoBalanceTwo, autoBalanceN as autoBalanceMany } from './balanceUtils.js?v=2025-09-19-avatars-2';
+import {
+  state,
+  setBalanceMode,
+  setLeague,
+  setLobbyPlayers,
+  setTeams,
+  setTeamsCount,
+} from './state.js?v=2025-09-19-avatars-2';
 
 let recomputeHandler = null;
+let allPlayers = [];
+const selectedCandidates = new Set();
 
 export function getBalanceMode() {
   return state.balanceMode;
@@ -37,24 +48,435 @@ export function applyModeUI() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+export function addToLobby(playersToAdd = []) {
+  const normalized = Array.isArray(playersToAdd)
+    ? playersToAdd.filter(player => player && typeof player.nick === 'string')
+    : [];
+
+  if (!normalized.length) {
+    console.debug('[balance] add', { added: [], lobbySize: state.lobbyPlayers.length });
+    return state.lobbyPlayers;
+  }
+
+  const existing = new Set(state.lobbyPlayers.map(p => p.nick));
+  const additions = normalized.filter(player => !existing.has(player.nick));
+
+  if (!additions.length) {
+    console.debug('[balance] add', { added: [], lobbySize: state.lobbyPlayers.length });
+    return state.lobbyPlayers;
+  }
+
+  setLobbyPlayers([...state.lobbyPlayers, ...additions]);
+  console.debug('[balance] add', {
+    added: additions.map(p => p.nick),
+    lobbySize: state.lobbyPlayers.length,
+  });
+
+  if (state.balanceMode === 'auto' && state.teamsCount > 0) {
+    const teams = autoBalance(state.lobbyPlayers, state.teamsCount);
+    setTeams(teams);
+  }
+
+  renderLobby();
+  return state.lobbyPlayers;
+}
+
+export function renderLobby() {
+  const lobbyContainer = document.getElementById('lobby-list');
+  if (lobbyContainer) {
+    lobbyContainer.innerHTML = '';
+    state.lobbyPlayers.forEach(player => {
+      const div = document.createElement('div');
+      div.className = 'lobby-player';
+      div.dataset.nick = player.nick;
+      const pts = Number.isFinite(player.pts) ? player.pts : 0;
+      const rank = player.rank || '';
+      div.textContent = `${player.nick} · ${pts} pts${rank ? ` · ${rank}` : ''}`;
+      lobbyContainer.appendChild(div);
+    });
+  }
+
+  updateSummary();
+  updatePlayersDatalist();
+  updateTeamButtonsUI();
+  renderTeams();
+
+  console.debug('[balance] render', {
+    lobbySize: state.lobbyPlayers.length,
+    teamsCount: state.teamsCount,
+    balanceMode: state.balanceMode,
+  });
+}
+
+export function autoBalance(lobby, teamsCount) {
+  const list = Array.isArray(lobby) ? lobby.filter(Boolean) : [];
+  const count = Number.isInteger(teamsCount) ? teamsCount : 0;
+
+  if (count <= 0 || !list.length) {
+    const empty = {};
+    for (let i = 1; i <= Math.max(0, count); i++) {
+      empty[i] = [];
+    }
+    console.debug('[balance] auto', {
+      lobbySize: list.length,
+      teamsCount: count,
+      result: empty,
+    });
+    return empty;
+  }
+
+  let result;
+  if (count === 1) {
+    result = { 1: [...list] };
+  } else if (count === 2) {
+    const { A, B } = autoBalanceTwo(list);
+    result = { 1: [...A], 2: [...B] };
+  } else {
+    result = autoBalanceMany(list, count);
+  }
+
+  console.debug('[balance] auto', {
+    lobbySize: list.length,
+    teamsCount: count,
+    result,
+  });
+
+  return result;
+}
+
+function updateSummary() {
+  const total = state.lobbyPlayers.reduce((sum, player) => sum + (Number(player.pts) || 0), 0);
+  const countEl = document.getElementById('lobby-count');
+  const sumEl = document.getElementById('lobby-sum');
+  const avgEl = document.getElementById('lobby-avg');
+
+  if (countEl) countEl.textContent = state.lobbyPlayers.length;
+  if (sumEl) sumEl.textContent = total;
+  if (avgEl) avgEl.textContent = state.lobbyPlayers.length
+    ? (total / state.lobbyPlayers.length).toFixed(1)
+    : '0';
+}
+
+function updatePlayersDatalist() {
+  const dl = document.getElementById('players-datalist');
+  if (!dl) return;
+  dl.innerHTML = '';
+  state.lobbyPlayers.forEach(player => {
+    const option = document.createElement('option');
+    option.value = player.nick;
+    dl.appendChild(option);
+  });
+}
+
+function updateTeamButtonsUI() {
+  const buttons = document.querySelectorAll('[data-teams]');
+  buttons.forEach(btn => {
+    const val = parseInt(btn.dataset.teams, 10);
+    const isActive = Number.isInteger(val) && val === state.teamsCount && state.teamsCount > 0;
+    btn.classList.toggle('btn-primary', isActive);
+  });
+}
+
+function renderTeams() {
+  const container = document.getElementById('lobby');
+  if (!container) return;
+
+  const teamDivs = container.querySelectorAll('.team');
+  teamDivs.forEach((teamDiv, index) => {
+    const teamNumber = index + 1;
+    const list = teamDiv.querySelector('.team-list');
+    const sumEl = teamDiv.querySelector('[data-team-sum]');
+    const members = state.teams[teamNumber] || [];
+    const shouldShow = state.teamsCount >= teamNumber && state.teamsCount > 0;
+
+    if (list) {
+      list.innerHTML = '';
+      members.forEach(player => {
+        const li = document.createElement('li');
+        li.className = 'team-player';
+        li.dataset.nick = player.nick;
+        li.textContent = `${player.nick} (${Number(player.pts) || 0})`;
+        list.appendChild(li);
+      });
+    }
+
+    if (sumEl) {
+      const total = members.reduce((sum, player) => sum + (Number(player.pts) || 0), 0);
+      sumEl.textContent = `∑ ${total}`;
+    }
+
+    teamDiv.classList.toggle('hidden', !shouldShow);
+  });
+}
+
+function runAutoBalance() {
+  if (state.balanceMode !== 'auto') return;
+  if (!state.lobbyPlayers.length) {
+    setTeams({});
+    renderLobby();
+    return;
+  }
+
+  let count = state.teamsCount;
+  if (!Number.isInteger(count) || count <= 0) {
+    count = state.lobbyPlayers.length <= 1 ? 1 : 2;
+    count = Math.min(4, Math.max(1, count));
+    setTeamsCount(count);
+  }
+
+  const teams = autoBalance(state.lobbyPlayers, count);
+  setTeams(teams);
+  renderLobby();
+}
+
+function getSelectedNicksFromList() {
+  const list = document.getElementById('player-list');
+  if (!list) return [];
+  return Array.from(list.querySelectorAll('input[type="checkbox"]:checked'))
+    .map(input => input.value)
+    .filter(Boolean);
+}
+
+function getPlayersByNicks(nicks) {
+  if (!Array.isArray(nicks) || !nicks.length) return [];
+  const lookup = new Map(allPlayers.map(player => [player.nick, player]));
+  return nicks
+    .map(nick => lookup.get(nick))
+    .filter(Boolean)
+    .map(player => ({ ...player }));
+}
+
+function renderPlayerPicker() {
+  const area = document.getElementById('select-area');
+  const list = document.getElementById('player-list');
+  if (!list) return;
+
+  if (area) area.classList.remove('hidden');
+
+  list.innerHTML = '';
+  allPlayers.forEach(player => {
+    const label = document.createElement('label');
+    label.className = 'player-option';
+    label.dataset.nick = player.nick;
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = player.nick;
+    checkbox.checked = selectedCandidates.has(player.nick);
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) selectedCandidates.add(player.nick);
+      else selectedCandidates.delete(player.nick);
+    });
+
+    const meta = document.createElement('div');
+    meta.className = 'player-meta';
+    const name = document.createElement('strong');
+    name.textContent = player.nick;
+    const stats = document.createElement('span');
+    const ptsText = `${Number(player.pts) || 0} pts`;
+    const rankText = player.rank ? ` · ${player.rank}` : '';
+    stats.textContent = `${ptsText}${rankText}`;
+    meta.append(name, stats);
+
+    label.append(checkbox, meta);
+    list.appendChild(label);
+  });
+
+  const searchInput = document.getElementById('player-search');
+  if (searchInput) {
+    applySearchFilter(searchInput.value || '');
+  }
+}
+
+function applySearchFilter(term) {
+  const list = document.getElementById('player-list');
+  if (!list) return;
+  const query = term.trim().toLowerCase();
+  Array.from(list.querySelectorAll('.player-option')).forEach(option => {
+    const nick = option.dataset.nick || '';
+    option.classList.toggle('hidden', !!query && !nick.toLowerCase().includes(query));
+  });
+}
+
+async function handleLeagueChange(selectEl) {
+  const rawValue = selectEl?.value ?? state.league;
+  const league = setLeague(rawValue);
+  const csvLeague = typeof window !== 'undefined' && typeof window.uiLeagueToCsv === 'function'
+    ? window.uiLeagueToCsv(rawValue)
+    : league;
+
+  try {
+    allPlayers = await loadPlayers(csvLeague);
+    allPlayers.sort((a, b) => a.nick.localeCompare(b.nick, 'uk'));
+  } catch (err) {
+    console.error('[balance] load players failed', err);
+    allPlayers = [];
+    const msg = 'Не вдалося завантажити гравців для обраної ліги';
+    if (typeof showToast === 'function') showToast(msg); else alert(msg);
+  }
+
+  selectedCandidates.clear();
+  setLobbyPlayers([]);
+  setTeamsCount(0);
+  setTeams({});
+
+  renderPlayerPicker();
+  renderLobby();
+  applyModeUI();
+}
+
+function handleAddToLobbyClick() {
+  const nicks = getSelectedNicksFromList();
+  if (!nicks.length) return;
+
+  const players = getPlayersByNicks(nicks);
+  addToLobby(players);
+
+  selectedCandidates.clear();
+  renderPlayerPicker();
+  const list = document.getElementById('player-list');
+  if (list) {
+    Array.from(list.querySelectorAll('input[type="checkbox"]')).forEach(input => {
+      input.checked = false;
+    });
+  }
+}
+
+function handleModeSwitch(mode) {
+  setBalanceMode(mode);
+  applyModeUI();
+
+  if (mode === 'auto') {
+    if (state.teamsCount <= 0) {
+      const fallback = state.lobbyPlayers.length <= 1 ? 1 : 2;
+      setTeamsCount(Math.min(4, Math.max(1, fallback)));
+    }
+    runAutoBalance();
+  } else {
+    setTeams({});
+    renderLobby();
+  }
+}
+
+function handleTeamsButton(value) {
+  const numeric = Number(value);
+  if (!Number.isInteger(numeric) || numeric <= 0) return;
+
+  setTeamsCount(numeric);
+  if (state.balanceMode === 'auto') {
+    runAutoBalance();
+  } else {
+    renderLobby();
+  }
+  updateTeamButtonsUI();
+}
+
+async function handleSaveGame() {
+  const payload = {
+    league: state.league,
+    mode: state.balanceMode,
+    teamsCount: state.teamsCount,
+    lobby: state.lobbyPlayers.map(player => player.nick).join(', '),
+  };
+
+  Object.entries(state.teams).forEach(([teamId, players]) => {
+    payload[`team${teamId}`] = players.map(player => player.nick).join(', ');
+  });
+  payload.teamsJson = JSON.stringify(state.teams);
+
+  let response;
+  try {
+    response = await saveResult(payload);
+    console.debug('[balance] save', { payload, response });
+  } catch (err) {
+    console.debug('[balance] save', { payload, error: err });
+    console.error('[balance] save failed', err);
+    const msg = 'Не вдалося зберегти результат';
+    if (typeof showToast === 'function') showToast(msg); else alert(msg);
+    return;
+  }
+
+  const ok = !!(response && response.ok);
+  if (!ok) {
+    const message = response && typeof response === 'object' && 'message' in response
+      ? response.message
+      : 'Невідома помилка';
+    const msg = `Помилка збереження: ${message}`;
+    if (typeof showToast === 'function') showToast(msg); else alert(msg);
+    return;
+  }
+
+  const successMessage = response && typeof response === 'object' && 'message' in response
+    ? response.message
+    : 'Результат успішно збережено';
+  if (typeof showToast === 'function') showToast(successMessage); else alert(successMessage);
+
+  if (Array.isArray(response?.players)) {
+    const lookup = new Map(response.players.map(item => [item.nick, item]));
+    const updated = state.lobbyPlayers.map(player => {
+      const fresh = lookup.get(player.nick);
+      if (!fresh) return player;
+      const pts = Number.isFinite(fresh.pts) ? fresh.pts : Number(fresh.points);
+      return {
+        ...player,
+        ...fresh,
+        pts: Number.isFinite(pts) ? pts : player.pts,
+      };
+    });
+    setLobbyPlayers(updated);
+    renderLobby();
+  }
+}
+
+function initSearch() {
+  const searchInput = document.getElementById('player-search');
+  if (!searchInput) return;
+  searchInput.addEventListener('input', () => {
+    applySearchFilter(searchInput.value || '');
+  });
+}
+
+function initEventListeners() {
+  const leagueSelect = document.getElementById('league');
+  const addBtn = document.getElementById('add-to-lobby');
   const autoBtn = document.getElementById('mode-auto');
   const manualBtn = document.getElementById('mode-manual');
+  const saveBtn = document.getElementById('save-game');
+
+  if (leagueSelect) {
+    leagueSelect.value = state.league;
+    leagueSelect.addEventListener('change', () => handleLeagueChange(leagueSelect));
+  }
+
+  if (addBtn) {
+    addBtn.addEventListener('click', handleAddToLobbyClick);
+  }
 
   if (autoBtn) {
-    autoBtn.addEventListener('click', async () => {
-      setBalanceMode('auto');
-      applyModeUI();
-      await recomputeAutoBalance();
-    });
+    autoBtn.addEventListener('click', () => handleModeSwitch('auto'));
   }
 
   if (manualBtn) {
-    manualBtn.addEventListener('click', () => {
-      setBalanceMode('manual');
-      applyModeUI();
-    });
+    manualBtn.addEventListener('click', () => handleModeSwitch('manual'));
   }
 
+  document.querySelectorAll('[data-teams]').forEach(btn => {
+    btn.addEventListener('click', () => handleTeamsButton(btn.dataset.teams));
+  });
+
+  if (saveBtn) {
+    saveBtn.addEventListener('click', handleSaveGame);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  initEventListeners();
+  initSearch();
+  registerRecomputeAutoBalance(runAutoBalance);
   applyModeUI();
+
+  const leagueSelect = document.getElementById('league');
+  await handleLeagueChange(leagueSelect || null);
+  renderPlayerPicker();
+  renderLobby();
 });


### PR DESCRIPTION
## Summary
- add lobby rendering and lobby management helpers to `scripts/balance.js`
- implement auto-balance orchestration with shared state updates and debug logging
- hook DOMContentLoaded listeners and integrate saveResult persistence

## Testing
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cfed05ddc48321bb5c59001d4d98f6