### PR TITLE
v2: remove duplicate highlights and unify Last Game Day MVP logic

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -6602,6 +6602,55 @@ body.theme-game .league-page .league-dashboard-group--gameday .league-game-day-c
   content: none !important;
 }
 
+body.theme-game .league-page .league-dashboard-group--gameday .league-game-day-card--summary {
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 20px 18px;
+  border-radius: 12px;
+  gap: 14px;
+}
+
+body.theme-game .league-page .league-dashboard-group--gameday .league-game-day-card__headline {
+  margin-top: -2px !important;
+}
+
+body.theme-game .league-page .league-dashboard-group--gameday .league-game-day-stats {
+  width: 100%;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+body.theme-game .league-page .league-dashboard-group--gameday .league-game-day-stat {
+  min-height: 76px;
+  align-content: center;
+}
+
+body.theme-game .league-page .league-game-day-card__mvp {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  text-align: center;
+  padding-top: 8px;
+  border-top: 1px solid rgba(136, 167, 222, 0.18);
+}
+
+body.theme-game .league-page .league-game-day-card__mvp-label {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7fb7ff;
+}
+
+body.theme-game .league-page .league-game-day-card__mvp-value {
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: #f4f7ff;
+}
+
+body.theme-game .league-page .league-game-day-cta-button {
+  width: min(100%, 420px);
+}
+
 /* Final scoped polish: GameDay V2 */
 body.theme-game .gameday-v2 {
   display: grid;

--- a/v2/core/dataHub.js
+++ b/v2/core/dataHub.js
@@ -1380,22 +1380,21 @@ export async function getCurrentLeagueLiveStats(leagueId = 'kids') {
   const gamesByDay = new Map();
   liveGames.forEach((game) => {
     if (!game.date) return;
-    const day = gamesByDay.get(game.date) || { date: game.date, matchesCount: 0, battlesCount: 0, mvpCounter: new Map() };
+    const day = gamesByDay.get(game.date) || { date: game.date, matchesCount: 0, battlesCount: 0, matches: [] };
     day.matchesCount += 1;
     day.battlesCount += safeRoundCount(game.rawSeries) || 1;
-    const mvpKey = normalizeHeader(game.mvp1);
-    if (mvpKey) day.mvpCounter.set(mvpKey, (day.mvpCounter.get(mvpKey) || 0) + 1);
+    day.matches.push(game);
     gamesByDay.set(game.date, day);
   });
 
   const latestDay = [...gamesByDay.values()].sort((a, b) => b.date.localeCompare(a.date))[0] || null;
   const nicknameByKey = new Map(players.map((player) => [normalizeHeader(player.nickname), player.nickname]));
-  const topDayMvpKey = latestDay ? ([...latestDay.mvpCounter.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] || null) : null;
+  const latestDaySummary = latestDay ? getGameDaySummaryFromMatches(latestDay.matches, nicknameByKey) : null;
   const lastGameDay = latestDay ? {
     date: latestDay.date,
     matchesCount: latestDay.matchesCount,
     battlesCount: latestDay.battlesCount,
-    mvp: nicknameByKey.get(topDayMvpKey) || topDayMvpKey || null
+    mvp: latestDaySummary?.mvp || null
   } : { date: '', matchesCount: 0, battlesCount: 0, mvp: null };
 
   const result = {
@@ -1849,6 +1848,32 @@ export async function getHomeFast() {
     rankDistKids: getRankDistribution(kidsTable),
     rankDistAdults: getRankDistribution(adultsTable)
   });
+}
+
+function getGameDaySummaryFromMatches(matches = [], nicknameByKey = new Map()) {
+  const mvpRows = new Map();
+  const registerMvp = (nick, scoreValue = 0, mvp1Value = 0) => {
+    const key = normalizeHeader(nick);
+    if (!key) return;
+    const row = mvpRows.get(key) || { key, score: 0, mvp1: 0 };
+    row.score += scoreValue;
+    row.mvp1 += mvp1Value;
+    mvpRows.set(key, row);
+  };
+
+  (Array.isArray(matches) ? matches : []).forEach((match) => {
+    registerMvp(match?.mvp1, 3, 1);
+    registerMvp(match?.mvp2, 2, 0);
+    registerMvp(match?.mvp3, 1, 0);
+  });
+
+  const leader = [...mvpRows.values()].sort((a, b) => b.score - a.score || b.mvp1 - a.mvp1 || a.key.localeCompare(b.key, 'uk'))[0] || null;
+  if (!leader) return { mvp: null, mvpKey: null, mvpScore: 0 };
+  return {
+    mvp: nicknameByKey.get(leader.key) || leader.key,
+    mvpKey: leader.key,
+    mvpScore: leader.score
+  };
 }
 
 export async function getGameDayView({ dateYMD, league } = {}) {
@@ -2393,7 +2418,8 @@ export async function getGameDay(dateOrOptions = {}, leagueArg = 'kids') {
     .sort((a, b) => (a.placeAfter || 9999) - (b.placeAfter || 9999) || (b.delta || 0) - (a.delta || 0));
   const pointsPlayed = players.reduce((sum, p) => sum + Math.max(0, Number(p.delta) || 0), 0);
   const topGain = [...players].sort((a, b) => (b.delta || 0) - (a.delta || 0))[0] || null;
-  const mvpLeader = [...players].sort((a, b) => ((b.mvp1 * 3 + b.mvp2 * 2 + b.mvp3) - (a.mvp1 * 3 + a.mvp2 * 2 + a.mvp3)))[0] || null;
+  const nicknameByKey = new Map(players.map((player) => [normalizeHeader(player.nick), player.nick]));
+  const daySummary = getGameDaySummaryFromMatches(dayMatches, nicknameByKey);
   const winrateLeader = [...players]
     .filter((p) => p.matches > 0)
     .sort((a, b) => ((b.wins / b.matches) - (a.wins / a.matches)) || b.matches - a.matches)[0] || null;
@@ -2413,7 +2439,7 @@ export async function getGameDay(dateOrOptions = {}, leagueArg = 'kids') {
       participants: players.length,
       totalPointsPlayed: pointsPlayed,
       bestGain: topGain ? { nick: topGain.nick, delta: topGain.delta } : null,
-      mvpDay: mvpLeader ? { nick: mvpLeader.nick, score: mvpLeader.mvp1 * 3 + mvpLeader.mvp2 * 2 + mvpLeader.mvp3 } : null,
+      mvpDay: daySummary?.mvp ? { nick: daySummary.mvp, score: daySummary.mvpScore } : null,
       bestWinRate: winrateLeader ? { nick: winrateLeader.nick, winRate: Math.round((winrateLeader.wins / winrateLeader.matches) * 100), matches: winrateLeader.matches } : null
     }
   };

--- a/v2/pages/league-stats.js
+++ b/v2/pages/league-stats.js
@@ -185,25 +185,6 @@ function getSmallestPositiveGrowth(players = []) {
   return candidates[0] || null;
 }
 
-function highlightCard(player, value, label, tone) {
-  const cardClass = 'highlight-card card';
-  const theme = tone === 'mvp' ? 'is-mvp' : tone === 'gain' ? 'is-gain' : 'is-neutral';
-  if (!player) {
-    return `<article class="${cardClass} ${theme}">
-      <div class="highlight-type">${esc(label)}</div>
-      <div class="highlight-name">—</div>
-      <div class="highlight-value">—</div>
-      <div class="highlight-meta">Ще недостатньо даних</div>
-    </article>`;
-  }
-  return `<article class="${cardClass} ${theme}">
-    <div class="highlight-type">${esc(label)}</div>
-    <div class="highlight-name">${esc(player.nickname)}</div>
-    <div class="highlight-value">${esc(value)}</div>
-    <div class="highlight-meta">${esc(player.matches || 0)} ігор · ${esc(player.points || 0)} pts</div>
-  </article>`;
-}
-
 function renderHero(root, league, data) {
   root.innerHTML = `<div class="league-hero__eyebrow">\u0416\u0438\u0432\u0438\u0439 \u0441\u0435\u0437\u043e\u043d</div>
   <h1 class="px-card__title league-section-title">${esc(leagueLabelUA(league))}</h1>
@@ -212,6 +193,7 @@ function renderHero(root, league, data) {
 
 function renderGameDaySection(lastGameDay, league) {
   const day = lastGameDay || { date: '', matchesCount: 0, battlesCount: 0, mvp: null };
+  const gameDayHref = `#gameday?league=${encodeURIComponent(league)}${day.date ? `&date=${encodeURIComponent(day.date)}` : ''}`;
   return `<section class="league-dashboard-group league-dashboard-group--gameday">
     <h3 class="league-subtitle">\u041e\u0441\u0442\u0430\u043d\u043d\u0456\u0439 \u0456\u0433\u0440\u043e\u0432\u0438\u0439 \u0434\u0435\u043d\u044c</h3>
     <article class="league-game-day-card card league-game-day-card--summary">
@@ -229,10 +211,13 @@ function renderGameDaySection(lastGameDay, league) {
             <span class="league-game-day-stat__value">${esc(day.battlesCount || 0)}</span>
           </div>
         </div>
-        <div class="league-game-day-card__meta">${day.mvp ? `MVP \u0434\u043d\u044f: ${esc(day.mvp)}` : 'MVP \u0434\u043d\u044f \u0449\u0435 \u043d\u0435 \u0432\u0438\u0437\u043d\u0430\u0447\u0435\u043d\u0438\u0439'}</div>
+        <div class="league-game-day-card__mvp">
+          <span class="league-game-day-card__mvp-label">MVP дня</span>
+          <strong class="league-game-day-card__mvp-value">${esc(day.mvp || '\u2014')}</strong>
+        </div>
       </div>
     </article>
-    <a class="button-primary league-game-day-cta-button" href="#gameday?league=${encodeURIComponent(league)}">\u0412\u0456\u0434\u043a\u0440\u0438\u0442\u0438 \u0434\u0435\u043d\u044c</a>
+    <a class="button-primary league-game-day-cta-button" href="${gameDayHref}">\u0412\u0456\u0434\u043a\u0440\u0438\u0442\u0438 \u0434\u0435\u043d\u044c</a>
   </section>`;
 }
 
@@ -307,14 +292,6 @@ function renderInfographic(root, data, remainingGameDays, league) {
   <section class="league-dashboard-group league-dashboard-group--ranks">
     <h3 class="league-subtitle">Розподіл за рангами</h3>
     <div class="league-rank-list">${rankDistributionBlock(data.summary.rankDistribution || {}, playersCount)}</div>
-  </section>
-  <section class="league-dashboard-group league-dashboard-group--moments">
-    <h3 class="league-subtitle">Ключові моменти</h3>
-    <div class="league-highlights-grid league-highlights-grid--moments">
-      ${highlightCard(bestGrowth, bestGrowth ? fmtSigned(bestGrowth.delta) : '—', 'Прорив сезону', 'gain')}
-      ${highlightCard(data.progress?.mostMvp, data.progress?.mostMvp ? `${data.progress.mostMvp.mvpTotal || 0} MVP` : '—', 'MVP-лідер', 'mvp')}
-      ${highlightCard(mostActive, mostActive ? `${mostActive.matches || 0} ігор` : '—', 'Найактивніший гравець', 'neutral')}
-    </div>
   </section>
   ${renderGameDaySection(data.lastGameDay, league)}`;
 }
@@ -554,5 +531,3 @@ async function safeInitLeagueStatsPage(root, params = {}) {
     renderTables();
   });
 }
-
-


### PR DESCRIPTION
### Motivation
- The league detail page duplicated information in the “Ключові моменти” block which repeated the season awards, cluttering the composition.  
- The summary card “Останній ігровий день” looked visually disjointed and not center-aligned.  
- MVP for the last game day was computed inconsistently between the league summary and the game-day detail, causing mismatched MVPs and dates shown to users.

### Description
- Removed the whole duplicate "Ключові моменти" section and its render helper from the V2 league detail flow so the season awards are no longer repeated; the `highlightCard` helper was deleted and the section markup removed from `renderInfographic` in `v2/pages/league-stats.js`.  
- Rebuilt the “Останній ігровий день” summary card markup to a centered, single-card composition (dedicated MVP row, symmetrical stats, CTA sized/centered) and added scoped CSS polish for alignment and spacing in `v2/assets/css/main.css`.  
- Fixed the MVP/date inconsistency by introducing a single aggregation utility `getGameDaySummaryFromMatches(...)` in `v2/core/dataHub.js` and using it both for the league page last-day summary and for the game-day detail summary, so both places use the same source-of-truth.  
- Ensured the league summary CTA links to the exact day by passing `&date=...` in the hash (`#gameday?league=...&date=...`) so the detail page opens the same date shown in the summary.  
- Files changed: `v2/pages/league-stats.js`, `v2/core/dataHub.js`, `v2/assets/css/main.css`.

### Testing
- Ran syntax checks: `node --check v2/pages/league-stats.js && node --check v2/core/dataHub.js` — succeeded.  
- Ran project build step used in CI smoke: `npm run build:summer2025-og` — succeeded (generated social preview).  
- No automated unit tests were present/modified; changes limited to V2 UI/data mapping and validated with the above static checks and build command.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea3b4591083218cf68d3899f1ed92)