### PR TITLE
v2: colorize rank letters and simplify player rank descriptions

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -7707,6 +7707,14 @@ body.theme-game .rules-v2.rules-v2--clean > .px-card::after,
   line-height: 1.35;
 }
 
+.rules-v2--clean .rank-s { color: var(--rank-s); }
+.rules-v2--clean .rank-a { color: var(--rank-a); }
+.rules-v2--clean .rank-b { color: var(--rank-b); }
+.rules-v2--clean .rank-c { color: var(--rank-c); }
+.rules-v2--clean .rank-d { color: var(--rank-d); }
+.rules-v2--clean .rank-e { color: var(--rank-e); }
+.rules-v2--clean .rank-f { color: var(--rank-f); }
+
 .rules-v2--clean .rules-v2__rank-meta {
   margin: .18rem 0 0;
   color: var(--muted);

--- a/v2/pages/rules.html
+++ b/v2/pages/rules.html
@@ -71,56 +71,56 @@
       <li class="rules-v2__rank-row rules-v2__rank-row--F">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
-          <strong class="rules-v2__rank-name">F — Вперше в грі</strong>
-          <p class="rules-v2__rank-meta">0–199 · Перші матчі, адаптація до темпу гри.</p>
+          <strong class="rules-v2__rank-name"><span class="rank-letter rank-f">F</span> — Вперше в грі</strong>
+          <p class="rules-v2__rank-meta">0–199 · Перші ігри</p>
         </div>
         <span class="rules-v2__rank-value">0</span>
       </li>
       <li class="rules-v2__rank-row rules-v2__rank-row--E">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
-          <strong class="rules-v2__rank-name">E — Новачок</strong>
-          <p class="rules-v2__rank-meta">200–399 · Вже орієнтується на майданчику.</p>
+          <strong class="rules-v2__rank-name"><span class="rank-letter rank-e">E</span> — Новачок</strong>
+          <p class="rules-v2__rank-meta">200–399 · Новачки</p>
         </div>
         <span class="rules-v2__rank-value">-4</span>
       </li>
       <li class="rules-v2__rank-row rules-v2__rank-row--D">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
-          <strong class="rules-v2__rank-name">D — Початківець</strong>
-          <p class="rules-v2__rank-meta">400–599 · Стабільно виконує базові ролі.</p>
+          <strong class="rules-v2__rank-name"><span class="rank-letter rank-d">D</span> — Початківець</strong>
+          <p class="rules-v2__rank-meta">400–599 · Вже розібрався в грі</p>
         </div>
         <span class="rules-v2__rank-value">-6</span>
       </li>
       <li class="rules-v2__rank-row rules-v2__rank-row--C">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
-          <strong class="rules-v2__rank-name">C — Досвідчений</strong>
-          <p class="rules-v2__rank-meta">600–799 · Добре читає гру та команду.</p>
+          <strong class="rules-v2__rank-name"><span class="rank-letter rank-c">C</span> — Досвідчений</strong>
+          <p class="rules-v2__rank-meta">600–799 · Грає стабільно</p>
         </div>
         <span class="rules-v2__rank-value">-8</span>
       </li>
       <li class="rules-v2__rank-row rules-v2__rank-row--B">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
-          <strong class="rules-v2__rank-name">B — Сильний гравець</strong>
-          <p class="rules-v2__rank-meta">800–999 · Впливає на результат матчу.</p>
+          <strong class="rules-v2__rank-name"><span class="rank-letter rank-b">B</span> — Сильний гравець</strong>
+          <p class="rules-v2__rank-meta">800–999 · Сильний гравець</p>
         </div>
         <span class="rules-v2__rank-value">-10</span>
       </li>
       <li class="rules-v2__rank-row rules-v2__rank-row--A">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
-          <strong class="rules-v2__rank-name">A — Майстер</strong>
-          <p class="rules-v2__rank-meta">1000–1199 · Сильна тактика та стабільність.</p>
+          <strong class="rules-v2__rank-name"><span class="rank-letter rank-a">A</span> — Майстер</strong>
+          <p class="rules-v2__rank-meta">1000–1199 · Високий рівень</p>
         </div>
         <span class="rules-v2__rank-value">-12</span>
       </li>
       <li class="rules-v2__rank-row rules-v2__rank-row--S">
         <span class="rules-v2__rank-dot" aria-hidden="true"></span>
         <div class="rules-v2__rank-main">
-          <strong class="rules-v2__rank-name">S — Еліта</strong>
-          <p class="rules-v2__rank-meta">1200+ · Найвищий рівень гри.</p>
+          <strong class="rules-v2__rank-name"><span class="rank-letter rank-s">S</span> — Еліта</strong>
+          <p class="rules-v2__rank-meta">1200+ · Топ рівень</p>
         </div>
         <span class="rules-v2__rank-value">-14</span>
       </li>


### PR DESCRIPTION
### Motivation
- Рядок «Ранги гравців» містив білий текст для літер рангу і надто формальні описи, що знижує читабельність. 
- Потрібно було зробити букви рангу кольоровими за canonical mapping V2 без inline-стилів і скоротити опис до коротких, корисних фраз. 
- Вимога — лише точкові правки в `v2/`, без зміни layout, spacing або додавання нових блоків.

### Description
- Додані утиліті-класи кольору рангу в `v2/assets/css/main.css`: `.rank-s`, `.rank-a`, `.rank-b`, `.rank-c`, `.rank-d`, `.rank-e`, `.rank-f`, що використовують існуючі змінні `--rank-*` і не додають glow або інших ефектів. 
- У `v2/pages/rules.html` кожна літера рангу обгорнута в `<span class="rank-letter rank-x">` (наприклад `<span class="rank-letter rank-s">S</span>`), щоб букви стали кольоровими без inline-стилів. 
- Тексти в `rules-v2__rank-meta` скорочено до швидко читається формулювань: F — `Перші ігри`, E — `Новачки`, D — `Вже розібрався в грі`, C — `Грає стабільно`, B — `Сильний гравець`, A — `Високий рівень`, S — `Топ рівень`. 
- Жодних змін у структурі рядка або інших страницях не робив: лишено формат «літера + назва / діапазон очок / короткий опис». 

### Testing
- Виконано перевірку целостності змін через `git diff --check`, яка пройшла успішно. 
- Підтверджено наявність класів і оновленого тексту за допомогою `rg` запитів проти `v2/pages/rules.html` і `v2/assets/css/main.css`, які знайшли очікувані вставки класів та нові рядки. 
- Перегляд фрагментів файлів здійснений через `nl`/`sed` для візуальної валідації змін, результати відповідають вимогам.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7749aae2c8321a0c5438207992ede)