### PR TITLE
Update balancer config and isolate avatar constants

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -4,9 +4,9 @@ import {
   AVATAR_PLACEHOLDER,
   AVATAR_WORKER_BASE,
   AVATAR_CACHE_BUST,
-  GAS_PROXY_BASE,
   ASSETS_VER
-} from './config.js';
+} from './avatarConfig.js';
+import { GAS_PROXY_BASE } from './config.js';
 
 // ==================== DIAGNOSTICS ====================
 const DEBUG_NETWORK = false;

--- a/scripts/avatar.js
+++ b/scripts/avatar.js
@@ -1,4 +1,4 @@
-import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-2';
+import { AVATAR_PLACEHOLDER } from './avatarConfig.js?v=2025-09-19-avatars-2';
 import { avatarNickKey } from './api.js?v=2025-09-19-avatars-2';
 import { renderAllAvatars } from './avatars.client.js';
 

--- a/scripts/avatarAdmin.js
+++ b/scripts/avatarAdmin.js
@@ -1,7 +1,7 @@
 // scripts/avatarAdmin.js
 import { log } from './logger.js?v=2025-09-19-avatars-2';
 import { uploadAvatar, loadPlayers, avatarNickKey } from './api.js?v=2025-09-19-avatars-2';
-import { AVATAR_PLACEHOLDER, AVATAR_WORKER_BASE } from './config.js?v=2025-09-19-avatars-2';
+import { AVATAR_PLACEHOLDER, AVATAR_WORKER_BASE } from './avatarConfig.js?v=2025-09-19-avatars-2';
 import { reloadAvatars } from './avatars.client.js';
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024;

--- a/scripts/avatarConfig.js
+++ b/scripts/avatarConfig.js
@@ -1,0 +1,4 @@
+export const AVATAR_WORKER_BASE = 'https://avatarsproxy.vartaclub.workers.dev';
+export const AVATAR_CACHE_BUST = '2025-09-19-avatars-2';
+export const AVATAR_PLACEHOLDER = 'assets/default_avatars/av0.png';
+export const ASSETS_VER = AVATAR_CACHE_BUST;

--- a/scripts/avatars.client.js
+++ b/scripts/avatars.client.js
@@ -1,4 +1,4 @@
-import { AVATAR_WORKER_BASE, AVATAR_PLACEHOLDER } from './config.js';
+import { AVATAR_WORKER_BASE, AVATAR_PLACEHOLDER } from './avatarConfig.js';
 
 const RAW_BASE = typeof AVATAR_WORKER_BASE === 'string' ? AVATAR_WORKER_BASE.trim() : '';
 const NORMALIZED_BASE = RAW_BASE ? RAW_BASE.replace(/\/+$/, '') : '';

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,6 +1,6 @@
+export const VER = '2025-09-19-balance-hotfix-1';
 export const GAS_PROXY_BASE = 'https://laser-proxy.vartaclub.workers.dev';
-export const AVATAR_WORKER_BASE = 'https://avatarsproxy.vartaclub.workers.dev';
-export const AVATAR_CACHE_BUST = '2025-09-19-avatars-2';
-export const AVATAR_PLACEHOLDER = 'assets/default_avatars/av0.png';
-export const VER = '2025-09-19-balance-1';
-export const ASSETS_VER = VER || AVATAR_CACHE_BUST;
+export const LEAGUE_CSV = {
+  kids: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1648067737&single=true&output=csv',
+  sundaygames: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSzum1H-NSUejvB_XMMWaTs04SPz7SQGpKkyFwz4NQjsN8hz2jAFAhl-jtRdYVAXgr36sN4RSoQSpEN/pub?gid=1286735969&single=true&output=csv'
+};

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -1,5 +1,5 @@
 import { log } from './logger.js?v=2025-09-19-avatars-2';
-import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-2';
+import { AVATAR_PLACEHOLDER } from './avatarConfig.js?v=2025-09-19-avatars-2';
 import { getPdfLinks, fetchOnce, CSV_URLS, avatarNickKey } from "./api.js?v=2025-09-19-avatars-2";
 import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-avatars-2';
 import { renderAllAvatars, reloadAvatars } from './avatars.client.js';

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -3,7 +3,7 @@ import { getProfile, uploadAvatar, getPdfLinks, fetchPlayerGames, safeSet, safeG
 import { rankLetterForPoints } from './rankUtils.js?v=2025-09-19-avatars-2';
 import * as Avatars from './avatars.client.js';
 import { noteAvatarFailure, setImgSafe, updateInlineAvatarImages } from './avatarAdmin.js?v=2025-09-19-avatars-2';
-import { AVATAR_PLACEHOLDER } from './config.js?v=2025-09-19-avatars-2';
+import { AVATAR_PLACEHOLDER } from './avatarConfig.js?v=2025-09-19-avatars-2';
 
 let gameLimit = 0;
 let gamesLeftEl = null;

--- a/scripts/ranking.js
+++ b/scripts/ranking.js
@@ -1,5 +1,5 @@
 import { log } from './logger.js';
-import { AVATAR_PLACEHOLDER } from './config.js';
+import { AVATAR_PLACEHOLDER } from './avatarConfig.js';
 import { fetchOnce, CSV_URLS, normalizeLeague } from "./api.js";
 import { LEAGUE } from "./constants.js";
 import { rankLetterForPoints } from './rankUtils.js';


### PR DESCRIPTION
## Summary
- update the balancer config version, proxy base, and add league CSV endpoints
- move avatar-related constants into a dedicated module and update imports

## Testing
- node --test tests/*.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cfff50b9e08321a5334462fe528e65