### PR TITLE
Add lobby clearing helper and deduplicate button

### DIFF
--- a/balance.html
+++ b/balance.html
@@ -27,7 +27,6 @@
               <input type="text" id="new-nick" placeholder="Нік">
               <input type="number" id="new-age" placeholder="Вік" min="0">
               <button id="btn-create">Створити гравця</button>
-              <button id="ui-clear-lobby" class="btn--danger">Очистити лоббі</button>
             </div>
           </div>
         </section>

--- a/scripts/balance.js
+++ b/scripts/balance.js
@@ -14,6 +14,7 @@ import { parseGamePdf } from './pdfParser.js?v=2025-09-19-balance-hotfix-1';
 import {
   state,
   setBalanceMode,
+  clearTeams,
   setLeague,
   setLobbyPlayers,
   setPlayers,
@@ -121,6 +122,28 @@ export function addToLobby(playersToAdd = []) {
   }
 
   renderLobby();
+  return state.lobbyPlayers;
+}
+
+export function clearLobby() {
+  const previousLobbySize = state.lobbyPlayers.length;
+  const teamsBefore = Object.fromEntries(
+    Object.entries(state.teams || {}).map(([key, members]) => [key, Array.isArray(members) ? members.length : 0]),
+  );
+
+  setLobbyPlayers([]);
+  clearTeams();
+  selectedCandidates.clear();
+
+  renderLobby();
+  renderPlayerList();
+
+  console.info('[balance] clearLobby', {
+    previousLobbySize,
+    teamsBefore,
+    lobbySize: state.lobbyPlayers.length,
+  });
+
   return state.lobbyPlayers;
 }
 
@@ -1244,6 +1267,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (addToLobbyBtnEl) {
     addToLobbyBtnEl.addEventListener('click', addSelectedToLobby);
+  }
+
+  const clearLobbyBtn = document.getElementById('btn-clear-lobby');
+  if (clearLobbyBtn) {
+    clearLobbyBtn.addEventListener('click', clearLobby);
   }
 
   const loadBtn = document.getElementById('btn-load');


### PR DESCRIPTION
## Summary
- remove the redundant clear lobby button from the balance page header
- add a reusable clearLobby helper that resets lobby state and selections
- hook the balance page clear lobby button to invoke the new helper and log the reset

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d01618e0008321b5f784e14c62ed63