### PR TITLE
Add MVP awards column and rank change icons to gameday view

### DIFF
--- a/gameday.html
+++ b/gameday.html
@@ -96,6 +96,36 @@
     tbody tr:nth-child(odd){ background:rgba(255,255,255,0.05); }
     .up   { color:lime; }
     .down { color:red; }
+    .rank-header {
+      white-space: nowrap;
+    }
+    .rank-change-placeholder {
+      display: inline-flex;
+      width: 1.5rem;
+      justify-content: center;
+      color: rgba(255,255,255,0.3);
+      margin-left: 0.3rem;
+    }
+    .rank-cell {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+      white-space: nowrap;
+    }
+    .rank-cell .rank-change-icon {
+      width: 1.5rem;
+      text-align: center;
+      font-size: 0.85rem;
+    }
+    .rank-change-icon.up   { color: lime; }
+    .rank-change-icon.down { color: #ff4d4f; }
+    .rank-change-icon.same { color: #ffd700; }
+    .awards-cell {
+      font-size: 0.8rem;
+      color: #ffd700;
+      letter-spacing: 0.02em;
+    }
     .avatar-img { width:40px; height:40px; object-fit:cover; }
     .nick-S { color: magenta; }
     .nick-A { color: red; }
@@ -155,7 +185,18 @@
       <h2>Поточні гравці</h2>
       <div class="table-container">
         <table>
-          <thead><tr><th>Позиція (попередня)</th><th>Аватар</th><th>Нік</th><th>Бали</th><th>Ігор</th><th>Перемоги</th><th>Зміна</th></tr></thead>
+          <thead>
+            <tr>
+              <th class="rank-header">Позиція (попередня)<span class="rank-change-placeholder" aria-hidden="true">⬍</span></th>
+              <th>Аватар</th>
+              <th>Нік</th>
+              <th>Бали</th>
+              <th>Ігор</th>
+              <th>Перемоги</th>
+              <th>Нагороди (MVP/🥈/🥉)</th>
+              <th>Зміна</th>
+            </tr>
+          </thead>
           <tbody id="players"></tbody>
         </table>
       </div>

--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -561,6 +561,11 @@ import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
       let prevPts = toNumber(stateBeforeDay[nick]?.points);
       if(!(nick in baseState)) prevPts = 0;
       const currPts = toNumber(stateAtDayEnd[nick]?.points || (prevPts + stats.delta));
+      const prevRank = Number.isFinite(prevRankMap[nick]) ? prevRankMap[nick] : '-';
+      const currRank = Number.isFinite(currRankMap[nick]) ? currRankMap[nick] : '-';
+      const rankDiff = (Number.isFinite(currRankMap[nick]) && Number.isFinite(prevRankMap[nick]))
+        ? currRankMap[nick] - prevRankMap[nick]
+        : 0;
       return {
         nick,
         prevPts,
@@ -568,8 +573,12 @@ import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
         delta: stats.delta,
         wins: stats.wins,
         games: stats.games,
-        prevRank: prevRankMap[nick] || '-',
-        currRank: currRankMap[nick] || '-',
+        mvp1: toNumber(stats.mvp1),
+        mvp2: toNumber(stats.mvp2),
+        mvp3: toNumber(stats.mvp3),
+        prevRank,
+        currRank,
+        rankDiff,
       };
     }).sort((a,b)=>{
       const rankA = Number.isFinite(a.currRank) ? a.currRank : Number.MAX_SAFE_INTEGER;
@@ -586,7 +595,23 @@ import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
       const nClass='nick-'+rankLetterForPoints(p.pts);
 
       const rank=document.createElement('td');
-      rank.textContent=`${p.currRank} (${p.prevRank})`;
+      rank.className='rank-cell';
+      const rankText=document.createElement('span');
+      rankText.textContent=`${p.currRank} (${p.prevRank})`;
+      const rankIcon=document.createElement('span');
+      let rankIconClass='same';
+      let rankIconSymbol='😐';
+      if(p.rankDiff < 0){
+        rankIconClass='up';
+        rankIconSymbol='▲';
+      }else if(p.rankDiff > 0){
+        rankIconClass='down';
+        rankIconSymbol='▼';
+      }
+      rankIcon.className=`rank-change-icon ${rankIconClass}`;
+      rankIcon.textContent=rankIconSymbol;
+      rank.appendChild(rankText);
+      rank.appendChild(rankIcon);
 
       const tdAvatar=document.createElement('td');
       const img=document.createElement('img');
@@ -614,11 +639,15 @@ import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
       const wins=document.createElement('td');
       wins.textContent=p.wins;
 
+      const awards=document.createElement('td');
+      awards.className='awards-cell';
+      awards.textContent=`${p.mvp1} / ${p.mvp2} / ${p.mvp3}`;
+
       const delta=document.createElement('td');
       delta.className=cls;
       delta.textContent=`${arrow} ${(p.delta>0?'+':'')+p.delta}`;
 
-      [rank,tdAvatar,nick,pts,games,wins,delta].forEach(td=>tr.appendChild(td));
+      [rank,tdAvatar,nick,pts,games,wins,awards,delta].forEach(td=>tr.appendChild(td));
       playersTb.appendChild(tr);
     });
 


### PR DESCRIPTION
## Summary
- add an awards column and rank-change placeholder to the gameday leaderboard header
- compute per-player MVP counts and rank movement to render icons in the leaderboard
- style the new rank change indicators and awards column to match the existing design

## Testing
- npm run build:summer2025-og

------
https://chatgpt.com/codex/tasks/task_e_68e1786325d88321b581e57d60d03030