### PR TITLE
Fix Summer 2025 pack JSON validity

### DIFF
--- a/SL_Summer2025_pack.json
+++ b/SL_Summer2025_pack.json
@@ -623,6 +623,8 @@
     { "player": "Den", "season_points": 311, "rankTier": "C", "games": null, "winRate": null, "MVP": 0 },
     { "player": "Люся", "season_points": 291, "rankTier": "C", "games": null, "winRate": null, "MVP": 0 },
     { "player": "Nata", "season_points": 261, "rankTier": "C", "games": null, "winRate": null, "MVP": 0 }
-    /* … решта гравців зі спрощеними полями, як і раніше (очки+ранг; за потреби додам повні) */
-  ]
+  ],
+  "notes": {
+    "allPlayers": "Решта гравців подані у спрощеному форматі (очки та ранг); за потреби можна додати повні дані."
+  }
 }


### PR DESCRIPTION
## Summary
- remove the inline comment from SL_Summer2025_pack.json and move the note into a notes field
- ensure the summer pack JSON stays valid

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs
- node -e "JSON.parse(require('fs').readFileSync('SL_Summer2025_pack.json','utf8')); console.log('JSON OK');"

------
https://chatgpt.com/codex/tasks/task_e_68dae0490efc8321a59f109422783bc5