### PR TITLE
Remove season points tab from summer leaderboard

### DIFF
--- a/summer-2025.html
+++ b/summer-2025.html
@@ -534,9 +534,6 @@
             <button class="tab-button" role="tab" data-sort="rank" aria-selected="true">
               Рейтинг
             </button>
-            <button class="tab-button" role="tab" data-sort="season_points">
-              Очки сезону
-            </button>
             <button
               class="tab-button"
               role="tab"


### PR DESCRIPTION
## Summary
- remove the season points sort tab from the Summer 2025 leaderboard tablist

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dbc336c0448321aad40cc529c4b9a1