### PR TITLE
Вирівняти V2 profile styles і підсилити парсинг історичних сезонів

### DIFF
--- a/v2/core/dataHub.js
+++ b/v2/core/dataHub.js
@@ -50,6 +50,7 @@ const RANK_META = {
   F: { label: 'F', cssClass: 'rank-F', themeVars: { '--rank-color': '#444', '--rank-glow': 'rgba(68,68,68,.22)' } }
 };
 const RANK_THRESHOLDS = [['S', 1200], ['A', 1000], ['B', 800], ['C', 600], ['D', 400], ['E', 200], ['F', 0]];
+const RANK_PRIORITY = { S: 0, A: 1, B: 2, C: 3, D: 4, E: 5, F: 6 };
 const MAX_BATTLES_PER_GAME = 7;
 const ARCHIVE_LIMIT_ROWS = 1000;
 const SEASON_MASTER_API_URL = 'https://script.google.com/macros/s/AKfycbyDdfnyXW_RPX3TWN-WLK5whqS366ZhacX1nYJ4tVkfx898_CHhAZDB13eTYKgn5n7Q/exec';
@@ -205,17 +206,61 @@ function parseNullableNumber(value) {
   return toNumber(value, null);
 }
 
-function firstNumberFromAliases(row = {}, aliases = []) {
+function buildNormalizedRowMap(row = {}) {
   const source = (row && typeof row === 'object') ? row : {};
-  const normalizedMap = Object.entries(source).reduce((acc, [key, value]) => {
+  return Object.entries(source).reduce((acc, [key, value]) => {
     acc[normalizeHeader(key)] = value;
     return acc;
   }, {});
+}
+
+function firstRawFromAliases(row = {}, aliases = []) {
+  const normalizedMap = buildNormalizedRowMap(row);
+  for (const alias of aliases) {
+    const value = normalizedMap[normalizeHeader(alias)];
+    if (value !== undefined && value !== null && String(value).trim() !== '') return value;
+  }
+  return null;
+}
+
+function firstNumberFromAliases(row = {}, aliases = []) {
+  const normalizedMap = buildNormalizedRowMap(row);
 
   for (const alias of aliases) {
     const parsed = parseNullableNumber(normalizedMap[normalizeHeader(alias)]);
     if (parsed !== null) return parsed;
   }
+  return null;
+}
+
+function parseRankLetter(value) {
+  const raw = String(value ?? '').trim().toUpperCase();
+  if (!raw) return null;
+  const letterMatch = raw.match(/[SABCDEF]/);
+  return letterMatch ? letterMatch[0] : null;
+}
+
+function resolveSeasonRank(row = {}, ratingEnd = null) {
+  const explicitRaw = firstRawFromAliases(row, [
+    'Rank',
+    'rank',
+    'Rank_letter',
+    'rank_letter',
+    'rank_tier',
+    'Rank_tier',
+    'Rank_final',
+    'rank_final',
+    'Final_rank',
+    'final_rank',
+    'Tier',
+    'tier'
+  ]);
+  const explicitLetter = parseRankLetter(explicitRaw);
+  if (explicitLetter) return explicitLetter;
+
+  const explicitNumeric = parseNullableNumber(explicitRaw);
+  if (Number.isFinite(explicitNumeric) && explicitNumeric >= 150) return rankFromPoints(explicitNumeric);
+  if (Number.isFinite(ratingEnd)) return rankFromPoints(ratingEnd);
   return null;
 }
 
@@ -238,38 +283,56 @@ function resolveSeasonTitle(seasonMaster = {}, seasonId = '') {
 }
 
 function hasMeaningfulSeasonStats(entry = {}) {
-  const values = [
-    entry.matches,
+  const finite = (value) => Number.isFinite(value);
+  const signals = [
+    entry.ratingStart,
     entry.ratingEnd,
+    entry.delta,
+    entry.matches,
     entry.wins,
     entry.losses,
     entry.draws,
+    entry.winRate,
     entry.mvpTotal,
     entry.place,
-    entry.rank
-  ];
-  return values.some((value) => Number.isFinite(value));
+    entry.rounds
+  ].filter(finite).length;
+  const hasWld = [entry.wins, entry.losses, entry.draws].some(finite);
+  const hasRatingPair = finite(entry.ratingStart) && finite(entry.ratingEnd);
+  const hasPlayableVolume = finite(entry.matches) || finite(entry.rounds);
+  return signals >= 2 || (hasWld && hasPlayableVolume) || hasRatingPair;
 }
 
 function buildSeasonEntry(row = {}, { seasonId = '', seasonTitle = '', nickname = '', profileLeagueContext = '' } = {}) {
   const league = normalizeLeague(pickFirst(row.league, row.League, row.league_id, row.lg, profileLeagueContext));
-  const ratingStart = firstNumberFromAliases(row, ['Rating_start', 'rating_start']);
-  const ratingEnd = firstNumberFromAliases(row, ['Rating_end', 'rating_end', 'Rating', 'rating']);
-  const delta = firstNumberFromAliases(row, ['Rating_delta', 'rating_delta']);
-  const matches = firstNumberFromAliases(row, ['Matches', 'matches']);
-  const wins = firstNumberFromAliases(row, ['Wins', 'wins']);
-  const losses = firstNumberFromAliases(row, ['Losses', 'losses']);
-  const draws = firstNumberFromAliases(row, ['Draws', 'draws']);
-  const winRate = firstNumberFromAliases(row, ['Winrate_%', 'winrate_%', 'Winrate', 'winrate', 'win_rate']);
-  const mvp1 = firstNumberFromAliases(row, ['MVP1', 'mvp1']);
-  const mvp2 = firstNumberFromAliases(row, ['MVP2', 'mvp2']);
-  const mvp3 = firstNumberFromAliases(row, ['MVP3', 'mvp3']);
-  const mvpTotalRaw = firstNumberFromAliases(row, ['MVP_total', 'mvp_total', 'MVP', 'mvp']);
-  const mvpTotal = mvpTotalRaw ?? [mvp1, mvp2, mvp3].reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0);
-  const rounds = firstNumberFromAliases(row, ['Rounds', 'rounds']);
-  const place = firstNumberFromAliases(row, ['Place', 'place', 'Place_final', 'final_place']);
-  const rank = firstNumberFromAliases(row, ['Rank_final', 'rank_final', 'Rank', 'rank']);
+  const ratingStart = firstNumberFromAliases(row, ['Rating_start', 'rating_start', 'Start_rating', 'start_rating', 'Start points', 'start points']);
+  const ratingEnd = firstNumberFromAliases(row, ['Rating_end', 'rating_end', 'Final_rating', 'final_rating', 'Rating', 'rating', 'Points', 'points']);
+  const deltaRaw = firstNumberFromAliases(row, ['Rating_delta', 'rating_delta', 'Delta', 'delta', 'Points_delta', 'points_delta']);
+  const matches = firstNumberFromAliases(row, ['Matches', 'matches', 'Games', 'games', 'Played', 'played']);
+  const wins = firstNumberFromAliases(row, ['Wins', 'wins', 'Win', 'win']);
+  const losses = firstNumberFromAliases(row, ['Losses', 'losses', 'Lose', 'lose']);
+  const draws = firstNumberFromAliases(row, ['Draws', 'draws', 'Ties', 'ties']);
+  const winRateRaw = firstNumberFromAliases(row, ['Winrate_%', 'winrate_%', 'WR%', 'wr%', 'Winrate', 'winrate', 'Win_rate', 'win_rate', 'WR', 'wr']);
+  const mvp1 = firstNumberFromAliases(row, ['MVP1', 'mvp1', 'Top1', 'top1']);
+  const mvp2 = firstNumberFromAliases(row, ['MVP2', 'mvp2', 'Top2', 'top2']);
+  const mvp3 = firstNumberFromAliases(row, ['MVP3', 'mvp3', 'Top3', 'top3']);
+  const mvpTotalRaw = firstNumberFromAliases(row, ['MVP_total', 'mvp_total', 'MVP total', 'mvp total', 'MVP', 'mvp']);
+  const hasMvpBreakdown = [mvp1, mvp2, mvp3].some((value) => Number.isFinite(value));
+  const mvpTotal = Number.isFinite(mvpTotalRaw)
+    ? mvpTotalRaw
+    : (hasMvpBreakdown ? [mvp1, mvp2, mvp3].reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0) : null);
+  const rounds = firstNumberFromAliases(row, ['Rounds', 'rounds', 'Battles', 'battles']);
+  const placeRaw = firstNumberFromAliases(row, ['Place', 'place', 'Place_final', 'place_final', 'Final_place', 'final_place', 'Position', 'position']);
+  const place = Number.isFinite(placeRaw) && placeRaw > 0 ? placeRaw : null;
+  const delta = Number.isFinite(deltaRaw)
+    ? deltaRaw
+    : (Number.isFinite(ratingStart) && Number.isFinite(ratingEnd) ? ratingEnd - ratingStart : null);
+  const rank = resolveSeasonRank(row, ratingEnd);
   const normalizedNick = String(pickFirst(row.nickname, row.Nickname, row.nick, row.Player, row.player, nickname) || '').trim();
+  const computedWinRate = Number.isFinite(matches) && matches > 0 && Number.isFinite(wins) ? Number(((wins / matches) * 100).toFixed(1)) : null;
+  const winRate = Number.isFinite(winRateRaw)
+    ? (winRateRaw <= 1 ? Number((winRateRaw * 100).toFixed(1)) : winRateRaw)
+    : computedWinRate;
 
   return {
     seasonId,
@@ -284,7 +347,7 @@ function buildSeasonEntry(row = {}, { seasonId = '', seasonTitle = '', nickname 
     wins,
     losses,
     draws,
-    winRate: winRate ?? (Number.isFinite(matches) && matches > 0 && Number.isFinite(wins) ? Number(((wins / matches) * 100).toFixed(1)) : null),
+    winRate,
     mvp1,
     mvp2,
     mvp3,
@@ -297,7 +360,7 @@ function buildSeasonEntry(row = {}, { seasonId = '', seasonTitle = '', nickname 
     top2: mvp2,
     top3: mvp3,
     ratingDelta: delta,
-    winrate: winRate ?? (Number.isFinite(matches) && matches > 0 && Number.isFinite(wins) ? Number(((wins / matches) * 100).toFixed(1)) : null),
+    winrate: winRate,
     finalPlace: place,
     points: ratingEnd
   };
@@ -306,7 +369,8 @@ function buildSeasonEntry(row = {}, { seasonId = '', seasonTitle = '', nickname 
 function isValidSeasonEntry(entry = {}, { targetNick = '', profileLeagueContext = '' } = {}) {
   const nickMatches = normalizePlayerKey(entry.nickname) === normalizePlayerKey(targetNick);
   const leagueMatches = !profileLeagueContext || normalizeLeagueKey(entry.league) === normalizeLeagueKey(profileLeagueContext);
-  return nickMatches && leagueMatches && hasMeaningfulSeasonStats(entry);
+  const hasSeasonIdentity = Boolean(String(entry.seasonId || '').trim() && String(entry.seasonTitle || '').trim());
+  return nickMatches && leagueMatches && hasSeasonIdentity && hasMeaningfulSeasonStats(entry);
 }
 
 function collapseMeta(metaSection) {
@@ -364,6 +428,14 @@ export function rankFromPoints(points = 0) {
 }
 
 export function rankMeta(rank = 'F') { return RANK_META[rank] || RANK_META.F; }
+
+function isRankBetter(nextRank = null, currentRank = null) {
+  const next = String(nextRank || '').trim().toUpperCase();
+  if (!next || !Object.hasOwn(RANK_PRIORITY, next)) return false;
+  const current = String(currentRank || '').trim().toUpperCase();
+  if (!current || !Object.hasOwn(RANK_PRIORITY, current)) return true;
+  return RANK_PRIORITY[next] < RANK_PRIORITY[current];
+}
 
 function readCache(key, ttlMs) {
   const hit = cache.get(key);
@@ -2131,7 +2203,7 @@ export async function buildPlayerCareer(nick, options = {}) {
     total.cumulativeDelta += seasonEntry.delta || 0;
 
     if (Number.isFinite(seasonEntry.ratingEnd) && (total.peakPoints === null || seasonEntry.ratingEnd > total.peakPoints)) total.peakPoints = seasonEntry.ratingEnd;
-    if (Number.isFinite(seasonEntry.rank) && (total.bestRank === null || seasonEntry.rank < total.bestRank)) total.bestRank = seasonEntry.rank;
+    if (isRankBetter(seasonEntry.rank, total.bestRank)) total.bestRank = seasonEntry.rank;
   }
 
   if (!playedSeasons.length) return null;

--- a/v2/pages/profile.js
+++ b/v2/pages/profile.js
@@ -56,11 +56,11 @@ function rankClass(rank = 'F') {
 }
 
 function metricCard({ label, value, accent = false, mono = false }) {
-  return `<article class="profile-kpi ${accent ? 'is-accent' : ''} ${mono ? 'is-mono' : ''}"><strong class="profile-kpi__value">${esc(value)}</strong><span class="profile-kpi__label">${esc(label)}</span></article>`;
+  return `<article class="profile-metric-card ${accent ? 'is-accent' : ''} ${mono ? 'is-mono' : ''}"><strong class="profile-metric-card__value">${esc(value)}</strong><span class="profile-metric-card__label">${esc(label)}</span></article>`;
 }
 
 function metricsGrid(items = [], classes = '') {
-  return `<div class="profile-kpi-grid ${classes}">${items.map(metricCard).join('')}</div>`;
+  return `<div class="profile-metrics-grid ${classes}">${items.map(metricCard).join('')}</div>`;
 }
 
 function renderCareerHighlights(highlights = {}) {
@@ -78,7 +78,7 @@ function renderCareerHighlights(highlights = {}) {
   if (mvpRecord?.seasonTitle && Number.isFinite(mvpRecord.mvpTotal)) cards.push({ label: 'MVP RECORD', value: `${mvpRecord.seasonTitle} • ${mvpRecord.mvpTotal}` });
 
   if (!cards.length) return '';
-  return `<section class="px-card profile-section"><h2 class="profile-section__title">Відзнаки кар'єри</h2><div class="profile-award-grid">${cards.map((item) => `<article class="profile-award-card"><span class="profile-award-card__label">${esc(item.label)}</span><strong class="profile-award-card__value">${esc(item.value)}</strong></article>`).join('')}</div></section>`;
+  return `<section class="px-card profile-section"><h2 class="profile-section__title">Відзнаки кар'єри</h2><div class="profile-highlight-grid">${cards.map((item) => `<article class="profile-highlight-card"><span>${esc(item.label)}</span><strong>${esc(item.value)}</strong></article>`).join('')}</div></section>`;
 }
 
 function renderCurrentSummary({ league, livePlayer, currentSeason }) {
@@ -126,7 +126,7 @@ function renderCareerSummary(profile) {
 
 function renderSeasonTabs(container, tabs, selectedId) {
   container.innerHTML = tabs.map((tab) => `
-    <button type="button" class="profile-filter-tab ${tab.id === selectedId ? 'is-active' : ''}" data-season-id="${esc(tab.id)}">
+    <button type="button" class="profile-season-tab ${tab.id === selectedId ? 'is-active' : ''}" data-season-id="${esc(tab.id)}">
       <span>${esc(tab.label)}</span>
       ${tab.current ? '<em>CURRENT</em>' : ''}
     </button>
@@ -136,7 +136,7 @@ function renderSeasonTabs(container, tabs, selectedId) {
 function renderSeasonSummary(season, allTime) {
   if (!season || season.id === 'all') {
     return `
-      <section class="profile-season-panel">
+      <section class="profile-season-summary">
         <h3>Усі сезони</h3>
         <p class="profile-muted">Повний зріз карʼєри по всіх сезонах.</p>
         ${metricsGrid([
@@ -152,7 +152,7 @@ function renderSeasonSummary(season, allTime) {
   }
 
   return `
-      <section class="profile-season-panel">
+      <section class="profile-season-summary">
         <h3>${esc(season.seasonTitle || season.id)}</h3>
       <p class="profile-muted">${esc(leagueLabelUA(season.league || 'kids'))}</p>
       ${metricsGrid([
@@ -278,7 +278,7 @@ export async function initProfilePage(params = {}) {
 
         <section class="px-card profile-section">
           <h2 class="profile-section__title">Вибір сезону</h2>
-          <div class="profile-filter-tabs" id="seasonTabs"></div>
+          <div class="profile-season-tabs" id="seasonTabs"></div>
           <div id="seasonSummaryHost"></div>
           <div id="seasonLogsHost"></div>
         </section>


### PR DESCRIPTION
### Motivation
- Привести сторінку профілю у `v2/` до існуючої V2 design system без перевинайднання сторінки. 
- Усунути випадки, коли сезонні метрики парсяться неправильно і в UI з'являються «фейкові нулі» або змішані поля `rank/place`.

### Description
- Узгоджено CSS-класи у `v2/pages/profile.js` з наявними класами з `v2/assets/css/main.css`: `profile-kpi*` → `profile-metric-card*`, `profile-kpi-grid` → `profile-metrics-grid`, `profile-filter-tab` → `profile-season-tab`, `profile-season-panel` → `profile-season-summary`, `profile-award-card` → `profile-highlight-card`, та `profile-filter-tabs` → `profile-season-tabs` для селектора сезонів; при цьому збережено поточний порядок блоків (hero → current → career → highlights → season selector/detail → logs). 
- Розширено і зміцнено шар мапінгу/екстракції полів у `v2/core/dataHub.js`: додано `buildNormalizedRowMap`, `firstRawFromAliases`, розширені alias-списки для `ratingStart`, `ratingEnd`, `delta`, `matches`, `wins`, `losses`, `draws`, `winRate`, `mvp1/2/3`, `mvpTotal`, `place`, `rank`, `rounds`, та логіку нормалізації `winRate` (підтримка дробів 0..1 і відсотків). 
- Безпечніші правила для delta/place/rank: `delta` обчислюється коли відсутній явний `delta` як `ratingEnd - ratingStart` при наявності обох; `place` береться тільки з placement-полів та лише якщо >0; `rank` спочатку пробує explicit rank-letter/tier, потім пробує derive від `ratingEnd` через canonical `rankFromPoints`, щоб не підставляти place-like числа у `rank`. 
- Уникнення фейкових нулів: відсутні або невалідні числа лишаються `null` (UI рендерить `—` через вже існуючі `val()/pct()/signed()` хелпери), `mvpTotal` тепер `null` якщо немає ні total, ні коректного breakdown. 
- Жорсткіша валідація сезонного запису: `isValidSeasonEntry` тепер перевіряє співпадіння nickname, league, наявність season identity і достатню кількість meaningful metrics, тому биті рядки не рендеряться і не включаються до career aggregation. 
- Aggregation fixes: підрахунок career summary враховує тільки валідні сезони; `bestRank` агрегується за canonical rank-letters (додано `RANK_PRIORITY` і `isRankBetter`) замість числового порівняння, щоб уникнути некоректних порівнянь. 

### Testing
- Виконано синтаксичну перевірку файлів за допомогою `node --check`: `v2/pages/profile.js` — пройшов, `v2/core/dataHub.js` — пройшов.
- Локальна збірка/рантайм тестів не додавався; зміни обмежені `v2/` і зворотно сумісні з існуючими responsive правилами в `v2/assets/css/main.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3cd8617dc8321a0527c78b8b2245c)