### PR TITLE
Add daily summary and MVP counters to gameday view

### DIFF
--- a/gameday.html
+++ b/gameday.html
@@ -122,10 +122,99 @@
       color:#ffd700;
       font-size:1.1rem;
     }
+    .summary {
+      background: rgba(0, 0, 0, 0.6);
+      border: 2px solid rgba(243, 156, 18, 0.4);
+      box-shadow: 0 0 15px rgba(243, 156, 18, 0.25);
+      border-radius: 10px;
+      padding: 1rem;
+      margin-top: 1.5rem;
+    }
+    .summary h2 {
+      margin-bottom: 0.75rem;
+      color: #f39c12;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      font-size: 1rem;
+      text-align: center;
+    }
+    .summary h3 {
+      font-size: 0.8rem;
+      margin: 1rem 0 0.5rem;
+      color: #f39c12;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 0.75rem;
+    }
+    .summary-card {
+      background: rgba(17, 17, 17, 0.75);
+      border: 1px solid rgba(255, 215, 0, 0.15);
+      border-radius: 8px;
+      padding: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      text-align: center;
+    }
+    .summary-label {
+      font-size: 0.7rem;
+      color: rgba(255, 255, 255, 0.75);
+      text-transform: uppercase;
+    }
+    .summary-value {
+      font-size: 1.4rem;
+      color: #fff;
+    }
+    .summary-lists {
+      margin-top: 1rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+    .summary-list {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      padding: 0;
+    }
+    .summary-list li {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: rgba(0, 0, 0, 0.45);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 6px;
+      padding: 0.45rem 0.6rem;
+      font-size: 0.75rem;
+    }
+    .summary-player {
+      color: #fff;
+    }
+    .summary-badge {
+      padding: 0.2rem 0.4rem;
+      border-radius: 4px;
+      background: rgba(243, 156, 18, 0.2);
+      border: 1px solid rgba(243, 156, 18, 0.65);
+      color: #f39c12;
+      font-size: 0.7rem;
+    }
+    .summary-list li.summary-empty {
+      justify-content: center;
+      color: rgba(255, 255, 255, 0.6);
+    }
+    .hidden {
+      display: none !important;
+    }
     @media (max-width: 600px) {
       nav { font-size:0.75rem; }
       table { font-size:0.75rem; }
       select, input[type=date], .filters button { font-size:0.75rem; }
+      .summary-value { font-size: 1.05rem; }
     }
   </style>
 </head>
@@ -167,6 +256,54 @@
       </div>
     </section>
     </div>
+    <section id="summarySection" class="summary hidden">
+      <h2>Підсумки дня</h2>
+      <div class="summary-grid">
+        <div class="summary-card">
+          <div class="summary-label">Матчів зіграно</div>
+          <div class="summary-value" id="summaryMatches">0</div>
+        </div>
+        <div class="summary-card">
+          <div class="summary-label">Учасників дня</div>
+          <div class="summary-value" id="summaryPlayers">0</div>
+        </div>
+        <div class="summary-card">
+          <div class="summary-label">Сумарна дельта очок</div>
+          <div class="summary-value" id="summaryPoints">0</div>
+        </div>
+        <div class="summary-card">
+          <div class="summary-label">Перемоги (усього)</div>
+          <div class="summary-value" id="summaryWins">0</div>
+        </div>
+      </div>
+      <div class="summary-lists">
+        <div class="summary-subblock">
+          <h3>Топ дельти</h3>
+          <ul class="summary-list" id="topDeltaList"></ul>
+        </div>
+        <div class="summary-subblock">
+          <h3>Топ перемог</h3>
+          <ul class="summary-list" id="topWinsList"></ul>
+        </div>
+      </div>
+    </section>
+    <section id="mvpSection" class="summary hidden">
+      <h2>Нагороди дня</h2>
+      <div class="summary-grid">
+        <div class="summary-card">
+          <div class="summary-label">🏅 MVP</div>
+          <div class="summary-value" id="summaryMvp1">0</div>
+        </div>
+        <div class="summary-card">
+          <div class="summary-label">⭐ Срібло</div>
+          <div class="summary-value" id="summaryMvp2">0</div>
+        </div>
+        <div class="summary-card">
+          <div class="summary-label">⭐ Бронза</div>
+          <div class="summary-value" id="summaryMvp3">0</div>
+        </div>
+      </div>
+    </section>
   </div>
   <script src="scripts/toast.js?v=2025-09-19-avatars-2"></script>
   <script type="module" src="scripts/config.js?v=2025-09-19-avatars-2"></script>

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -31,6 +31,17 @@ import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
   const playersTb = document.getElementById('players');
   const matchesTb = document.getElementById('matches');
   const fullscreenBtn = document.getElementById('fullscreen');
+  const summarySection = document.getElementById('summarySection');
+  const mvpSection = document.getElementById('mvpSection');
+  const summaryMatchesEl = document.getElementById('summaryMatches');
+  const summaryPlayersEl = document.getElementById('summaryPlayers');
+  const summaryPointsEl = document.getElementById('summaryPoints');
+  const summaryWinsEl = document.getElementById('summaryWins');
+  const summaryMvp1El = document.getElementById('summaryMvp1');
+  const summaryMvp2El = document.getElementById('summaryMvp2');
+  const summaryMvp3El = document.getElementById('summaryMvp3');
+  const topDeltaList = document.getElementById('topDeltaList');
+  const topWinsList = document.getElementById('topWinsList');
 
   leagueSel.addEventListener('change', loadData);
   dateInput.addEventListener('change', loadData);
@@ -399,6 +410,107 @@ import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
     return `${vpIcons(a)} - ${vpIcons(b)}`;
   }
 
+  function toggleHidden(el, hidden){
+    if(!el) return;
+    el.classList.toggle('hidden', hidden);
+  }
+
+  function formatSigned(value){
+    const num = toNumber(value);
+    if(num > 0) return `+${num}`;
+    return `${num}`;
+  }
+
+  function populateList(listEl, items, formatter){
+    if(!listEl) return;
+    listEl.innerHTML = '';
+    if(!items.length){
+      const li = document.createElement('li');
+      li.className = 'summary-empty';
+      li.textContent = 'Немає даних';
+      listEl.appendChild(li);
+      return;
+    }
+    items.forEach((item, idx) => {
+      const { label, value } = formatter(item, idx);
+      const li = document.createElement('li');
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'summary-player';
+      nameSpan.textContent = label;
+      const valueSpan = document.createElement('span');
+      valueSpan.className = 'summary-badge';
+      valueSpan.textContent = value;
+      li.appendChild(nameSpan);
+      li.appendChild(valueSpan);
+      listEl.appendChild(li);
+    });
+  }
+
+  function renderDaySummary(dayStats, matches){
+    if(!summarySection || !mvpSection) return;
+    const entries = Object.entries(dayStats || {});
+    const totals = entries.reduce((acc, [, stats]) => {
+      acc.delta += toNumber(stats.delta);
+      acc.wins += toNumber(stats.wins);
+      acc.games += toNumber(stats.games);
+      acc.mvp1 += toNumber(stats.mvp1);
+      acc.mvp2 += toNumber(stats.mvp2);
+      acc.mvp3 += toNumber(stats.mvp3);
+      return acc;
+    }, { delta: 0, wins: 0, games: 0, mvp1: 0, mvp2: 0, mvp3: 0 });
+    totals.matches = matches.length;
+    totals.players = entries.length;
+
+    const hasMatches = totals.matches > 0;
+    toggleHidden(summarySection, !hasMatches);
+    toggleHidden(mvpSection, !hasMatches);
+
+    if(!hasMatches){
+      if(summaryMatchesEl) summaryMatchesEl.textContent = '0';
+      if(summaryPlayersEl) summaryPlayersEl.textContent = '0';
+      if(summaryPointsEl) summaryPointsEl.textContent = '0';
+      if(summaryWinsEl) summaryWinsEl.textContent = '0';
+      if(summaryMvp1El) summaryMvp1El.textContent = '0';
+      if(summaryMvp2El) summaryMvp2El.textContent = '0';
+      if(summaryMvp3El) summaryMvp3El.textContent = '0';
+      if(topDeltaList) topDeltaList.innerHTML = '';
+      if(topWinsList) topWinsList.innerHTML = '';
+      return;
+    }
+
+    if(summaryMatchesEl) summaryMatchesEl.textContent = `${totals.matches}`;
+    if(summaryPlayersEl) summaryPlayersEl.textContent = `${Math.max(totals.players, 0)}`;
+    if(summaryPointsEl) summaryPointsEl.textContent = formatSigned(totals.delta);
+    if(summaryWinsEl) summaryWinsEl.textContent = `${totals.wins}`;
+    if(summaryMvp1El) summaryMvp1El.textContent = `${totals.mvp1}`;
+    if(summaryMvp2El) summaryMvp2El.textContent = `${totals.mvp2}`;
+    if(summaryMvp3El) summaryMvp3El.textContent = `${totals.mvp3}`;
+
+    const topDelta = entries
+      .slice()
+      .sort((a,b)=>toNumber(b[1].delta) - toNumber(a[1].delta))
+      .slice(0,3);
+    const topWins = entries
+      .slice()
+      .sort((a,b)=>{
+        const winDiff = toNumber(b[1].wins) - toNumber(a[1].wins);
+        if(winDiff) return winDiff;
+        const gameDiff = toNumber(b[1].games) - toNumber(a[1].games);
+        if(gameDiff) return gameDiff;
+        return toNumber(b[1].delta) - toNumber(a[1].delta);
+      })
+      .slice(0,3);
+
+    populateList(topDeltaList, topDelta, ([nick, stats], idx) => ({
+      label: `${idx + 1}. ${nick}`,
+      value: `${formatSigned(stats.delta)} оч.`,
+    }));
+    populateList(topWinsList, topWins, ([nick, stats], idx) => ({
+      label: `${idx + 1}. ${nick}`,
+      value: `${toNumber(stats.wins)} / ${toNumber(stats.games)} ігор`,
+    }));
+  }
+
   function normalizeLeagueForFilter(v){
     return String(v || '').toLowerCase() === 'kids' ? 'kids' : 'sundaygames';
   }
@@ -416,6 +528,7 @@ import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
     }catch(err){
       playersTb.innerHTML = '';
       matchesTb.innerHTML = '';
+      renderDaySummary({}, []);
       log('[ranking]', err);
       const msg = 'Failed to load gameday data. Please try again later.';
       if (typeof showToast === 'function') showToast(msg); else alert(msg);
@@ -637,5 +750,6 @@ import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
       tds.forEach(td=>tr.appendChild(td));
       matchesTb.appendChild(tr);
     });
+    renderDaySummary(dayStats, preparedMatches);
   }
 })();


### PR DESCRIPTION
## Summary
- add summary and awards sections below the gameday tables
- compute aggregated per-player stats and feed totals/top performers into the new widgets
- align the new summary blocks with the existing visual style

## Testing
- npm test *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68e111e99ec08321807a6642dd8a065d