### PR TITLE
Automate Summer 2025 social preview generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 # Ignore test HTML files
 test*.html
+
+# Generated social preview for summer 2025
+assets/summer2025-table-preview.png
+
+# Dependencies installed locally
+node_modules/

--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ The pages use ES modules, therefore they must be served via HTTP. Any static ser
 
 If the API proxy is unavailable, the balancer page will fetch player data directly from the published Google Sheets.
 
+## Deployment checklist
+
+Before publishing the static site make sure the generated assets are up to date. The Summer 2025 social preview is created from
+the latest ranking pack and should be rebuilt on every deploy:
+
+```
+npm ci && npm run build:summer2025-og
+```
+
+The command writes the image to `assets/summer2025-table-preview.png`, which is excluded from version control but must be present
+in the final artifact served by the CDN/hosting provider.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,509 @@
+{
+  "name": "laser-tag-ranking",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "laser-tag-ranking",
+      "version": "1.0.0",
+      "dependencies": {
+        "sharp": "^0.33.3"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
+      "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "laser-tag-ranking",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build:summer2025-og": "node scripts/summer2025-og.js"
+  },
+  "dependencies": {
+    "sharp": "^0.33.3"
+  }
+}

--- a/scripts/summer2025-og.js
+++ b/scripts/summer2025-og.js
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const DEFAULT_OUTPUT = path.resolve(PROJECT_ROOT, 'assets', 'summer2025-table-preview.png');
+const DATA_FILE = path.resolve(PROJECT_ROOT, 'SL_Summer2025_pack.json');
+
+function parseArgs(argv) {
+  const args = { out: DEFAULT_OUTPUT };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--help' || token === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (token === '--out' || token === '-o') {
+      const next = argv[i + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('Expected a path after --out');
+      }
+      args.out = path.resolve(process.cwd(), next);
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--out=')) {
+      const outPath = token.slice('--out='.length);
+      if (!outPath) {
+        throw new Error('Expected a path after --out=');
+      }
+      args.out = path.resolve(process.cwd(), outPath);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${token}`);
+  }
+  return args;
+}
+
+function escapeXml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+const numberFormatter = new Intl.NumberFormat('uk-UA');
+const percentFormatter = new Intl.NumberFormat('uk-UA', {
+  style: 'percent',
+  maximumFractionDigits: 1
+});
+
+function formatNumber(value) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return '—';
+  }
+  return numberFormatter.format(numeric);
+}
+
+function formatPercent(value) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return '—';
+  }
+  return percentFormatter.format(numeric);
+}
+
+function buildRows(players) {
+  const rowHeight = 74;
+  const startY = 280;
+  return players
+    .map((player, index) => {
+      const y = startY + index * rowHeight;
+      const rank = formatNumber(player.rank);
+      const name = escapeXml(player.player ?? 'Невідомо');
+      const points = formatNumber(player.season_points);
+      const games = formatNumber(player.games);
+      const winRate = formatPercent(player.winRate);
+      const mvps = formatNumber(player.MVP);
+      const badge = escapeXml(player.rankTier ?? '—');
+
+      return `
+        <g transform="translate(90 ${y})">
+          <rect x="0" y="-52" width="1020" height="62" rx="14" fill="rgba(10, 16, 34, 0.72)" stroke="rgba(255, 255, 255, 0.08)" />
+          <text x="30" y="-15" fill="#FFD700" font-size="36" font-weight="700" font-family="'Inter', 'DejaVu Sans', sans-serif">${rank}</text>
+          <text x="110" y="-15" fill="#F8F8FF" font-size="32" font-weight="600" font-family="'Inter', 'DejaVu Sans', sans-serif">${name}</text>
+          <text x="525" y="-15" fill="#FFD700" font-size="32" font-weight="600" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">${points}</text>
+          <text x="680" y="-15" fill="#9DD7FF" font-size="28" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">${games}</text>
+          <text x="830" y="-15" fill="#9DD7FF" font-size="28" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">${winRate}</text>
+          <text x="960" y="-15" fill="#FF66C4" font-size="28" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">${mvps}</text>
+          <g transform="translate(1010 -41)">
+            <rect x="0" y="0" width="60" height="32" rx="9" fill="#FF66C4" />
+            <text x="30" y="23" fill="#05070E" font-size="20" text-anchor="middle" font-weight="700" font-family="'Inter', 'DejaVu Sans', sans-serif">${badge}</text>
+          </g>
+        </g>`;
+    })
+    .join('');
+}
+
+function buildStats(pack) {
+  const aggregates = pack.aggregates ?? {};
+  const topPlayers = (pack.top10 ?? []).slice(0, 3);
+  const statBlocks = [
+    { label: 'Ігор сезону', value: formatNumber(aggregates.total_games) },
+    { label: 'Учасників', value: formatNumber(aggregates.players_in_rating ?? aggregates.players_with_games) },
+    { label: 'Раундів', value: formatNumber(aggregates.total_rounds) },
+    {
+      label: 'Очки топ-3',
+      value: formatNumber(
+        topPlayers.reduce((sum, player) => sum + (Number(player.season_points) || 0), 0)
+      )
+    }
+  ];
+
+  return statBlocks
+    .map((stat, index) => {
+      const x = 150 + index * 260;
+      return `
+        <g transform="translate(${x} 220)">
+          <rect x="0" y="-90" width="220" height="88" rx="18" fill="rgba(12, 24, 52, 0.78)" stroke="rgba(255, 255, 255, 0.06)" />
+          <text x="110" y="-52" fill="#9DD7FF" font-size="20" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">${escapeXml(stat.label)}</text>
+          <text x="110" y="-16" fill="#FFD700" font-size="34" font-weight="700" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">${stat.value}</text>
+        </g>`;
+    })
+    .join('');
+}
+
+function buildPodium(pack) {
+  const podium = pack.aggregates?.podium ?? {};
+  const entries = [
+    { color: '#FFD700', label: '1', name: podium.gold },
+    { color: '#C0C0C0', label: '2', name: podium.silver },
+    { color: '#CD7F32', label: '3', name: podium.bronze }
+  ];
+
+  return entries
+    .map((entry, index) => {
+      const x = 160 + index * 320;
+      return `
+        <g transform="translate(${x} 500)">
+          <rect x="0" y="-140" width="280" height="120" rx="24" fill="rgba(255, 255, 255, 0.05)" stroke="${entry.color}" stroke-width="3" />
+          <text x="40" y="-82" fill="${entry.color}" font-size="52" font-weight="700" font-family="'Inter', 'DejaVu Sans', sans-serif">${escapeXml(entry.label)}</text>
+          <text x="140" y="-82" fill="#F8F8FF" font-size="32" font-weight="600" font-family="'Inter', 'DejaVu Sans', sans-serif">${escapeXml(entry.name ?? '—')}</text>
+          <text x="140" y="-36" fill="#9DD7FF" font-size="22" font-family="'Inter', 'DejaVu Sans', sans-serif">П'єдестал</text>
+        </g>`;
+    })
+    .join('');
+}
+
+function createSvg(pack) {
+  const width = 1200;
+  const height = 630;
+  const meta = pack.meta ?? {};
+  const title = escapeXml(meta.season ?? 'Літній сезон 2025');
+  const subtitle = escapeXml(meta.league ?? 'Sunday League');
+
+  const topRows = buildRows((pack.top10 ?? []).slice(0, 5));
+  const stats = buildStats(pack);
+  const podium = buildPodium(pack);
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg-gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#05070E" />
+      <stop offset="50%" stop-color="#12092B" />
+      <stop offset="100%" stop-color="#250C3F" />
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.1" r="0.9">
+      <stop offset="0%" stop-color="rgba(255, 102, 196, 0.4)" />
+      <stop offset="100%" stop-color="rgba(255, 102, 196, 0)" />
+    </radialGradient>
+  </defs>
+  <rect width="${width}" height="${height}" fill="url(#bg-gradient)" />
+  <rect x="40" y="40" width="1120" height="550" rx="38" fill="rgba(9, 12, 28, 0.88)" stroke="rgba(255, 255, 255, 0.12)" stroke-width="2" />
+  <rect x="40" y="40" width="1120" height="550" rx="38" fill="url(#glow)" />
+  <text x="600" y="140" fill="#FFD700" font-size="64" font-weight="700" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">${title}</text>
+  <text x="600" y="190" fill="#9DD7FF" font-size="30" font-weight="500" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">${subtitle}</text>
+  <text x="110" y="248" fill="#9DD7FF" font-size="24" font-weight="500" font-family="'Inter', 'DejaVu Sans', sans-serif">Ранг</text>
+  <text x="200" y="248" fill="#9DD7FF" font-size="24" font-weight="500" font-family="'Inter', 'DejaVu Sans', sans-serif">Гравець</text>
+  <text x="525" y="248" fill="#9DD7FF" font-size="24" font-weight="500" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">Очки</text>
+  <text x="680" y="248" fill="#9DD7FF" font-size="24" font-weight="500" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">Ігор</text>
+  <text x="830" y="248" fill="#9DD7FF" font-size="24" font-weight="500" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">Win%</text>
+  <text x="960" y="248" fill="#9DD7FF" font-size="24" font-weight="500" text-anchor="middle" font-family="'Inter', 'DejaVu Sans', sans-serif">MVP</text>
+  ${stats}
+  ${topRows}
+  ${podium}
+</svg>`;
+}
+
+async function generateOgImage(outPath) {
+  const raw = await fs.promises.readFile(DATA_FILE, 'utf8');
+  const pack = JSON.parse(raw);
+  const svg = createSvg(pack);
+  await fs.promises.mkdir(path.dirname(outPath), { recursive: true });
+  const buffer = Buffer.from(svg, 'utf8');
+  await sharp(buffer, { density: 240 }).png({ compressionLevel: 9 }).toFile(outPath);
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+    console.error('\nUsage: node scripts/summer2025-og.js [--out path/to/output.png]');
+    return;
+  }
+
+  if (args.help) {
+    console.log('Generate the Summer 2025 social preview PNG.');
+    console.log('Usage: node scripts/summer2025-og.js [--out path/to/output.png]');
+    return;
+  }
+
+  const outPath = args.out ?? DEFAULT_OUTPUT;
+  try {
+    await generateOgImage(outPath);
+    const relative = path.relative(process.cwd(), outPath);
+    console.log(`Social preview generated at ${relative}`);
+  } catch (error) {
+    console.error('Failed to generate preview:');
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  parseArgs,
+  createSvg
+};

--- a/summer-2025.html
+++ b/summer-2025.html
@@ -22,13 +22,13 @@
     />
     <meta
       property="og:image"
-      content="https://laser.vartaclub.workers.dev/assets/background_marathon.png?v=2025-09-19-avatars-3"
+      content="https://laser.vartaclub.workers.dev/assets/summer2025-table-preview.png?v=2025-10-01-og"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta
       property="og:image:alt"
-      content="Неоновий фон із логотипом літнього сезону лазертагу 2025 року"
+      content="Попередній перегляд таблиці літнього сезону 2025 з топ-5 гравців та п'єдесталом"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Літній сезон 2025 | Лазертаг" />
@@ -38,7 +38,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://laser.vartaclub.workers.dev/assets/background_marathon.png?v=2025-09-19-avatars-3"
+      content="https://laser.vartaclub.workers.dev/assets/summer2025-table-preview.png?v=2025-10-01-og"
     />
     <script type="module" src="scripts/polyfills.js?v=2025-09-19-avatars-3"></script>
     <style>


### PR DESCRIPTION
## Summary
- ignore the generated Summer 2025 preview asset and local dependencies
- add an npm script backed by a sharp-based generator that accepts an --out path and creates the target folder
- document the deploy step for rebuilding the preview and point Summer 2025 meta tags at the new image URL

## Testing
- npm run build:summer2025-og -- --out assets/summer2025-table-preview.png

------
https://chatgpt.com/codex/tasks/task_e_68dc0870c8348321a816d98ebd70608b