### PR TITLE
Polish V2 rules page layout and mobile readability

### DIFF
--- a/v2/pages/rules.html
+++ b/v2/pages/rules.html
@@ -1,46 +1,48 @@
 <section id="rulesRoot" class="rules-v2">
   <article class="px-card rules-v2__hero">
-    <h1 class="px-card__title">Правила клубу та рейтингових ігор</h1>
-    <p class="px-card__text rules-v2__notice">⚠️ Правила оновлюються за рішенням інструкторів та організаторів.</p>
+    <p class="px-badge">V2 • Правила</p>
+    <h1 class="px-card__title rules-v2__page-title">Правила клубу та рейтингових ігор</h1>
+    <p class="px-card__text rules-v2__subtitle">Коротко про поведінку на полі, систему рейтингу та нарахування балів.</p>
+  </article>
+
+  <article class="px-card rules-v2__alert" role="note" aria-label="Важливе повідомлення">
+    <p class="rules-v2__alert-title">Важливо</p>
+    <p class="px-card__text rules-v2__alert-text">⚠️ Правила оновлюються за рішенням інструкторів та організаторів.</p>
   </article>
 
   <article class="px-card rules-v2__section">
     <h2 class="px-card__title">Загальні правила поведінки</h2>
+    <p class="px-card__text rules-v2__section-intro">Дотримання цих пунктів робить гру безпечною та комфортною для всіх.</p>
     <ul class="rules-v2__list">
-      <li>Дотримуйся вказівок інструктора.</li>
-      <li>Не використовуй нецензурну лексику та агресію.</li>
-      <li>Бережи обладнання та майно клубу.</li>
-      <li>Грай чесно — фейрплей понад усе!</li>
-      <li>Після гри поверни все обладнання.</li>
+      <li><span>Дотримуйся вказівок інструктора.</span></li>
+      <li><span>Не використовуй нецензурну лексику та агресію.</span></li>
+      <li><span>Бережи обладнання та майно клубу.</span></li>
+      <li><span>Грай чесно — фейрплей понад усе!</span></li>
+      <li><span>Після гри поверни все обладнання.</span></li>
     </ul>
   </article>
 
   <article class="px-card rules-v2__section">
     <h2 class="px-card__title">Нарахування балів</h2>
-    <div class="rules-v2__table-wrap">
-      <table class="rules-v2__points-table" aria-label="Нарахування балів">
-        <thead>
-          <tr><th>Подія</th><th>Бали</th></tr>
-        </thead>
-        <tbody>
-          <tr><td>Перемога</td><td>+20</td></tr>
-          <tr><td>MVP (1-й у списку)</td><td>+12</td></tr>
-          <tr><td>MVP (2-й у списку)</td><td>+7</td></tr>
-          <tr><td>MVP (3-й у списку)</td><td>+3</td></tr>
-          <tr><td>Участь F ранг</td><td>+0</td></tr>
-          <tr><td>Участь E ранг</td><td>-4</td></tr>
-          <tr><td>Участь D ранг</td><td>-6</td></tr>
-          <tr><td>Участь C ранг</td><td>-8</td></tr>
-          <tr><td>Участь B ранг</td><td>-10</td></tr>
-          <tr><td>Участь A ранг</td><td>-12</td></tr>
-          <tr><td>Участь S ранг</td><td>-14</td></tr>
-        </tbody>
-      </table>
-    </div>
+    <p class="px-card__text rules-v2__section-intro">Бали за події матчу та участь згідно з поточним рангом.</p>
+    <ul class="rules-v2__score-list" aria-label="Нарахування балів">
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Перемога</span><strong class="rules-v2__score-value">+20</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (1-й у списку)</span><strong class="rules-v2__score-value">+12</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (2-й у списку)</span><strong class="rules-v2__score-value">+7</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (3-й у списку)</span><strong class="rules-v2__score-value">+3</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь F ранг</span><strong class="rules-v2__score-value">+0</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь E ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-4</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь D ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-6</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь C ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-8</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь B ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-10</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь A ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-12</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь S ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-14</strong></li>
+    </ul>
   </article>
 
   <article class="px-card rules-v2__section">
     <h2 class="px-card__title">Ранги гравців</h2>
+    <p class="px-card__text rules-v2__section-intro">Що означає кожен ранг і який базовий штраф за участь він додає.</p>
     <div class="rules-v2__rank-grid">
       <div class="rules-v2__rank-item"><span class="rules-v2__rank-icon">⚪</span><div><strong>F ранг</strong><br>0–199 — новачки <span class="rules-v2__rank-penalty">0</span></div></div>
       <div class="rules-v2__rank-item"><span class="rules-v2__rank-icon">🟢</span><div><strong>E ранг</strong><br>200–399 — початківці <span class="rules-v2__rank-penalty">-4</span></div></div>
@@ -51,5 +53,4 @@
       <div class="rules-v2__rank-item"><span class="rules-v2__rank-icon">🟣</span><div><strong>S ранг</strong><br>1200+ — еліта <span class="rules-v2__rank-penalty">-14</span></div></div>
     </div>
   </article>
-
 </section>

--- a/v2/styles/pixel-layer.css
+++ b/v2/styles/pixel-layer.css
@@ -531,6 +531,222 @@ body::before, body::after { z-index: 0; }
 .rules-shell th, .rules-shell td { border: 1px solid rgba(173,232,255,.2); padding: 8px; }
 .rules-shell .btn { margin-top: 8px; }
 
+/* RULES V2 */
+.rules-v2 {
+  display: grid;
+  gap: .85rem;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.rules-v2 > .px-card {
+  gap: .72rem;
+  min-width: 0;
+  border-color: rgba(143, 217, 255, 0.26);
+}
+
+.rules-v2__hero {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(125deg, rgba(183, 255, 42, 0.08), transparent 28%),
+    linear-gradient(180deg, rgba(11, 18, 31, 0.94), rgba(7, 12, 22, 0.92));
+}
+
+.rules-v2__hero::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(143, 217, 255, 0.6), transparent);
+}
+
+.rules-v2__page-title {
+  font-size: clamp(1.28rem, 4.5vw, 1.7rem);
+  line-height: 1.15;
+}
+
+.rules-v2__subtitle {
+  max-width: 48ch;
+  line-height: 1.48;
+  color: rgba(227, 247, 255, 0.82);
+}
+
+.rules-v2__alert {
+  gap: .4rem !important;
+  padding-block: .62rem !important;
+  border-color: rgba(183, 255, 42, 0.45) !important;
+  background:
+    linear-gradient(180deg, rgba(27, 35, 11, 0.55), rgba(14, 23, 8, 0.46)),
+    var(--panel) center/100% 100% no-repeat url('../assets/pixel/frame.svg');
+}
+
+.rules-v2__alert-title {
+  margin: 0;
+  width: fit-content;
+  font-family: var(--font-mono);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  font-size: .7rem;
+  color: var(--accent);
+}
+
+.rules-v2__alert-text {
+  line-height: 1.45;
+}
+
+.rules-v2__section {
+  gap: .64rem;
+}
+
+.rules-v2__section .px-card__title {
+  font-size: clamp(1.03rem, 3.6vw, 1.25rem);
+  margin-bottom: .05rem;
+}
+
+.rules-v2__section-intro {
+  margin: 0;
+  max-width: 56ch;
+  line-height: 1.48;
+  color: rgba(227, 247, 255, 0.8);
+}
+
+.rules-v2__list {
+  list-style: none;
+  margin: .1rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: .48rem;
+}
+
+.rules-v2__list li {
+  display: grid;
+  grid-template-columns: 12px 1fr;
+  gap: .42rem;
+  align-items: start;
+  border: 1px solid rgba(143, 217, 255, 0.18);
+  background: rgba(8, 13, 24, 0.58);
+  border-radius: 8px;
+  padding: .5rem .58rem;
+  line-height: 1.45;
+}
+
+.rules-v2__list li::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  margin-top: .32rem;
+  border-radius: 2px;
+  background: linear-gradient(180deg, var(--accent), #59dbff);
+  box-shadow: 0 0 0 1px rgba(143, 217, 255, 0.38);
+}
+
+.rules-v2__score-list {
+  list-style: none;
+  margin: .12rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: .38rem;
+}
+
+.rules-v2__score-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: .6rem;
+  align-items: center;
+  border: 1px solid rgba(143, 217, 255, 0.2);
+  background: linear-gradient(180deg, rgba(8, 13, 24, 0.8), rgba(6, 11, 21, 0.84));
+  border-radius: 9px;
+  padding: .44rem .56rem;
+}
+
+.rules-v2__score-event {
+  min-width: 0;
+  line-height: 1.38;
+}
+
+.rules-v2__score-value {
+  font-family: var(--font-mono);
+  font-size: .88rem;
+  letter-spacing: .02em;
+  color: #b8ff2f;
+  border: 1px solid rgba(183, 255, 42, 0.5);
+  border-radius: 999px;
+  padding: .08rem .46rem;
+  background: rgba(113, 154, 33, 0.16);
+  white-space: nowrap;
+}
+
+.rules-v2__score-value--minus {
+  color: #ffb59f;
+  border-color: rgba(255, 138, 113, 0.5);
+  background: rgba(147, 58, 39, 0.2);
+}
+
+.rules-v2__rank-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .44rem;
+}
+
+.rules-v2__rank-item {
+  border: 1px solid rgba(143, 217, 255, 0.2);
+  background: rgba(7, 12, 22, 0.78);
+  border-radius: 8px;
+  padding: .46rem .52rem;
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: .42rem;
+  align-items: start;
+  line-height: 1.42;
+}
+
+.rules-v2__rank-icon {
+  font-size: 1rem;
+  text-align: center;
+}
+
+.rules-v2__rank-penalty {
+  display: inline-block;
+  margin-left: .26rem;
+  border: 1px solid rgba(255, 138, 113, 0.45);
+  border-radius: 999px;
+  padding: 0 .35rem;
+  font-family: var(--font-mono);
+  font-size: .72rem;
+  color: #ffb59f;
+}
+
+@media (max-width: 760px) {
+  .rules-v2 {
+    gap: .74rem;
+  }
+
+  .rules-v2 > .px-card {
+    padding: .72rem;
+  }
+
+  .rules-v2__rank-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .rules-v2__score-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+}
+
+@media (max-width: 420px) {
+  .rules-v2__score-event {
+    font-size: .92rem;
+  }
+
+  .rules-v2__score-value {
+    font-size: .8rem;
+    padding-inline: .4rem;
+  }
+}
+
 .league-toggle { display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
 .league-toggle label { min-height:44px; display:inline-flex; align-items:center; gap:6px; }
 


### PR DESCRIPTION
### Motivation
- Уніфікувати вигляд сторінки `Правила` з іншими V2 екранами, зберігаючи dark sci‑fi / HUD напрямок без перевантаження. 
- Поліпшити сканування та читабельність на мобільних (mobile‑first), прибрати ефект «сирого документа» та довгих суцільних блоків. 
- Зробити систему нарахування балів зручною для огляду на маленьких екранах без втрати даних.

### Description
- Рефакторинг структури сторінки в `v2/pages/rules.html`: верх поділено на hero (badge + title + subtitle) і легкий alert‑карточний блок, додано короткі intro тексти для секцій та замінено таблицю на mobile‑перший список рядків для нарахувань балів; весь зміст правил лишився без змін. 
- Додав новий блок стилів `/* RULES V2 */` в `v2/styles/pixel-layer.css` з правилами для: hero, alert, секцій, відступів, list‑item стилізації, мобільних breakpoint'ів, та стилізованих value‑чіпів для балів, підігнаних під V2 HUD систему. 
- Замінено табличну верстку на компактні рядки скорингу (`.rules-v2__score-list` / `.rules-v2__score-row`) щоб усунути горизонтальний скрол і покращити читабельність на телефонах. 
- Змінені файли: `v2/pages/rules.html` і `v2/styles/pixel-layer.css`.

### Testing
- Запущено юніт‑тести через `node --test tests/*.mjs`, всі тести пройшли (`4/4` — успішно). 
- Виконано збірку соціального превʼю через `npm run build:summer2025-og`, збірка пройшла успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6891b15ec832181614c4e3c681918)