### PR TITLE
Replace balance dynamic import with static module tags

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -234,16 +234,10 @@
   <script src="scripts/toast.js?v=2025-09-19"></script>
 
   <!-- ЄДИНИЙ ланцюжок ES-модулів, правильний порядок -->
-  <script type="module">
-    const VER = '2025-09-19-balance-hotfix-1';
-    const chain = [
-      `./scripts/config.js?v=${VER}`,
-      `./scripts/logger.js?v=${VER}`,
-      `./scripts/api.js?v=${VER}`,
-      `./scripts/state.js?v=${VER}`,
-      `./scripts/balance.js?v=${VER}`,
-    ];
-    for (const m of chain) { await import(m); }
-  </script>
+  <script type="module" src="scripts/config.js?v=2025-09-19-balance-hotfix-1"></script>
+  <script type="module" src="scripts/logger.js?v=2025-09-19-balance-hotfix-1"></script>
+  <script type="module" src="scripts/api.js?v=2025-09-19-balance-hotfix-1"></script>
+  <script type="module" src="scripts/state.js?v=2025-09-19-balance-hotfix-1"></script>
+  <script type="module" src="scripts/balance.js?v=2025-09-19-balance-hotfix-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the dynamic import chain in balance.html with five explicit module script tags
- apply a shared cache-busting query string to each module import while leaving other scripts unchanged

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cffe9bf3bc832190443dbf4b2a22c0