### PR TITLE
Update summer 2025 metrics and ticker

### DIFF
--- a/summer-2025.html
+++ b/summer-2025.html
@@ -149,6 +149,11 @@
         font-size: clamp(0.95rem, 2.5vw, 1.35rem);
         color: var(--primary);
       }
+      .metric-delta {
+        font-size: 0.55rem;
+        color: var(--accent);
+        text-transform: none;
+      }
       .metric-footnote {
         font-size: 0.5rem;
         color: #b9b9ff;


### PR DESCRIPTION
## Summary
- Switch the summer metrics to rely on `seasonGeneral` data and surface top-10 spread info from `seasonPointsSummary`.
- Add seasonal ticker messages backed by constants with season totals and race highlights.
- Style the new metric delta line within the dashboard cards.

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d1baa7b7848321b4293ab38e44e0da