### PR TITLE
Preserve teams count when reloading league

### DIFF
--- a/scripts/balance.js
+++ b/scripts/balance.js
@@ -742,7 +742,10 @@ export async function loadPlayersForLeague(source) {
 
   selectedCandidates.clear();
   setLobbyPlayers([]);
-  setTeamsCount(0);
+  const preservedTeamsCount = Number.isInteger(state.teamsCount) && state.teamsCount > 0
+    ? state.teamsCount
+    : 4;
+  setTeamsCount(preservedTeamsCount);
   setTeams({});
 
   resetArenaUI();


### PR DESCRIPTION
## Summary
- keep the existing manual teams count when reloading players and fall back to four teams when no value is set
- clear teams without hiding the manual drag UI so manual mode stays ready after switching leagues

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d016de037083218e37f9e0f24f36f8