### PR TITLE
Fix season asset URL resolution

### DIFF
--- a/scripts/summer2025.js
+++ b/scripts/summer2025.js
@@ -1246,14 +1246,32 @@ function resolveSeasonAsset(pathname) {
   }
 
   if (typeof window !== 'undefined') {
-    const baseUrl =
-      (typeof document !== 'undefined' && document.baseURI) ||
-      window.location?.href ||
-      window.location?.origin;
+    const directoryHref = (() => {
+      if (typeof document !== 'undefined' && document.baseURI) {
+        try {
+          return new URL('.', document.baseURI).href;
+        } catch (error) {
+          console.warn('[summer2025] failed to resolve document.baseURI', error);
+        }
+      }
 
-    if (baseUrl) {
+      const { origin, pathname: currentPath } = window.location ?? {};
+      if (origin) {
+        try {
+          const base = currentPath ? `${origin}${currentPath}` : origin;
+          return new URL('.', base).href;
+        } catch (error) {
+          console.warn('[summer2025] failed to resolve window.location', error);
+          return `${origin}/`;
+        }
+      }
+
+      return undefined;
+    })();
+
+    if (directoryHref) {
       try {
-        return new URL(pathname, baseUrl).href;
+        return new URL(pathname, directoryHref).href;
       } catch (error) {
         console.warn('[summer2025] failed to resolve asset URL', pathname, error);
       }


### PR DESCRIPTION
## Summary
- update the season asset resolver to compute the page directory before building asset URLs
- ensure asset fetches remain relative to the deployment subpath

## Testing
- npm test *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dad669041083218f025eff3adfedff