### PR TITLE
Scope player profile historical stats by canonical league (v2)

### DIFF
--- a/v2/core/dataHub.js
+++ b/v2/core/dataHub.js
@@ -1,7 +1,7 @@
 // Changelog (Codex): safe rounds parsing, home snapshot top5/stats normalization, and battles/rounds consistency for Home/GameDay summaries.
 import seasonsConfig from './seasons.config.js';
 import { jsonp } from './utils.js';
-import { normalizeLeague as normalizeLeagueName } from './naming.js';
+import { leagueLabelUA, normalizeLeague as normalizeLeagueName, normalizeLeagueKey } from './naming.js';
 
 const cache = new Map();
 const inFlight = new Map();
@@ -65,6 +65,21 @@ function normalizePlayerKey(value = '') {
 function normalizeHeader(value = '') { return normalizePlayerKey(value); }
 function normalizeLeague(league = '') {
   return normalizeLeagueName(league);
+}
+
+function selectPlayerRowByLeague(players = [], targetNick = '', profileLeagueContext = '') {
+  const normalizedNick = normalizePlayerKey(targetNick);
+  const targetLeague = normalizeLeagueKey(profileLeagueContext);
+  const sameNick = (Array.isArray(players) ? players : [])
+    .filter((player) => normalizePlayerKey(player?.nickname || player?.Nickname || player?.nick || player?.Player) === normalizedNick);
+  if (!sameNick.length) return null;
+
+  const sameLeague = sameNick.filter((player) => normalizeLeagueKey(player?.League || player?.league || player?.league_id || player?.lg) === targetLeague);
+  if (sameLeague.length) return sameLeague[0];
+
+  const unknownLeague = sameNick.filter((player) => !normalizeLeagueKey(player?.League || player?.league || player?.league_id || player?.lg));
+  if (unknownLeague.length && sameNick.length === 1) return unknownLeague[0];
+  return null;
 }
 function toNumber(value, fallback = null) {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -1879,10 +1894,11 @@ export async function getSeasonPlayerQuickCard({ seasonId, league, nick } = {}) 
   };
 }
 
-export async function buildPlayerCareer(nick) {
+export async function buildPlayerCareer(nick, options = {}) {
   if (!nick) return null;
   const normalizedTargetNick = normalizePlayerKey(nick);
-  const key = `profile-all:${normalizedTargetNick}`;
+  const profileLeagueContext = normalizeLeague(typeof options === 'string' ? options : (options?.league || options?.profileLeagueContext || ''));
+  const key = `profile-all:${normalizedTargetNick}:${profileLeagueContext || 'all'}`;
   const cached = readCache(key, TTL.profile);
   if (cached) return cached;
 
@@ -1923,7 +1939,10 @@ export async function buildPlayerCareer(nick) {
     const players = Array.isArray(seasonMaster?.sections?.players) ? seasonMaster.sections.players : [];
     if (!players.length) continue;
 
-    const playerRow = players.find((player) => normalizePlayerKey(player?.nickname || player?.Nickname || player?.nick || player?.Player) === normalizedTargetNick);
+    const playerRow = selectPlayerRowByLeague(players, nick, profileLeagueContext)
+      || (!profileLeagueContext
+        ? players.find((player) => normalizePlayerKey(player?.nickname || player?.Nickname || player?.nick || player?.Player) === normalizedTargetNick)
+        : null);
     if (!playerRow) continue;
 
     const mvp1 = toNumber(playerRow?.MVP1 ?? playerRow?.mvp1, 0) || 0;
@@ -1940,10 +1959,14 @@ export async function buildPlayerCareer(nick) {
     const finalPlace = toNumber(playerRow?.Rank_final ?? playerRow?.rank_final, null);
     const winrate = matches ? Number(((wins / matches) * 100).toFixed(1)) : null;
 
+    const seasonLeague = normalizeLeague(playerRow?.League || playerRow?.league || '');
+    if (profileLeagueContext && seasonLeague !== profileLeagueContext) continue;
+
     const seasonRow = {
       seasonId,
       seasonTitle: seasonId,
-      league: normalizeLeague(playerRow?.League || playerRow?.league || '') || 'kids',
+      league: seasonLeague || profileLeagueContext || 'kids',
+      leagueLabel: leagueLabelUA(seasonLeague || profileLeagueContext || 'kids'),
       games: matches,
       matches,
       rounds: null,
@@ -2023,7 +2046,8 @@ export async function buildPlayerCareer(nick) {
   return writeCache(key, {
     nick,
     avatar: avatars.get(normalizedTargetNick) || '',
-    league: primaryLeague,
+    league: profileLeagueContext || primaryLeague,
+    profileLeagueContext: profileLeagueContext || primaryLeague,
     allTime: total,
     seasons: playedSeasons,
     highlights: {
@@ -2038,8 +2062,10 @@ export async function buildPlayerCareer(nick) {
   });
 }
 
-export async function getPlayerAllTimeProfile(nick) {
-  return buildPlayerCareer(nick);
+export async function getPlayerAllTimeProfile(nickOrOptions = {}) {
+  const nick = typeof nickOrOptions === 'object' ? nickOrOptions.nick : nickOrOptions;
+  const league = typeof nickOrOptions === 'object' ? nickOrOptions.league : undefined;
+  return buildPlayerCareer(nick, { league });
 }
 
 export async function getPlayerSeasonLogs({ nick, seasonId } = {}) {
@@ -2140,9 +2166,10 @@ export async function getSeasonOverview(seasonIdOrOptions = {}) {
 
 export async function getPlayerProfile(nickOrOptions = {}, leagueArg = 'kids') {
   const nick = typeof nickOrOptions === 'object' ? nickOrOptions.nick : nickOrOptions;
-  const profile = await getPlayerAllTimeProfile(nick);
+  const requestedLeague = normalizeLeague(typeof nickOrOptions === 'object' ? (nickOrOptions.league || leagueArg) : leagueArg) || 'kids';
+  const profile = await getPlayerAllTimeProfile({ nick, league: requestedLeague });
   if (!profile) return null;
-  const league = typeof nickOrOptions === 'object' ? (nickOrOptions.league || profile.league) : leagueArg;
+  const league = requestedLeague;
   const currentSeason = await getCurrentSeason();
   const snap = await getLeagueSnapshot(league, currentSeason.id);
   const current = snap.table.find((p) => normalizeHeader(p.nick) === normalizeHeader(nick));

--- a/v2/core/naming.js
+++ b/v2/core/naming.js
@@ -1,7 +1,15 @@
+export function normalizeLeagueKey(value) {
+  const s = String(value || '').trim().toLowerCase();
+  if (s === 'olds') return 'sundaygames';
+  if (s === 'sunday') return 'sundaygames';
+  if (s === 'adult') return 'sundaygames';
+  return s;
+}
+
 export function normalizeLeague(input) {
-  const value = String(input || '').trim().toLowerCase();
+  const value = normalizeLeagueKey(input);
   if (['kids', 'kid', 'child', 'діти', 'дитяча'].includes(value)) return 'kids';
-  if (['sundaygames', 'sunday', 'olds', 'old', 'adults', 'adult', 'дорослі', 'доросла'].includes(value)) return 'sundaygames';
+  if (['sundaygames', 'old', 'adults', 'дорослі', 'доросла'].includes(value)) return 'sundaygames';
   return '';
 }
 

--- a/v2/pages/profile.js
+++ b/v2/pages/profile.js
@@ -1,5 +1,5 @@
 import { buildPlayerCareer, getCurrentLeagueLiveStats, getCurrentSeason, getPlayerSeasonLogs, safeErrorMessage } from '../core/dataHub.js';
-import { normalizeLeague, leagueLabelUA } from '../core/naming.js';
+import { normalizeLeague, normalizeLeagueKey, leagueLabelUA } from '../core/naming.js';
 import { decodeParam, getRouteState, normalizePlayerKey } from '../core/utils.js';
 
 const placeholder = '../assets/default-avatar.svg';
@@ -39,8 +39,10 @@ function buildHash(route, params = {}) {
 function resolveParams(params = {}) {
   const { query: qp } = getRouteState();
   const rawNick = params.nick ?? qp.get('nick') ?? '';
+  const profileLeagueContext = normalizeLeague(params.league || qp.get('league') || 'kids') || 'kids';
   return {
-    league: normalizeLeague(params.league || qp.get('league') || 'kids') || 'kids',
+    league: profileLeagueContext,
+    profileLeagueContext,
     nick: decodeParam(rawNick)
   };
 }
@@ -203,7 +205,7 @@ export async function initProfilePage(params = {}) {
   const root = document.getElementById('profileRoot') || document.getElementById('view');
   if (!root) return;
 
-  const { nick, league } = resolveParams(params);
+  const { nick, league, profileLeagueContext: routeLeagueContext } = resolveParams(params);
   if (!nick) {
     root.innerHTML = `<section class="px-card"><h1 class="px-card__title">Профіль гравця</h1><p class="px-card__text">Не вказано нікнейм гравця.</p><div class="px-card__actions"><a class="btn btn--secondary" href="${buildHash('league-stats', { league })}">Назад до ліги</a></div></section>`;
     return;
@@ -213,7 +215,7 @@ export async function initProfilePage(params = {}) {
 
   try {
     const [profile, liveStats, currentSeason] = await Promise.all([
-      buildPlayerCareer(nick),
+      buildPlayerCareer(nick, { profileLeagueContext: routeLeagueContext }),
       getCurrentLeagueLiveStats(league),
       getCurrentSeason()
     ]);
@@ -226,6 +228,13 @@ export async function initProfilePage(params = {}) {
       return;
     }
 
+    const profileLeagueContext = normalizeLeague(
+      routeLeagueContext
+      || livePlayer?.league
+      || profile?.profileLeagueContext
+      || profile?.league
+      || league
+    ) || 'kids';
     const displayNick = livePlayer?.nickname || profile?.nick || nick;
     const seasonRows = profile?.seasons || [];
     const seasonRowsById = new Map(seasonRows.map((row) => [row.seasonId, row]));
@@ -233,7 +242,7 @@ export async function initProfilePage(params = {}) {
     const statusLine = [
       livePlayer?.place ? `#${livePlayer.place}` : '—',
       currentSeason?.uiLabel || 'Поточний сезон',
-      leagueLabelUA(league)
+      leagueLabelUA(profileLeagueContext)
     ].join(' • ');
 
     root.innerHTML = `
@@ -260,11 +269,11 @@ export async function initProfilePage(params = {}) {
     ], 'is-hero')}
           </div>
           <div class="profile-hero__actions">
-            <a class="btn btn--secondary" href="${buildHash('league-stats', { league })}">Назад до ліги</a>
+            <a class="btn btn--secondary" href="${buildHash('league-stats', { league: normalizeLeagueKey(profileLeagueContext) })}">Назад до ліги</a>
           </div>
         </article>
 
-        ${renderCurrentSummary({ league, livePlayer: livePlayer || {}, currentSeason })}
+        ${renderCurrentSummary({ league: profileLeagueContext, livePlayer: livePlayer || {}, currentSeason })}
         ${renderCareerSummary(profile || { allTime: {} })}
         ${renderCareerHighlights(profile?.highlights || {})}
 


### PR DESCRIPTION
### Motivation
- Prevent historical season rows from mixing kids and adult (`sundaygames`) leagues in player profile views by using a single canonical league key on the frontend. 
- Ensure season selector, career summary and season cards are built only from rows that match the opened profile league context.

### Description
- Added `normalizeLeagueKey()` and wired `normalizeLeague()` through it to provide a single canonical mapping for league inputs (`olds/sunday/adult -> 'sundaygames'`), kept `kids` / `sundaygames` as canonical values (`v2/core/naming.js`).
- Introduced `selectPlayerRowByLeague()` and made `buildPlayerCareer()` accept `profileLeagueContext` (used in cache key) to pick historical rows by nickname then by normalized league with a controlled fallback to unknown-league rows only when a single nickname match exists, and to skip rows from other leagues; each season entry now contains `league` and `leagueLabel` (`v2/core/dataHub.js`).
- Updated `getPlayerAllTimeProfile()` and `getPlayerProfile()` to pass requested league context into career building so all-time and current-season lookups are league-scoped (`v2/core/dataHub.js`).
- Updated profile page flow to read/preserve `profileLeagueContext` from route/query, pass it to `buildPlayerCareer(...)`, use canonical league values for UI labels and back-link, and render season selector from the already filtered seasons (`v2/pages/profile.js`).
- Changes are limited to `v2/` files: `v2/core/naming.js`, `v2/core/dataHub.js`, `v2/pages/profile.js`.

### Testing
- Performed static syntax checks with `node --check v2/core/naming.js && node --check v2/core/dataHub.js && node --check v2/pages/profile.js`, which succeeded.
- Ran project build `npm run build:summer2025-og` to verify runtime integration, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94ff91cf08321a33d0d7f59076b19)