### PR TITLE
Add Open Graph metadata to summer 2025 page

### DIFF
--- a/summer-2025.html
+++ b/summer-2025.html
@@ -8,6 +8,38 @@
       href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
       rel="stylesheet"
     />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="uk_UA" />
+    <meta property="og:site_name" content="Лазертаг Рейтинг" />
+    <meta property="og:title" content="Літній сезон 2025 | Лазертаг" />
+    <meta
+      property="og:description"
+      content="Сезонні підсумки, статистика та ключові івенти літнього чемпіонату 2025 року."
+    />
+    <meta
+      property="og:url"
+      content="https://laser.vartaclub.workers.dev/summer-2025.html"
+    />
+    <meta
+      property="og:image"
+      content="https://laser.vartaclub.workers.dev/assets/background_marathon.png?v=2025-09-19-avatars-3"
+    />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="Неоновий фон із логотипом літнього сезону лазертагу 2025 року"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Літній сезон 2025 | Лазертаг" />
+    <meta
+      name="twitter:description"
+      content="Сезонні підсумки, статистика та ключові івенти літнього чемпіонату 2025 року."
+    />
+    <meta
+      name="twitter:image"
+      content="https://laser.vartaclub.workers.dev/assets/background_marathon.png?v=2025-09-19-avatars-3"
+    />
     <script type="module" src="scripts/polyfills.js?v=2025-09-19-avatars-3"></script>
     <style>
       :root {


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter card metadata to the Summer 2025 landing page for better sharing previews
- configure share image, locale, and description values with absolute URLs

## Testing
- node tests/loadPlayersFallback.test.mjs
- node tests/saveResultFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dbf3393e048321b6ba48296c924beb