### PR TITLE
Set cumulative chart mode as modal default

### DIFF
--- a/scripts/summer2025.js
+++ b/scripts/summer2025.js
@@ -1005,11 +1005,11 @@ function renderModal(player) {
 
   const timeline = buildPlayerTimelineData(player, EVENTS, PACK?.aliases ?? {});
   const hasTimeline = Array.isArray(timeline?.delta) && timeline.delta.length > 0;
-  const defaultChartMode = 'delta';
+  const defaultChartMode = 'cum';
   const chartControlsMarkup = hasTimeline
     ? `<div class="chart-mode-switch" role="radiogroup" aria-label="Режим графіка">
-        <label><input type="radio" name="chart-mode" value="delta" checked /> Δ очки</label>
-        <label><input type="radio" name="chart-mode" value="cum" /> Σ очки</label>
+        <label><input type="radio" name="chart-mode" value="delta" /> Δ очки</label>
+        <label><input type="radio" name="chart-mode" value="cum" checked /> Σ очки</label>
       </div>`
     : '';
   const chartMarkup = hasTimeline


### PR DESCRIPTION
## Summary
- default the summer player modal chart to cumulative mode
- update the chart mode radio buttons to reflect the new default

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dad25b4c5c832187cadbe39879a179