### PR TITLE
Fix summer 2025 data fetch paths

### DIFF
--- a/scripts/summer2025.js
+++ b/scripts/summer2025.js
@@ -1116,11 +1116,34 @@ async function fetchJSON(url, options = {}) {
   return response.json();
 }
 
+function resolveSeasonAsset(pathname) {
+  if (typeof pathname !== 'string' || !pathname) {
+    return pathname;
+  }
+
+  if (typeof window !== 'undefined') {
+    const baseUrl =
+      (typeof document !== 'undefined' && document.baseURI) ||
+      window.location?.href ||
+      window.location?.origin;
+
+    if (baseUrl) {
+      try {
+        return new URL(pathname, baseUrl).href;
+      } catch (error) {
+        console.warn('[summer2025] failed to resolve asset URL', pathname, error);
+      }
+    }
+  }
+
+  return pathname;
+}
+
 async function boot() {
   try {
     const [packData, eventsData] = await Promise.all([
-      fetchJSON('/SL_Summer2025_pack.json'),
-      fetchJSON('/sunday_summer_2025_EVENTS.json')
+      fetchJSON(resolveSeasonAsset('SL_Summer2025_pack.json')),
+      fetchJSON(resolveSeasonAsset('sunday_summer_2025_EVENTS.json'))
     ]);
     PACK = packData;
     EVENTS = eventsData;


### PR DESCRIPTION
## Summary
- resolve the Summer 2025 pack and events JSON URLs relative to the page location so the leaderboard works from subdirectories
- add a helper to centralize Summer 2025 asset URL resolution

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68da88104008832186abc72133b1d9b2