### PR TITLE
Update summer leaderboard battles column

### DIFF
--- a/scripts/summer2025.js
+++ b/scripts/summer2025.js
@@ -921,6 +921,19 @@ function formatPercent(value, formatter = percentFormatter0) {
   return formatter.format(value);
 }
 
+function getGamesPlayedValue(player) {
+  const alias = nameAlias(player.nickname);
+  const stats = gamesPlayedByPlayer[alias];
+  return stats?.games ?? player.games ?? 0;
+}
+
+function getSortValue(player, sortKey) {
+  if (sortKey === 'games') {
+    return getGamesPlayedValue(player);
+  }
+  return player[sortKey];
+}
+
 const seasonTickerMessages = [
   `Матчів: ${numberFormatter.format(seasonGeneral.totalGamesLogged)} · Раундів: ${numberFormatter.format(seasonGeneral.totalRounds)}`,
   `Очки сезону: ${numberFormatter.format(seasonGeneral.totalPointsScored)} (подіум ${formatPercent(seasonPointsSummary.podiumShare, percentFormatter1)})`,
@@ -1202,8 +1215,8 @@ function renderLeaderboard() {
     if (currentSort === 'rank') {
       return direction * (a.rank - b.rank);
     }
-    const valueA = a[currentSort];
-    const valueB = b[currentSort];
+    const valueA = getSortValue(a, currentSort);
+    const valueB = getSortValue(b, currentSort);
     if (valueA === valueB) {
       return a.rank - b.rank;
     }
@@ -1238,6 +1251,8 @@ function renderLeaderboard() {
   filtered.forEach((player) => {
     const row = document.createElement('tr');
     row.classList.add(`tier-${player.rankTier}`);
+    const gamesPlayed = getGamesPlayedValue(player);
+    const rankBadge = `<span class="role-badge tier-${player.rankTier}" aria-label="Ранг ${player.rankTier}">${player.rankTier}</span>`;
     row.innerHTML = `
       <td><span class="rank-chip">${player.rank}</span></td>
       <td>
@@ -1248,8 +1263,13 @@ function renderLeaderboard() {
       <td>${numberFormatter.format(player.averagePoints)}</td>
       <td>${numberFormatter.format(player.games)}</td>
       <td>${formatPercent(player.winRate)}</td>
-      <td>${formatPercent(player.accuracy)}</td>
-      <td>${player.role}</td>
+      <td>${numberFormatter.format(gamesPlayed)}</td>
+      <td>
+        <span class="role-cell">
+          <span>${player.role}</span>
+          ${rankBadge}
+        </span>
+      </td>
       <td><button type="button" class="pixel-button" data-player="${player.nickname}">Профіль</button></td>
     `;
 

--- a/summer-2025.html
+++ b/summer-2025.html
@@ -280,6 +280,35 @@
         background: rgba(0, 0, 0, 0.6);
         border: var(--pixel-border) solid rgba(255, 255, 255, 0.1);
       }
+      .role-cell {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        flex-wrap: wrap;
+      }
+      .role-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 1.6rem;
+        padding: 0.15rem 0.35rem;
+        background: rgba(0, 0, 0, 0.55);
+        border: var(--pixel-border) solid rgba(255, 255, 255, 0.18);
+        font-size: 0.5rem;
+        letter-spacing: 0.08em;
+      }
+      .role-badge.tier-S {
+        color: #ff66c4;
+        border-color: rgba(255, 102, 196, 0.6);
+      }
+      .role-badge.tier-A {
+        color: #ffd700;
+        border-color: rgba(255, 215, 0, 0.5);
+      }
+      .role-badge.tier-B {
+        color: #66ffda;
+        border-color: rgba(102, 255, 218, 0.45);
+      }
       tr.tier-S .rank-chip {
         color: #ff66c4;
         border-color: rgba(255, 102, 196, 0.6);
@@ -456,8 +485,13 @@
             <button class="tab-button" role="tab" data-sort="averagePoints">
               Середній бал
             </button>
-            <button class="tab-button" role="tab" data-sort="accuracy">
-              Точність
+            <button
+              class="tab-button"
+              role="tab"
+              data-sort="games"
+              aria-label="Сортувати таблицю за кількістю боїв"
+            >
+              Бої
             </button>
             <button class="tab-button" role="tab" data-sort="winRate">
               Win rate
@@ -474,7 +508,7 @@
                 <th scope="col">Сер. очки</th>
                 <th scope="col">Ігор</th>
                 <th scope="col">% перемог</th>
-                <th scope="col">Точність</th>
+                <th scope="col">Бої</th>
                 <th scope="col">Роль</th>
                 <th scope="col">Деталі</th>
               </tr>


### PR DESCRIPTION
## Summary
- replace the Summer 2025 leaderboard accuracy controls with a battles column and badge styling for role rows
- surface battle counts in the leaderboard using the dedicated player dictionary and expose rank tier badges next to the role
- update sorting logic to work with the dictionary-backed battles values

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d1bda6f7788321a578dc1624d2ea82