### PR TITLE
Update summer 2025 leaderboard columns

### DIFF
--- a/scripts/summer2025.js
+++ b/scripts/summer2025.js
@@ -552,15 +552,15 @@ function getSortValue(player, sortKey) {
       return toFiniteNumber(player.season_points ?? player.totalPoints);
     case 'games':
       return toFiniteNumber(player.games);
+    case 'wins':
+      return toFiniteNumber(player.wins);
+    case 'losses':
+      return toFiniteNumber(player.losses);
     case 'rounds':
       return toFiniteNumber(player.rounds);
     case 'winRate':
     case 'roundWR':
       return toFiniteNumber(player[sortKey]);
-    case 'win_streak':
-      return toFiniteNumber(player.win_streak ?? player.bestStreak);
-    case 'loss_streak':
-      return toFiniteNumber(player.loss_streak ?? player.lossStreak);
     case 'MVP':
       return toFiniteNumber(player.MVP);
     case 'rankTier': {
@@ -638,7 +638,7 @@ function renderLeaderboard(players = topPlayers) {
 
   if (filtered.length === 0) {
     const emptyRow = document.createElement('tr');
-    emptyRow.innerHTML = `<td colspan="9">Немає гравців за цим запитом</td>`;
+    emptyRow.innerHTML = `<td colspan="10">Немає гравців за цим запитом</td>`;
     leaderboardBody.append(emptyRow);
     return;
   }
@@ -681,9 +681,6 @@ function renderLeaderboard(players = topPlayers) {
     if (drawsLabel !== FALLBACK) {
       gamesTooltipParts.push(`Нічиї: ${drawsLabel}`);
     }
-    if (winRateLabel !== FALLBACK) {
-      gamesTooltipParts.push(`Win rate: ${winRateLabel}`);
-    }
     const gamesTooltip = gamesTooltipParts.join(' · ');
 
     const roundsTooltipParts = [];
@@ -694,6 +691,15 @@ function renderLeaderboard(players = topPlayers) {
       roundsTooltipParts.push(`Поразки: ${roundLossesLabel}`);
     }
     const roundsTooltip = roundsTooltipParts.join(' · ');
+
+    const winRateTooltipParts = [];
+    if (winStreakLabel !== FALLBACK) {
+      winRateTooltipParts.push(`Стрік перемог: ${winStreakLabel}`);
+    }
+    if (lossStreakLabel !== FALLBACK) {
+      winRateTooltipParts.push(`Стрік поразок: ${lossStreakLabel}`);
+    }
+    const winRateTooltip = winRateTooltipParts.join(' · ');
 
     const playerNickname = typeof player?.nickname === 'string' ? player.nickname : '';
 
@@ -708,11 +714,14 @@ function renderLeaderboard(players = topPlayers) {
       <td>
         <span ${gamesTooltip ? `title="${gamesTooltip}"` : ''}>${gamesLabel}</span>
       </td>
+      <td>${winsLabel}</td>
+      <td>${lossesLabel}</td>
+      <td>
+        <span ${winRateTooltip ? `title="${winRateTooltip}"` : ''}>${winRateLabel}</span>
+      </td>
       <td>
         <span ${roundsTooltip ? `title="${roundsTooltip}"` : ''}>${roundsLabel}</span>
       </td>
-      <td>${winStreakLabel}</td>
-      <td>${lossStreakLabel}</td>
       <td>${mvpLabel}</td>
       <td>
         <span class="role-cell">

--- a/summer-2025.html
+++ b/summer-2025.html
@@ -561,9 +561,10 @@
                 <th scope="col">Гравець</th>
                 <th scope="col">Очки сезону</th>
                 <th scope="col">Ігор</th>
+                <th scope="col">Перемог</th>
+                <th scope="col">Поразок</th>
+                <th scope="col">WinRate %</th>
                 <th scope="col">Раундів</th>
-                <th scope="col">Стрік перемог</th>
-                <th scope="col">Стрік поразок</th>
                 <th scope="col">MVP</th>
                 <th scope="col">Ранг</th>
               </tr>


### PR DESCRIPTION
## Summary
- update the summer 2025 leaderboard table headers to highlight wins, losses, and win rate
- adjust renderLeaderboard to render the new columns, move streak details into tooltips, and update the empty state layout
- extend sorting support for wins, losses, and winRate while pruning unused streak cases

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dad0d2b3908321b35b6b516f09d9e5