### PR TITLE
Refactor state management to in-memory helpers

### DIFF
--- a/scripts/balance.js
+++ b/scripts/balance.js
@@ -10,6 +10,7 @@ import {
   setLobbyPlayers,
   setTeams,
   setTeamsCount,
+  getTeamMembers,
 } from './state.js?v=2025-09-19-avatars-2';
 
 let recomputeHandler = null;
@@ -192,7 +193,7 @@ function renderTeams() {
     const teamNumber = index + 1;
     const list = teamDiv.querySelector('.team-list');
     const sumEl = teamDiv.querySelector('[data-team-sum]');
-    const members = state.teams[teamNumber] || [];
+    const members = getTeamMembers(teamNumber);
     const shouldShow = state.teamsCount >= teamNumber && state.teamsCount > 0;
 
     if (list) {
@@ -388,9 +389,10 @@ async function handleSaveGame() {
     lobby: state.lobbyPlayers.map(player => player.nick).join(', '),
   };
 
-  Object.entries(state.teams).forEach(([teamId, players]) => {
-    payload[`team${teamId}`] = players.map(player => player.nick).join(', ');
-  });
+  for (let i = 1; i <= state.teamsCount; i++) {
+    const members = getTeamMembers(i);
+    payload[`team${i}`] = members.map(player => player.nick).join(', ');
+  }
   payload.teamsJson = JSON.stringify(state.teams);
 
   let response;

--- a/scripts/scenario.js
+++ b/scripts/scenario.js
@@ -3,7 +3,7 @@
 import { teams, initTeams }          from './teams.js?v=2025-09-19-avatars-2';
 import { autoBalance2, autoBalanceN } from './balanceUtils.js?v=2025-09-19-avatars-2';
 import { lobby, setManualCount }      from './lobby.js?v=2025-09-19-avatars-2';
-import { state }                      from './state.js?v=2025-09-19-avatars-2';
+import { state, getTeamNumber }       from './state.js?v=2025-09-19-avatars-2';
 import {
   registerRecomputeAutoBalance,
   recomputeAutoBalance as triggerRecomputeAutoBalance,
@@ -21,7 +21,9 @@ export function initScenario() {
 function renderArenaCheckboxes() {
   arenaCheckboxes.innerHTML = '';
   Object.keys(teams).forEach(id => {
-    const sum = teams[id].reduce((s,p)=>s+p.pts, 0);
+    const teamNo = getTeamNumber(id);
+    if (!Number.isInteger(teamNo) || teamNo > state.teamsCount) return;
+    const sum = (teams[id] || []).reduce((s,p)=>s+p.pts, 0);
     const label = document.createElement('label');
     const cb    = document.createElement('input');
     cb.type     = 'checkbox';
@@ -29,7 +31,7 @@ function renderArenaCheckboxes() {
     cb.dataset.team = id;
     cb.addEventListener('change', updateStartButton);
     label.appendChild(cb);
-    label.insertAdjacentText('beforeend', ` Команда ${id} (∑ ${sum})`);
+    label.insertAdjacentText('beforeend', ` Команда ${teamNo} (∑ ${sum})`);
     arenaCheckboxes.appendChild(label);
   });
 }

--- a/scripts/teams.js
+++ b/scripts/teams.js
@@ -1,4 +1,10 @@
-import { state, setTeamsCount, setTeams, saveLobbyState } from './state.js?v=2025-09-19-avatars-2';
+import {
+  state,
+  setTeamsCount,
+  setTeams,
+  getTeamKey,
+  getTeamMembers,
+} from './state.js?v=2025-09-19-avatars-2';
 
 export const teams = state.teams;
 
@@ -7,15 +13,22 @@ export function initTeams(n, data = {}) {
   if (!area) return;
 
   area.innerHTML = '';
+  if (n <= 0) {
+    area.classList.add('hidden');
+    setTeamsCount(0);
+    setTeams({});
+    return;
+  }
+
   area.classList.remove('hidden');
 
-  setTeamsCount(n);
-  setTeams({});
+  const count = setTeamsCount(n);
+  setTeams(data);
 
-  for (let i = 1; i <= state.teamsCount; i++) {
-    const arr = Array.isArray(data?.[i]) ? [...data[i]] : [];
-    state.teams[i] = arr;
-    const sum = arr.reduce((s, p) => s + (Number(p.pts) || 0), 0);
+  for (let i = 1; i <= count; i++) {
+    const key = getTeamKey(i);
+    const members = getTeamMembers(key);
+    const sum = members.reduce((s, p) => s + (Number(p.pts) || 0), 0);
     const div = document.createElement('div');
     div.className = `card team-box team-${i}`;
     div.innerHTML = `
@@ -23,10 +36,8 @@ export function initTeams(n, data = {}) {
         <input type="checkbox" class="team-select" data-team="${i}">
         Команда ${i} (∑ ${sum})
       </label>
-      <ul>${arr.map(p => `<li class="rank-${p.rank}">${p.nick} (${p.pts})</li>`).join('')}</ul>
+      <ul>${members.map(p => `<li class="rank-${p.rank}">${p.nick} (${p.pts})</li>`).join('')}</ul>
     `;
     area.append(div);
   }
-
-  saveLobbyState();
 }


### PR DESCRIPTION
## Summary
- replace the shared state module with a simple in-memory object and pure helper setters
- update lobby, teams, balance, and scenario modules to consume the new state structure and remove local storage usage

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d004e16d1083219e6c819416a7a404