### PR TITLE
Переробка сторінки «Правила» (v2) — чистіший mobile-first UX

### DIFF
--- a/v2/pages/rules.html
+++ b/v2/pages/rules.html
@@ -2,55 +2,140 @@
   <article class="px-card rules-v2__hero">
     <p class="px-badge">V2 • Правила</p>
     <h1 class="px-card__title rules-v2__page-title">Правила клубу та рейтингових ігор</h1>
-    <p class="px-card__text rules-v2__subtitle">Коротко про поведінку на полі, систему рейтингу та нарахування балів.</p>
+    <p class="px-card__text rules-v2__subtitle">Чіткі правила безпеки, поведінки та роботи з обладнанням, щоб гра залишалась чесною, комфортною і безпечною для всіх.</p>
   </article>
 
   <article class="px-card rules-v2__alert" role="note" aria-label="Важливе повідомлення">
-    <p class="rules-v2__alert-title">Важливо</p>
-    <p class="px-card__text rules-v2__alert-text">⚠️ Правила оновлюються за рішенням інструкторів та організаторів.</p>
+    <span class="rules-v2__alert-icon" aria-hidden="true">⚠️</span>
+    <div>
+      <p class="rules-v2__alert-title">Важливо</p>
+      <p class="px-card__text rules-v2__alert-text">Правила оновлюються за рішенням інструкторів та організаторів.</p>
+    </div>
   </article>
 
   <article class="px-card rules-v2__section">
-    <h2 class="px-card__title">Загальні правила поведінки</h2>
-    <p class="px-card__text rules-v2__section-intro">Дотримання цих пунктів робить гру безпечною та комфортною для всіх.</p>
-    <ul class="rules-v2__list">
-      <li><span>Дотримуйся вказівок інструктора.</span></li>
-      <li><span>Не використовуй нецензурну лексику та агресію.</span></li>
-      <li><span>Бережи обладнання та майно клубу.</span></li>
-      <li><span>Грай чесно — фейрплей понад усе!</span></li>
-      <li><span>Після гри поверни все обладнання.</span></li>
+    <div class="rules-v2__section-head">
+      <span class="rules-v2__section-icon" aria-hidden="true">🛡️</span>
+      <h2 class="px-card__title">Безпека на майданчику</h2>
+    </div>
+    <p class="px-card__text rules-v2__section-intro">Головний пріоритет під час гри — контроль руху та уникнення травм.</p>
+    <ul class="rules-v2__list" aria-label="Правила безпеки">
+      <li>Не залазь на фігури, укриття, конструкції та не лізь у вікна.</li>
+      <li>Завжди дивись під ноги та контролюй свій рух по майданчику.</li>
+      <li>Уникай зіткнень з іншими гравцями.</li>
+      <li>Тримай безпечну дистанцію.</li>
+      <li>Якщо помітив небезпеку або несправність — одразу звернись до інструктора.</li>
+    </ul>
+  </article>
+
+  <article class="px-card rules-v2__section">
+    <div class="rules-v2__section-head">
+      <span class="rules-v2__section-icon" aria-hidden="true">🤝</span>
+      <h2 class="px-card__title">Поведінка під час гри</h2>
+    </div>
+    <p class="px-card__text rules-v2__section-intro">Повага, дисципліна та фейрплей роблять матч сильнішим для кожного.</p>
+    <ul class="rules-v2__list" aria-label="Правила поведінки">
+      <li>Чітко виконуй вказівки інструктора.</li>
+      <li>Не сперечайся з інструктором під час гри та підготовки.</li>
+      <li>Заборонено нецензурну лайку на майданчику.</li>
+      <li>Заборонені образи, агресія та провокації.</li>
+      <li>Грай чесно — фейрплей понад усе.</li>
+      <li>Поважай інших гравців.</li>
+    </ul>
+  </article>
+
+  <article class="px-card rules-v2__section">
+    <div class="rules-v2__section-head">
+      <span class="rules-v2__section-icon" aria-hidden="true">🎯</span>
+      <h2 class="px-card__title">Обладнання та техніка</h2>
+    </div>
+    <p class="px-card__text rules-v2__section-intro">Справне спорядження та дбайливе ставлення до майна клубу — обовʼязкові.</p>
+    <ul class="rules-v2__list" aria-label="Правила поводження з обладнанням">
+      <li>Бережливо стався до техніки, спорядження та майна клубу.</li>
+      <li>Не використовуй обладнання не за призначенням.</li>
+      <li>Після гри поверни все обладнання в належному стані.</li>
+      <li>У разі несправності одразу повідом інструктора.</li>
     </ul>
   </article>
 
   <article class="px-card rules-v2__section">
     <h2 class="px-card__title">Нарахування балів</h2>
-    <p class="px-card__text rules-v2__section-intro">Бали за події матчу та участь згідно з поточним рангом.</p>
+    <p class="px-card__text rules-v2__section-intro">Ліворуч — подія матчу, праворуч — зміна рейтингу. Плюс за результат, мінус за участь залежно від рангу.</p>
     <ul class="rules-v2__score-list" aria-label="Нарахування балів">
       <li class="rules-v2__score-row"><span class="rules-v2__score-event">Перемога</span><strong class="rules-v2__score-value">+20</strong></li>
       <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (1-й у списку)</span><strong class="rules-v2__score-value">+12</strong></li>
       <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (2-й у списку)</span><strong class="rules-v2__score-value">+7</strong></li>
       <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (3-й у списку)</span><strong class="rules-v2__score-value">+3</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь F ранг</span><strong class="rules-v2__score-value">+0</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь E ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-4</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь D ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-6</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь C ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-8</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь B ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-10</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь A ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-12</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь S ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-14</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь • F ранг</span><strong class="rules-v2__score-value rules-v2__score-value--neutral">0</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь • E ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-4</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь • D ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-6</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь • C ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-8</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь • B ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-10</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь • A ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-12</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь • S ранг</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-14</strong></li>
     </ul>
   </article>
 
   <article class="px-card rules-v2__section">
     <h2 class="px-card__title">Ранги гравців</h2>
-    <p class="px-card__text rules-v2__section-intro">Що означає кожен ранг і який базовий штраф за участь він додає.</p>
-    <div class="rules-v2__rank-grid">
-      <div class="rules-v2__rank-item"><span class="rules-v2__rank-icon">⚪</span><div><strong>F ранг</strong><br>0–199 — новачки <span class="rules-v2__rank-penalty">0</span></div></div>
-      <div class="rules-v2__rank-item"><span class="rules-v2__rank-icon">🟢</span><div><strong>E ранг</strong><br>200–399 — початківці <span class="rules-v2__rank-penalty">-4</span></div></div>
-      <div class="rules-v2__rank-item"><span class="rules-v2__rank-icon">🔵</span><div><strong>D ранг</strong><br>400–599 — з досвідом <span class="rules-v2__rank-penalty">-6</span></div></div>
-      <div class="rules-v2__rank-item"><span class="rules-v2__rank-icon">🟡</span><div><strong>C ранг</strong><br>600–799 — досвідчені <span class="rules-v2__rank-penalty">-8</span></div></div>
-      <div class="rules-v2__rank-item"><span class="rules-v2__rank-icon">🟠</span><div><strong>B ранг</strong><br>800–999 — профі <span class="rules-v2__rank-penalty">-10</span></div></div>
-      <div class="rules-v2__rank-item"><span class="rules-v2__rank-icon">🔴</span><div><strong>A ранг</strong><br>1000–1199 — майстри <span class="rules-v2__rank-penalty">-12</span></div></div>
-      <div class="rules-v2__rank-item"><span class="rules-v2__rank-icon">🟣</span><div><strong>S ранг</strong><br>1200+ — еліта <span class="rules-v2__rank-penalty">-14</span></div></div>
-    </div>
+    <p class="px-card__text rules-v2__section-intro">Ранг показує поточний рівень гравця, діапазон очок і базове списання за участь у матчі.</p>
+    <ul class="rules-v2__rank-list" aria-label="Ранги гравців">
+      <li class="rules-v2__rank-item rules-v2__rank-item--F">
+        <span class="rules-v2__rank-dot" aria-hidden="true"></span>
+        <div class="rules-v2__rank-main">
+          <strong class="rules-v2__rank-name">F ранг — Вперше в грі</strong>
+          <span class="rules-v2__rank-range">0–199 очок</span>
+        </div>
+        <span class="rules-v2__rank-penalty">0</span>
+      </li>
+      <li class="rules-v2__rank-item rules-v2__rank-item--E">
+        <span class="rules-v2__rank-dot" aria-hidden="true"></span>
+        <div class="rules-v2__rank-main">
+          <strong class="rules-v2__rank-name">E ранг — Новачок</strong>
+          <span class="rules-v2__rank-range">200–399 очок</span>
+        </div>
+        <span class="rules-v2__rank-penalty">-4</span>
+      </li>
+      <li class="rules-v2__rank-item rules-v2__rank-item--D">
+        <span class="rules-v2__rank-dot" aria-hidden="true"></span>
+        <div class="rules-v2__rank-main">
+          <strong class="rules-v2__rank-name">D ранг — Початківець</strong>
+          <span class="rules-v2__rank-range">400–599 очок</span>
+        </div>
+        <span class="rules-v2__rank-penalty">-6</span>
+      </li>
+      <li class="rules-v2__rank-item rules-v2__rank-item--C">
+        <span class="rules-v2__rank-dot" aria-hidden="true"></span>
+        <div class="rules-v2__rank-main">
+          <strong class="rules-v2__rank-name">C ранг — Досвідчений</strong>
+          <span class="rules-v2__rank-range">600–799 очок</span>
+        </div>
+        <span class="rules-v2__rank-penalty">-8</span>
+      </li>
+      <li class="rules-v2__rank-item rules-v2__rank-item--B">
+        <span class="rules-v2__rank-dot" aria-hidden="true"></span>
+        <div class="rules-v2__rank-main">
+          <strong class="rules-v2__rank-name">B ранг — Сильний гравець</strong>
+          <span class="rules-v2__rank-range">800–999 очок</span>
+        </div>
+        <span class="rules-v2__rank-penalty">-10</span>
+      </li>
+      <li class="rules-v2__rank-item rules-v2__rank-item--A">
+        <span class="rules-v2__rank-dot" aria-hidden="true"></span>
+        <div class="rules-v2__rank-main">
+          <strong class="rules-v2__rank-name">A ранг — Майстер</strong>
+          <span class="rules-v2__rank-range">1000–1199 очок</span>
+        </div>
+        <span class="rules-v2__rank-penalty">-12</span>
+      </li>
+      <li class="rules-v2__rank-item rules-v2__rank-item--S">
+        <span class="rules-v2__rank-dot" aria-hidden="true"></span>
+        <div class="rules-v2__rank-main">
+          <strong class="rules-v2__rank-name">S ранг — Еліта</strong>
+          <span class="rules-v2__rank-range">1200+ очок</span>
+        </div>
+        <span class="rules-v2__rank-penalty">-14</span>
+      </li>
+    </ul>
   </article>
 </section>

--- a/v2/styles/pixel-layer.css
+++ b/v2/styles/pixel-layer.css
@@ -534,7 +534,7 @@ body::before, body::after { z-index: 0; }
 /* RULES V2 */
 .rules-v2 {
   display: grid;
-  gap: .85rem;
+  gap: .9rem;
   width: 100%;
   max-width: 100%;
   min-width: 0;
@@ -543,14 +543,14 @@ body::before, body::after { z-index: 0; }
 .rules-v2 > .px-card {
   gap: .72rem;
   min-width: 0;
-  border-color: rgba(143, 217, 255, 0.26);
+  border-color: rgba(143, 217, 255, 0.24);
 }
 
 .rules-v2__hero {
   position: relative;
   overflow: hidden;
   background:
-    linear-gradient(125deg, rgba(183, 255, 42, 0.08), transparent 28%),
+    linear-gradient(125deg, rgba(183, 255, 42, 0.07), transparent 30%),
     linear-gradient(180deg, rgba(11, 18, 31, 0.94), rgba(7, 12, 22, 0.92));
 }
 
@@ -559,32 +559,38 @@ body::before, body::after { z-index: 0; }
   position: absolute;
   inset: auto 0 0;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(143, 217, 255, 0.6), transparent);
+  background: linear-gradient(90deg, transparent, rgba(143, 217, 255, 0.58), transparent);
 }
 
 .rules-v2__page-title {
-  font-size: clamp(1.28rem, 4.5vw, 1.7rem);
-  line-height: 1.15;
+  font-size: clamp(1.3rem, 4.7vw, 1.76rem);
+  line-height: 1.16;
 }
 
 .rules-v2__subtitle {
-  max-width: 48ch;
-  line-height: 1.48;
-  color: rgba(227, 247, 255, 0.82);
+  margin: 0;
+  max-width: 54ch;
+  line-height: 1.5;
+  color: rgba(227, 247, 255, 0.84);
 }
 
 .rules-v2__alert {
-  gap: .4rem !important;
-  padding-block: .62rem !important;
-  border-color: rgba(183, 255, 42, 0.45) !important;
-  background:
-    linear-gradient(180deg, rgba(27, 35, 11, 0.55), rgba(14, 23, 8, 0.46)),
-    var(--panel) center/100% 100% no-repeat url('../assets/pixel/frame.svg');
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: .56rem !important;
+  border-color: rgba(183, 255, 42, 0.4) !important;
+  background: linear-gradient(180deg, rgba(24, 33, 11, 0.48), rgba(12, 20, 10, 0.44));
+}
+
+.rules-v2__alert-icon {
+  font-size: 1.05rem;
+  line-height: 1.2;
+  margin-top: .05rem;
 }
 
 .rules-v2__alert-title {
   margin: 0;
-  width: fit-content;
   font-family: var(--font-mono);
   letter-spacing: .08em;
   text-transform: uppercase;
@@ -593,71 +599,83 @@ body::before, body::after { z-index: 0; }
 }
 
 .rules-v2__alert-text {
+  margin: .16rem 0 0;
   line-height: 1.45;
 }
 
 .rules-v2__section {
-  gap: .64rem;
+  gap: .68rem;
+}
+
+.rules-v2__section-head {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+}
+
+.rules-v2__section-icon {
+  width: 1.4rem;
+  text-align: center;
+  flex: 0 0 auto;
+  opacity: .92;
 }
 
 .rules-v2__section .px-card__title {
-  font-size: clamp(1.03rem, 3.6vw, 1.25rem);
-  margin-bottom: .05rem;
+  margin: 0;
+  font-size: clamp(1.02rem, 3.8vw, 1.24rem);
 }
 
 .rules-v2__section-intro {
   margin: 0;
-  max-width: 56ch;
-  line-height: 1.48;
+  max-width: 58ch;
+  line-height: 1.5;
   color: rgba(227, 247, 255, 0.8);
 }
 
-.rules-v2__list {
+.rules-v2__list,
+.rules-v2__score-list,
+.rules-v2__rank-list {
   list-style: none;
   margin: .1rem 0 0;
   padding: 0;
   display: grid;
-  gap: .48rem;
+}
+
+.rules-v2__list {
+  gap: .34rem;
 }
 
 .rules-v2__list li {
-  display: grid;
-  grid-template-columns: 12px 1fr;
-  gap: .42rem;
-  align-items: start;
-  border: 1px solid rgba(143, 217, 255, 0.18);
-  background: rgba(8, 13, 24, 0.58);
-  border-radius: 8px;
-  padding: .5rem .58rem;
+  position: relative;
+  border-bottom: 1px solid rgba(143, 217, 255, 0.14);
+  padding: .42rem 0 .42rem 1rem;
   line-height: 1.45;
 }
 
 .rules-v2__list li::before {
   content: '';
-  width: 7px;
-  height: 7px;
-  margin-top: .32rem;
+  position: absolute;
+  left: .16rem;
+  top: .92rem;
+  width: .38rem;
+  height: .38rem;
   border-radius: 2px;
-  background: linear-gradient(180deg, var(--accent), #59dbff);
-  box-shadow: 0 0 0 1px rgba(143, 217, 255, 0.38);
+  background: linear-gradient(180deg, var(--accent), #5dd8ff);
+  box-shadow: 0 0 0 1px rgba(143, 217, 255, 0.28);
 }
 
 .rules-v2__score-list {
-  list-style: none;
-  margin: .12rem 0 0;
-  padding: 0;
-  display: grid;
-  gap: .38rem;
+  gap: .4rem;
 }
 
 .rules-v2__score-row {
   display: grid;
-  grid-template-columns: 1fr auto;
-  gap: .6rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: .62rem;
   align-items: center;
-  border: 1px solid rgba(143, 217, 255, 0.2);
-  background: linear-gradient(180deg, rgba(8, 13, 24, 0.8), rgba(6, 11, 21, 0.84));
-  border-radius: 9px;
+  border: 1px solid rgba(143, 217, 255, 0.18);
+  background: rgba(7, 12, 22, 0.78);
+  border-radius: 8px;
   padding: .44rem .56rem;
 }
 
@@ -668,14 +686,20 @@ body::before, body::after { z-index: 0; }
 
 .rules-v2__score-value {
   font-family: var(--font-mono);
-  font-size: .88rem;
+  font-size: .84rem;
   letter-spacing: .02em;
   color: #b8ff2f;
   border: 1px solid rgba(183, 255, 42, 0.5);
   border-radius: 999px;
-  padding: .08rem .46rem;
+  padding: .08rem .44rem;
   background: rgba(113, 154, 33, 0.16);
   white-space: nowrap;
+}
+
+.rules-v2__score-value--neutral {
+  color: rgba(227, 247, 255, 0.85);
+  border-color: rgba(143, 217, 255, 0.4);
+  background: rgba(50, 83, 105, 0.26);
 }
 
 .rules-v2__score-value--minus {
@@ -684,66 +708,95 @@ body::before, body::after { z-index: 0; }
   background: rgba(147, 58, 39, 0.2);
 }
 
-.rules-v2__rank-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: .44rem;
+.rules-v2__rank-list {
+  gap: .42rem;
 }
 
 .rules-v2__rank-item {
+  --rank-color: var(--rank-f);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: .5rem;
   border: 1px solid rgba(143, 217, 255, 0.2);
   background: rgba(7, 12, 22, 0.78);
   border-radius: 8px;
-  padding: .46rem .52rem;
-  display: grid;
-  grid-template-columns: 24px 1fr;
-  gap: .42rem;
-  align-items: start;
-  line-height: 1.42;
+  padding: .46rem .56rem;
 }
 
-.rules-v2__rank-icon {
-  font-size: 1rem;
-  text-align: center;
+.rules-v2__rank-dot {
+  width: .6rem;
+  height: .6rem;
+  border-radius: 999px;
+  background: var(--rank-color);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.rules-v2__rank-main {
+  min-width: 0;
+  display: grid;
+  gap: .06rem;
+}
+
+.rules-v2__rank-name {
+  line-height: 1.35;
+}
+
+.rules-v2__rank-range {
+  font-size: .85rem;
+  color: rgba(227, 247, 255, 0.76);
 }
 
 .rules-v2__rank-penalty {
-  display: inline-block;
-  margin-left: .26rem;
   border: 1px solid rgba(255, 138, 113, 0.45);
   border-radius: 999px;
-  padding: 0 .35rem;
+  padding: 0 .38rem;
   font-family: var(--font-mono);
   font-size: .72rem;
   color: #ffb59f;
+  white-space: nowrap;
 }
+
+.rules-v2__rank-item--S { --rank-color: var(--rank-s); }
+.rules-v2__rank-item--A { --rank-color: var(--rank-a); }
+.rules-v2__rank-item--B { --rank-color: var(--rank-b); }
+.rules-v2__rank-item--C { --rank-color: var(--rank-c); }
+.rules-v2__rank-item--D { --rank-color: var(--rank-d); }
+.rules-v2__rank-item--E { --rank-color: var(--rank-e); }
+.rules-v2__rank-item--F { --rank-color: var(--rank-f); }
 
 @media (max-width: 760px) {
   .rules-v2 {
-    gap: .74rem;
+    gap: .76rem;
   }
 
   .rules-v2 > .px-card {
     padding: .72rem;
   }
+}
 
-  .rules-v2__rank-grid {
-    grid-template-columns: 1fr;
+@media (max-width: 520px) {
+  .rules-v2__rank-item {
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: .44rem;
   }
 
-  .rules-v2__score-row {
-    grid-template-columns: minmax(0, 1fr) auto;
+  .rules-v2__rank-penalty {
+    justify-self: start;
+    margin-left: 1.02rem;
   }
 }
 
 @media (max-width: 420px) {
-  .rules-v2__score-event {
+  .rules-v2__score-event,
+  .rules-v2__list li,
+  .rules-v2__rank-name {
     font-size: .92rem;
   }
 
   .rules-v2__score-value {
-    font-size: .8rem;
-    padding-inline: .4rem;
+    font-size: .78rem;
+    padding-inline: .38rem;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Покращити читабельність та mobile-first UX сторінки «Правила», зменшити кількість зайвих овальних рамок і привести візуальну мову до загального V2 dark HUD стилю. 
- Зберегти існуючу структуру V2 та router, зробити мінімальні і спрямовані зміни для кращої ієрархії й менше візуального шуму. 
- Skills used: no external skill was required for these edits.

### Description
- Змінено тільки файли `v2/pages/rules.html` і `v2/styles/pixel-layer.css` для реструктуризації і стилізації сторінки під V2 (hero, alert, секції правил, scoring, ranks). 
- Розбито правила на три логічні секції — «Безпека на майданчику», «Поведінка під час гри» і «Обладнання та техніка» — з короткими інтро і компактними рядками-пунктами, додано всі запитані пункти. 
- Перероблено блок «Нарахування балів» у компактні score-rows з value-chips (позитив/нейтраль/штраф) і оновлено блок «Ранги гравців» на сучасні рядки з кольоровим індикатором, назвою, діапазоном та penalty справа, збережено всі діапазони і штрафи. 
- Спрощено CSS: зменшено вкладені декоративні рамки, прибрано зайві «капсули», вирівняно типографіку і додано mobile-first правила щоб уникнути горизонтального overflow.

### Testing
- Виконано синтаксичну перевірку JS через `node --check v2/pages/rules.js` і вона пройшла успішно. 
- Перевірка наявності ключових секцій у HTML виконана через Node (`node -e` quick assertion) і пройшла успішно. 
- Прогон простого контролю збалансованості фігурних дужок CSS виконано через Python (brace-balance) і пройшов успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6939fec748321a7c09e8e9dd592de)