### PR TITLE
Update gameday MVP medal icons

### DIFF
--- a/scripts/gameday.js
+++ b/scripts/gameday.js
@@ -703,7 +703,7 @@ import { renderAllAvatars, reloadAvatars } from './avatars.client.js';
       tdScore.appendChild(vs);
 
       const tdMvp=document.createElement('td');
-      const labels=['🏅 MVP:','⭐ Срібна зірка:','⭐ Бронзова зірка:'];
+      const labels=['🏅 MVP:','🥈 Срібна медаль:','🥉 Бронзова медаль:'];
       match.mvp.forEach((mvps,idx)=>{
         const label=labels[idx];
         mvps.forEach(mv=>{


### PR DESCRIPTION
## Summary
- replace the gameday MVP labels with gold, silver, and bronze medal emojis so each row displays distinct icons

## Testing
- npm run build:summer2025-og

------
https://chatgpt.com/codex/tasks/task_e_68e17d89571c83219ab30663c0d277dd