### PR TITLE
Isolate & simplify V2 Rules page: remove oval/pill style conflicts

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -7523,3 +7523,227 @@ body.theme-game .table-wrap > table {
     padding: 6px 2px 8px !important;
   }
 }
+
+/* Rules V2 clean layout: isolate from decorative/pill global overrides */
+body.theme-game .rules-v2.rules-v2--clean,
+.rules-v2.rules-v2--clean {
+  width: min(100%, 860px);
+  margin: 0 auto;
+  display: grid;
+  gap: .75rem;
+}
+
+body.theme-game .rules-v2.rules-v2--clean > .px-card,
+.rules-v2.rules-v2--clean > .px-card {
+  margin: 0;
+  padding: .9rem;
+  border: 1px solid rgba(146, 176, 223, .24);
+  border-radius: 14px !important;
+  background: linear-gradient(180deg, rgba(11, 18, 31, .92), rgba(8, 14, 25, .9));
+  box-shadow: none;
+}
+
+body.theme-game .rules-v2.rules-v2--clean > .px-card::before,
+body.theme-game .rules-v2.rules-v2--clean > .px-card::after,
+.rules-v2.rules-v2--clean > .px-card::before,
+.rules-v2.rules-v2--clean > .px-card::after {
+  content: none !important;
+}
+
+.rules-v2.rules-v2--clean :is(.px-card__title, .px-card__text) {
+  margin: 0;
+  text-align: left !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
+.rules-v2--clean .rules-v2__title {
+  margin: 0;
+  font-size: clamp(1.28rem, 3.2vw, 1.62rem);
+  font-weight: 800;
+  letter-spacing: .01em;
+  line-height: 1.2;
+}
+
+.rules-v2--clean .rules-v2__intro {
+  margin: .38rem 0 0;
+  color: var(--muted);
+  line-height: 1.48;
+}
+
+.rules-v2--clean .rules-v2__alert {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: .58rem;
+  align-items: start;
+}
+
+.rules-v2--clean .rules-v2__alert-icon {
+  width: 1.35rem;
+  text-align: center;
+  line-height: 1.35rem;
+}
+
+.rules-v2--clean .rules-v2__alert-label {
+  margin: 0;
+  font-size: .8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: #ffd98a;
+}
+
+.rules-v2--clean .rules-v2__alert-text {
+  margin: .12rem 0 0;
+  line-height: 1.45;
+}
+
+.rules-v2--clean .rules-v2__section-title {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.28;
+}
+
+.rules-v2--clean .rules-v2__section-intro {
+  margin: .34rem 0 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.rules-v2--clean .rules-v2__list,
+.rules-v2--clean .rules-v2__score-list,
+.rules-v2--clean .rules-v2__rank-list {
+  list-style: none;
+  margin: .62rem 0 0;
+  padding: 0;
+}
+
+.rules-v2--clean .rules-v2__list-item {
+  margin: 0;
+  padding: .5rem 0 .5rem 1.15rem;
+  position: relative;
+  line-height: 1.5;
+  border-top: 1px solid rgba(255, 255, 255, .1);
+}
+
+.rules-v2--clean .rules-v2__list-item::before {
+  content: '';
+  position: absolute;
+  left: .16rem;
+  top: 1.04rem;
+  width: .36rem;
+  height: .36rem;
+  border-radius: 50%;
+  background: rgba(49, 208, 255, .9);
+}
+
+.rules-v2--clean .rules-v2__score-row,
+.rules-v2--clean .rules-v2__rank-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: .6rem;
+  padding: .5rem 0;
+  border-top: 1px solid rgba(255, 255, 255, .1);
+}
+
+.rules-v2--clean .rules-v2__score-event {
+  min-width: 0;
+  line-height: 1.4;
+}
+
+.rules-v2--clean .rules-v2__score-badge,
+.rules-v2--clean .rules-v2__rank-value {
+  border-radius: 999px !important;
+  border: 1px solid rgba(255, 255, 255, .2);
+  padding: .17rem .48rem;
+  font-size: .82rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.rules-v2--clean .rules-v2__score-badge--plus {
+  color: #7cff72;
+  border-color: rgba(124, 255, 114, .48);
+  background: rgba(124, 255, 114, .12);
+}
+
+.rules-v2--clean .rules-v2__score-badge--minus,
+.rules-v2--clean .rules-v2__rank-value {
+  color: #ff8f8f;
+  border-color: rgba(255, 143, 143, .46);
+  background: rgba(255, 143, 143, .12);
+}
+
+.rules-v2--clean .rules-v2__score-badge--neutral {
+  color: #d7e4ff;
+  border-color: rgba(180, 196, 230, .45);
+  background: rgba(180, 196, 230, .12);
+}
+
+.rules-v2--clean .rules-v2__rank-row {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: start;
+}
+
+.rules-v2--clean .rules-v2__rank-dot {
+  width: .62rem;
+  height: .62rem;
+  margin-top: .38rem;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, .16);
+}
+
+.rules-v2--clean .rules-v2__rank-main {
+  min-width: 0;
+}
+
+.rules-v2--clean .rules-v2__rank-name {
+  display: block;
+  line-height: 1.35;
+}
+
+.rules-v2--clean .rules-v2__rank-meta {
+  margin: .18rem 0 0;
+  color: var(--muted);
+  font-size: .9rem;
+  line-height: 1.42;
+}
+
+.rules-v2--clean .rules-v2__rank-row--F { color: var(--rank-f); }
+.rules-v2--clean .rules-v2__rank-row--E { color: var(--rank-e); }
+.rules-v2--clean .rules-v2__rank-row--D { color: var(--rank-d); }
+.rules-v2--clean .rules-v2__rank-row--C { color: var(--rank-c); }
+.rules-v2--clean .rules-v2__rank-row--B { color: var(--rank-b); }
+.rules-v2--clean .rules-v2__rank-row--A { color: var(--rank-a); }
+.rules-v2--clean .rules-v2__rank-row--S { color: var(--rank-s); }
+
+@media (max-width: 640px) {
+  body.theme-game .rules-v2.rules-v2--clean > .px-card,
+  .rules-v2.rules-v2--clean > .px-card {
+    padding: .78rem;
+  }
+
+  .rules-v2--clean .rules-v2__title {
+    font-size: 1.2rem;
+  }
+
+  .rules-v2--clean .rules-v2__section-title {
+    font-size: .98rem;
+  }
+
+  .rules-v2--clean .rules-v2__rank-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: .5rem;
+  }
+
+  .rules-v2--clean .rules-v2__rank-value {
+    margin-left: 1.12rem;
+    margin-top: .2rem;
+    justify-self: start;
+  }
+}

--- a/v2/pages/rules.html
+++ b/v2/pages/rules.html
@@ -1,130 +1,128 @@
-<section id="rulesRoot" class="rules-v2">
+<section id="rulesRoot" class="rules-v2 rules-v2--clean">
   <article class="px-card rules-v2__hero">
-    <h1 class="px-card__title rules-v2__page-title">Правила клубу та рейтингових ігор</h1>
-    <p class="px-card__text rules-v2__subtitle">Чіткі правила безпеки та гри, щоб кожен матч був чесним і безпечним.</p>
+    <h1 class="rules-v2__title">Правила гри</h1>
+    <p class="rules-v2__intro">Чіткі правила безпеки та гри, щоб кожен матч був чесним і безпечним.</p>
   </article>
 
   <article class="px-card rules-v2__alert" role="note" aria-label="Важливе повідомлення">
     <span class="rules-v2__alert-icon" aria-hidden="true">⚠️</span>
-    <div>
-      <p class="rules-v2__alert-title">Важливо</p>
-      <p class="px-card__text rules-v2__alert-text">Правила можуть змінюватись за рішенням інструкторів.</p>
+    <div class="rules-v2__alert-content">
+      <p class="rules-v2__alert-label">Важливо</p>
+      <p class="rules-v2__alert-text">Правила можуть змінюватись за рішенням інструкторів.</p>
     </div>
   </article>
 
   <article class="px-card rules-v2__section">
-    <h2 class="px-card__title">Безпека на майданчику</h2>
-    <p class="px-card__text rules-v2__section-intro">Контролюй рух і уникай травм.</p>
+    <h2 class="rules-v2__section-title">Безпека на майданчику</h2>
+    <p class="rules-v2__section-intro">Головне під час гри — контроль руху та безпека.</p>
     <ul class="rules-v2__list" aria-label="Правила безпеки">
-      <li>Не залазь на фігури та не лізь у вікна.</li>
-      <li>Дивись під ноги під час руху.</li>
-      <li>Уникай зіткнень.</li>
-      <li>Тримай дистанцію.</li>
-      <li>Якщо є проблема — одразу звернись до інструктора.</li>
+      <li class="rules-v2__list-item">Не залазь на фігури, укриття та не лізь у вікна.</li>
+      <li class="rules-v2__list-item">Дивись під ноги під час руху.</li>
+      <li class="rules-v2__list-item">Уникай зіткнень з іншими гравцями.</li>
+      <li class="rules-v2__list-item">Тримай безпечну дистанцію.</li>
+      <li class="rules-v2__list-item">Якщо є проблема або несправність — одразу звернись до інструктора.</li>
     </ul>
   </article>
 
   <article class="px-card rules-v2__section">
-    <h2 class="px-card__title">Поведінка</h2>
-    <p class="px-card__text rules-v2__section-intro">Поважай гру і гравців.</p>
+    <h2 class="rules-v2__section-title">Поведінка</h2>
+    <p class="rules-v2__section-intro">Поважай гру, інструктора і інших гравців.</p>
     <ul class="rules-v2__list" aria-label="Правила поведінки">
-      <li>Виконуй вказівки інструктора.</li>
-      <li>Не сперечайся під час гри.</li>
-      <li>Заборонена нецензурна лайка.</li>
-      <li>Без агресії та образ.</li>
-      <li>Грай чесно.</li>
-      <li>Поважай інших гравців.</li>
+      <li class="rules-v2__list-item">Чітко виконуй вказівки інструктора.</li>
+      <li class="rules-v2__list-item">Не сперечайся з інструктором під час гри.</li>
+      <li class="rules-v2__list-item">Заборонена нецензурна лайка.</li>
+      <li class="rules-v2__list-item">Заборонені образи, агресія та провокації.</li>
+      <li class="rules-v2__list-item">Грай чесно — фейрплей понад усе.</li>
+      <li class="rules-v2__list-item">Поважай інших гравців.</li>
     </ul>
   </article>
 
   <article class="px-card rules-v2__section">
-    <h2 class="px-card__title">Обладнання</h2>
-    <p class="px-card__text rules-v2__section-intro">Техніка — відповідальність гравця.</p>
+    <h2 class="rules-v2__section-title">Обладнання та техніка</h2>
+    <p class="rules-v2__section-intro">Бережливе ставлення до спорядження — обов’язкове.</p>
     <ul class="rules-v2__list" aria-label="Правила поводження з обладнанням">
-      <li>Бережи обладнання.</li>
-      <li>Не використовуй обладнання не за призначенням.</li>
-      <li>Поверни після гри.</li>
-      <li>Повідомляй про несправності.</li>
+      <li class="rules-v2__list-item">Бережи техніку та майно клубу.</li>
+      <li class="rules-v2__list-item">Не використовуй обладнання не за призначенням.</li>
+      <li class="rules-v2__list-item">Після гри поверни все спорядження.</li>
+      <li class="rules-v2__list-item">Якщо помітив несправність — одразу повідом інструктора.</li>
     </ul>
   </article>
 
   <article class="px-card rules-v2__section">
-    <h2 class="px-card__title">Нарахування балів</h2>
-    <p class="px-card__text rules-v2__section-intro">Ліворуч — подія, праворуч — зміна рейтингу.</p>
+    <h2 class="rules-v2__section-title">Нарахування балів</h2>
     <ul class="rules-v2__score-list" aria-label="Нарахування балів">
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Перемога</span><strong class="rules-v2__score-value">+20</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (1 місце)</span><strong class="rules-v2__score-value">+12</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (2 місце)</span><strong class="rules-v2__score-value">+7</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (3 місце)</span><strong class="rules-v2__score-value">+3</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь: F</span><strong class="rules-v2__score-value rules-v2__score-value--neutral">0</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь: E</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-4</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь: D</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-6</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь: C</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-8</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь: B</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-10</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь: A</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-12</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь: S</span><strong class="rules-v2__score-value rules-v2__score-value--minus">-14</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Перемога</span><strong class="rules-v2__score-badge rules-v2__score-badge--plus">+20</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (1 місце)</span><strong class="rules-v2__score-badge rules-v2__score-badge--plus">+12</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (2 місце)</span><strong class="rules-v2__score-badge rules-v2__score-badge--plus">+7</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (3 місце)</span><strong class="rules-v2__score-badge rules-v2__score-badge--plus">+3</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: F</span><strong class="rules-v2__score-badge rules-v2__score-badge--neutral">0</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: E</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-4</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: D</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-6</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: C</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-8</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: B</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-10</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: A</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-12</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: S</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-14</strong></li>
     </ul>
   </article>
 
   <article class="px-card rules-v2__section">
-    <h2 class="px-card__title">Ранги гравців</h2>
-    <p class="px-card__text rules-v2__section-intro">Ранг, діапазон очок і штраф за участь.</p>
+    <h2 class="rules-v2__section-title">Ранги гравців</h2>
     <ul class="rules-v2__rank-list" aria-label="Ранги гравців">
-      <li class="rules-v2__rank-item rules-v2__rank-item--F">
+      <li class="rules-v2__rank-row rules-v2__rank-row--F">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
           <strong class="rules-v2__rank-name">F — Вперше в грі</strong>
-          <span class="rules-v2__rank-range">0–199</span>
+          <p class="rules-v2__rank-meta">0–199 · Перші матчі, адаптація до темпу гри.</p>
         </div>
-        <span class="rules-v2__rank-penalty">0</span>
+        <span class="rules-v2__rank-value">0</span>
       </li>
-      <li class="rules-v2__rank-item rules-v2__rank-item--E">
+      <li class="rules-v2__rank-row rules-v2__rank-row--E">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
           <strong class="rules-v2__rank-name">E — Новачок</strong>
-          <span class="rules-v2__rank-range">200–399</span>
+          <p class="rules-v2__rank-meta">200–399 · Вже орієнтується на майданчику.</p>
         </div>
-        <span class="rules-v2__rank-penalty">-4</span>
+        <span class="rules-v2__rank-value">-4</span>
       </li>
-      <li class="rules-v2__rank-item rules-v2__rank-item--D">
+      <li class="rules-v2__rank-row rules-v2__rank-row--D">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
           <strong class="rules-v2__rank-name">D — Початківець</strong>
-          <span class="rules-v2__rank-range">400–599</span>
+          <p class="rules-v2__rank-meta">400–599 · Стабільно виконує базові ролі.</p>
         </div>
-        <span class="rules-v2__rank-penalty">-6</span>
+        <span class="rules-v2__rank-value">-6</span>
       </li>
-      <li class="rules-v2__rank-item rules-v2__rank-item--C">
+      <li class="rules-v2__rank-row rules-v2__rank-row--C">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
           <strong class="rules-v2__rank-name">C — Досвідчений</strong>
-          <span class="rules-v2__rank-range">600–799</span>
+          <p class="rules-v2__rank-meta">600–799 · Добре читає гру та команду.</p>
         </div>
-        <span class="rules-v2__rank-penalty">-8</span>
+        <span class="rules-v2__rank-value">-8</span>
       </li>
-      <li class="rules-v2__rank-item rules-v2__rank-item--B">
+      <li class="rules-v2__rank-row rules-v2__rank-row--B">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
           <strong class="rules-v2__rank-name">B — Сильний гравець</strong>
-          <span class="rules-v2__rank-range">800–999</span>
+          <p class="rules-v2__rank-meta">800–999 · Впливає на результат матчу.</p>
         </div>
-        <span class="rules-v2__rank-penalty">-10</span>
+        <span class="rules-v2__rank-value">-10</span>
       </li>
-      <li class="rules-v2__rank-item rules-v2__rank-item--A">
+      <li class="rules-v2__rank-row rules-v2__rank-row--A">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
           <strong class="rules-v2__rank-name">A — Майстер</strong>
-          <span class="rules-v2__rank-range">1000–1199</span>
+          <p class="rules-v2__rank-meta">1000–1199 · Сильна тактика та стабільність.</p>
         </div>
-        <span class="rules-v2__rank-penalty">-12</span>
+        <span class="rules-v2__rank-value">-12</span>
       </li>
-      <li class="rules-v2__rank-item rules-v2__rank-item--S">
+      <li class="rules-v2__rank-row rules-v2__rank-row--S">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
           <strong class="rules-v2__rank-name">S — Еліта</strong>
-          <span class="rules-v2__rank-range">1200+</span>
+          <p class="rules-v2__rank-meta">1200+ · Найвищий рівень гри.</p>
         </div>
-        <span class="rules-v2__rank-penalty">-14</span>
+        <span class="rules-v2__rank-value">-14</span>
       </li>
     </ul>
   </article>

--- a/v2/pages/rules.js
+++ b/v2/pages/rules.js
@@ -1,5 +1,5 @@
 export async function initRulesPage() {
   const root = document.getElementById('rulesRoot') || document.getElementById('view');
   if (!root) return;
-  root.classList.add('rules-v2');
+  root.classList.add('rules-v2', 'rules-v2--clean');
 }


### PR DESCRIPTION
### Motivation

- Усути конфлікти глобальних декоративних стилів (oval/pill) що псували вигляд сторінки `rules` і викликали накладення рамок на текст.
- Перетворити сторінку на просту, читабельну mobile-first інформаційну сторінку без додаткового декоративного шуму, збереживши V2 візуальну мову.
- Забезпечити, щоб зміни були scoped тільки для `rules` у `v2/` і не ламали інші сторінки.

### Description

- Змінено файли: `v2/pages/rules.html`, `v2/pages/rules.js`, `v2/assets/css/main.css` і перебудовано HTML в просту структуру (header title + intro, компактний «Важливо», 3 секції правил, block «Нарахування балів», block «Ранги гравців»). 
- Додано scoped-клас `rules-v2--clean` і CSS правила в `v2/assets/css/main.css`, які ізолюють сторінку від глобальних pill/oval overrides, деякі декоратори `::before/::after` відключені і `px-card__title`/`px-card__text` скидаються у межах цього scope. 
- Списки правил перероблено в спокійні вертикальні row-елементи з маленьким маркером та divider між пунктами, scoring перетворено на прості score-рядки з компактними бейджами `plus/minus/neutral`, рейтинги — на чисті rank-рядки з кольоровими індикаторами і компактними значеннями участі. 
- `v2/pages/rules.js` оновлено, щоб при ініціалізації root отримував `rules-v2--clean` для гарантованого застосування scoped-стилів на рендері.

### Testing

- Виконано синтаксичну перевірку JS: `node --check v2/pages/rules.js` — успішно. 
- Виконано синтаксичну перевірку роутера: `node --check v2/router.js` — успішно. 
- Стилі додані локально в `v2/assets/css/main.css` з mobile-first медіа-правилами і перевірені на відсутність критичних синтаксичних помилок у CSS (ручна перевірка в середовищі розробки).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6c42d6cd08321ab630aa042e44e91)