### PR TITLE
v2: Fix game day best growth, draws parsing, date labels and UI wording (Матчі→Ігри)

### DIFF
--- a/v2/core/dataHub.js
+++ b/v2/core/dataHub.js
@@ -311,7 +311,7 @@ function buildSeasonEntry(row = {}, { seasonId = '', seasonTitle = '', nickname 
   const matches = firstNumberFromAliases(row, ['Matches', 'matches', 'Games', 'games', 'Played', 'played']);
   const wins = firstNumberFromAliases(row, ['Wins', 'wins', 'Win', 'win']);
   const losses = firstNumberFromAliases(row, ['Losses', 'losses', 'Lose', 'lose']);
-  const draws = firstNumberFromAliases(row, ['Draws', 'draws', 'Ties', 'ties']);
+  const draws = firstNumberFromAliases(row, ['Draws', 'draws', 'Draw', 'draw', 'Ties', 'ties', 'Tie', 'tie', 'Нічиї', 'Нічия', 'ничьи', 'ничья']);
   const winRateRaw = firstNumberFromAliases(row, ['Winrate_%', 'winrate_%', 'WR%', 'wr%', 'Winrate', 'winrate', 'Win_rate', 'win_rate', 'WR', 'wr']);
   const mvp1 = firstNumberFromAliases(row, ['MVP1', 'mvp1', 'Top1', 'top1']);
   const mvp2 = firstNumberFromAliases(row, ['MVP2', 'mvp2', 'Top2', 'top2']);
@@ -773,7 +773,8 @@ function detectCols(header = []) {
   const idx = (names) => normalized.findIndex((col) => names.includes(col));
   return {
     nick: idx(['nick', 'nickname', 'player']), league: idx(['league', 'division']), points: idx(['points', 'pts', 'score', 'mmr']),
-    games: idx(['games', 'matches']), wins: idx(['wins', 'win']), losses: idx(['losses', 'lose', 'lost']), draws: idx(['draws', 'ties']),
+    games: idx(['games', 'matches']), wins: idx(['wins', 'win']), losses: idx(['losses', 'lose', 'lost']),
+    draws: idx(['draws', 'draw', 'ties', 'tie', 'нічия', 'нічиї', 'ничья', 'ничьи']),
     winRate: idx(['winrate', 'win rate', 'wr']), mvp: idx(['mvp', 'top1']), top2: idx(['top2', 'mvp2']), top3: idx(['top3', 'mvp3']), inactive: idx(['inactive', 'isinactive'])
   };
 }
@@ -2510,6 +2511,7 @@ export async function getGameDay(dateOrOptions = {}, leagueArg = 'kids') {
       matches: dayMatches.length,
       participants: players.length,
       totalPointsPlayed: pointsPlayed,
+      bestDelta: topGain ? { nick: topGain.nick, delta: topGain.delta } : null,
       bestGain: topGain ? { nick: topGain.nick, delta: topGain.delta } : null,
       mvpDay: daySummary?.mvp ? { nick: daySummary.mvp, score: daySummary.mvpScore } : null,
       bestWinRate: winrateLeader ? { nick: winrateLeader.nick, winRate: Math.round((winrateLeader.wins / winrateLeader.matches) * 100), matches: winrateLeader.matches } : null

--- a/v2/pages/gameday.js
+++ b/v2/pages/gameday.js
@@ -61,6 +61,15 @@ function prettyWinner(winner = '') {
   return 'Переможця не визначено';
 }
 
+function cleanDateLabel(date = '', timestamp = '') {
+  const fromDate = String(date || '').trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(fromDate)) return fromDate;
+  const fromTimestamp = String(timestamp || '').trim();
+  const match = fromTimestamp.match(/\d{4}-\d{2}-\d{2}/);
+  if (match) return match[0];
+  return fromDate || fromTimestamp || '—';
+}
+
 function parseSeries(series = '') {
   const res = { team1: 0, team2: 0, team3: 0, team4: 0, draws: 0 };
   (String(series || '').match(/[0-4]/g) || []).forEach((token) => {
@@ -141,7 +150,7 @@ function buildMatchCard(match = {}, roster = new Map()) {
   const scoreLabel = scoreParts.length ? scoreParts.join(' : ') : (match.seriesSummary || '—');
   const winnerKey = /^team\d$/.test(String(match.winner || '')) ? String(match.winner) : '';
   const matchId = `gamedayMatch${match.index}`;
-  const summaryLine = [match.date, match.timestamp].filter(Boolean).join(' · ');
+  const summaryLine = cleanDateLabel(match.date, match.timestamp);
   const versusLine = teams.map(([, members]) => compactTeamPreview(members)).join(' vs ');
   const teamsLine = teams.map(([key]) => {
     const isWinner = key === winnerKey;
@@ -157,7 +166,7 @@ function buildMatchCard(match = {}, roster = new Map()) {
     <article class="gameday-match-card ${winnerKey ? `gameday-match-card--winner-${winnerKey}` : ''}" data-match-id="${matchId}">
       <button class="gameday-match-head" type="button" aria-expanded="false" aria-controls="${matchId}Details" id="${matchId}Trigger">
         <div class="gameday-match-head__top">
-          <span class="gameday-match-head__eyebrow">Матч #${match.index}</span>
+          <span class="gameday-match-head__eyebrow">Гра #${match.index}</span>
           <span class="gameday-match-head__score">${esc(scoreLabel)}</span>
         </div>
         <div class="gameday-match-head__title">${teamsLine || 'Склади команд'}</div>
@@ -235,8 +244,8 @@ function render(root, payload, filters) {
         <button id="gamedayLoad" class="btn">Оновити</button>
       </div>
       <div class="gameday-summary-grid">
-        <div class="gameday-summary-card"><span>Матчів</span><b>${summary.matches ?? payload.gamesCount ?? 0}</b></div>
-        <div class="gameday-summary-card"><span>Найбільший приріст</span><b>${esc(summary.bestDelta?.nick ? `${summary.bestDelta.nick} ${fmtDelta(summary.bestDelta.delta)}` : '—')}</b></div>
+        <div class="gameday-summary-card"><span>Ігор</span><b>${summary.matches ?? payload.gamesCount ?? 0}</b></div>
+        <div class="gameday-summary-card"><span>Найбільший приріст</span><b>${esc((summary.bestDelta?.nick || summary.bestGain?.nick) ? `${summary.bestDelta?.nick || summary.bestGain?.nick} ${fmtDelta(summary.bestDelta?.delta ?? summary.bestGain?.delta)}` : '—')}</b></div>
         <div class="gameday-summary-card"><span>Гравців</span><b>${summary.participants ?? players.length}</b></div>
         <div class="gameday-summary-card"><span>MVP дня</span><b>${esc(summary.mvpDay?.nick || '—')}</b></div>
       </div>
@@ -246,18 +255,18 @@ function render(root, payload, filters) {
     <section class="px-card gameday-players-block">
       <div class="gameday-section-head">
         <h2 class="px-card__title">Таблиця гравців дня</h2>
-        <p class="px-card__text">Компактна зведена таблиця за день: очки, приріст, матчі, перемоги та MVP.</p>
+        <p class="px-card__text">Компактна зведена таблиця за день: очки, приріст, ігри, перемоги та MVP.</p>
       </div>
       ${buildPlayersTable(players, payload.league)}
     </section>
 
     <section class="px-card gameday-matches-block">
       <div class="gameday-section-head">
-        <h2 class="px-card__title">Лог матчів</h2>
-        <p class="px-card__text">Кожен матч згорнутий. У шапці одразу видно рахунок, склади та переможця.</p>
+        <h2 class="px-card__title">Лог ігор</h2>
+        <p class="px-card__text">Кожна гра згорнута. У шапці одразу видно рахунок, склади та переможця.</p>
       </div>
       <div class="gameday-match-list">
-        ${(matches || []).map((m) => buildMatchCard(m, rosterMap)).join('') || '<p class="px-card__text">Немає матчів за цей день.</p>'}
+        ${(matches || []).map((m) => buildMatchCard(m, rosterMap)).join('') || '<p class="px-card__text">Немає ігор за цей день.</p>'}
       </div>
     </section>
   `;

--- a/v2/pages/league-stats.js
+++ b/v2/pages/league-stats.js
@@ -210,10 +210,10 @@ function renderGameDaySection(lastGameDay, league) {
       <div class="league-game-day-card__stack">
         <div class="league-game-day-card__label">\u041e\u0441\u0442\u0430\u043d\u043d\u0454 \u043e\u043d\u043e\u0432\u043b\u0435\u043d\u043d\u044f</div>
         <div class="league-game-day-card__value">${esc(day.date || '\u2014')}</div>
-        <div class="league-game-day-card__headline">${day.matchesCount || day.battlesCount ? `\u0417\u0456\u0433\u0440\u0430\u043d\u043e ${esc(day.matchesCount || 0)} \u043c\u0430\u0442\u0447\u0456\u0432` : '\u0414\u0430\u043d\u0456 \u0434\u043d\u044f \u0449\u0435 \u043d\u0435 \u0437\u0456\u0431\u0440\u0430\u043d\u0456'}</div>
+        <div class="league-game-day-card__headline">${day.matchesCount || day.battlesCount ? `\u0417\u0456\u0433\u0440\u0430\u043d\u043e ${esc(day.matchesCount || 0)} \u0456\u0433\u043e\u0440` : '\u0414\u0430\u043d\u0456 \u0434\u043d\u044f \u0449\u0435 \u043d\u0435 \u0437\u0456\u0431\u0440\u0430\u043d\u0456'}</div>
         <div class="league-game-day-stats">
           <div class="league-game-day-stat">
-            <span class="league-game-day-stat__label">\u041c\u0430\u0442\u0447\u0456</span>
+            <span class="league-game-day-stat__label">\u0406\u0433\u0440\u0438</span>
             <span class="league-game-day-stat__value">${esc(day.matchesCount || 0)}</span>
           </div>
           <div class="league-game-day-stat">
@@ -304,8 +304,8 @@ function renderInfographic(root, data, remainingGameDays, league) {
       ${insightCard({
         eyebrow: '\u0410\u043a\u0442\u0438\u0432\u043d\u0456\u0441\u0442\u044c',
         title: mostActive ? mostActive.nickname : '\u041d\u0435\u043c\u0430\u0454 \u0434\u0430\u043d\u0438\u0445',
-        value: mostActive ? `${mostActive.battles || 0} боїв` : '\u2014',
-        meta: mostActive ? `${mostActive.matches || 0} ігор у сезоні` : '\u0410\u043a\u0442\u0438\u0432\u043d\u0430 \u0441\u0442\u0430\u0442\u0438\u0441\u0442\u0438\u043a\u0430 \u0449\u0435 \u043d\u0435 \u0437\u0456\u0431\u0440\u0430\u043d\u0430',
+        value: mostActive ? `${mostActive.matches || 0} ігор` : '\u2014',
+        meta: mostActive ? `${mostActive.battles || 0} боїв у сезоні` : '\u0410\u043a\u0442\u0438\u0432\u043d\u0430 \u0441\u0442\u0430\u0442\u0438\u0441\u0442\u0438\u043a\u0430 \u0449\u0435 \u043d\u0435 \u0437\u0456\u0431\u0440\u0430\u043d\u0430',
         footer: activityFooter,
         tone: 'warm'
       })}
@@ -318,8 +318,8 @@ function renderInfographic(root, data, remainingGameDays, league) {
     ${seasonStatCard({ label: 'Кращий WR у топ-10', value: bestWinrateTop10Value, meta: bestWinrateTop10 ? `${bestWinrateTop10.nickname} · ${bestWinrateTop10.matches || 0} ігор` : 'Топ-10 ще формується', width: bestWinrateTop10Width })}
     </div>
     <div class="league-kpi-grid league-kpi-grid--tertiary">
-    ${seasonStatCard({ label: 'Матчі / середні бої', value: `${matchesCount} / ${battlesPerMatch}`, meta: `${playersCount} активних гравців`, width: clampPercent(matchesCount * 3) })}
-    ${seasonStatCard({ label: 'Середній приріст за матч', value: averageDeltaPerMatch, meta: leader ? `Лідер ліги зараз у ранзі ${topRank}` : 'Дані ще збираються', width: averageDeltaPerMatchWidth })}
+    ${seasonStatCard({ label: 'Ігри / середні бої', value: `${matchesCount} / ${battlesPerMatch}`, meta: `${playersCount} активних гравців`, width: clampPercent(matchesCount * 3) })}
+    ${seasonStatCard({ label: 'Середній приріст за гру', value: averageDeltaPerMatch, meta: leader ? `Лідер ліги зараз у ранзі ${topRank}` : 'Дані ще збираються', width: averageDeltaPerMatchWidth })}
     </div>
   </section>
   <section class="league-dashboard-group league-dashboard-group--ranks">

--- a/v2/pages/season.js
+++ b/v2/pages/season.js
@@ -48,7 +48,7 @@ export async function initSeasonPage(params = {}) {
   if (!root) return;
 
   root.innerHTML = `<section class="season-header px-card px-card--accent"><h1 id="seasonPageTitle">Сезон</h1><p id="seasonPeriod" class="px-card__text">Період: —</p><p id="seasonUpdated" class="px-card__text">Оновлення: —</p></section>
-<section class="px-card"><div class="season-controls-row"><select id="seasonSelect" class="search-input"></select><div class="league-toggle"><label><input type="radio" name="leagueToggle" value="kids"> Дитяча ліга</label><label><input type="radio" name="leagueToggle" value="sundaygames"> Доросла ліга</label></div><select id="seasonSort" class="search-input"><option value="rating">Сортувати: рейтинг</option><option value="matches">Сортувати: матчі</option><option value="mvp">Сортувати: MVP</option><option value="delta">Сортувати: Δ рейтингу</option></select></div><p id="seasonState" class="px-card__text"></p></section>
+<section class="px-card"><div class="season-controls-row"><select id="seasonSelect" class="search-input"></select><div class="league-toggle"><label><input type="radio" name="leagueToggle" value="kids"> Дитяча ліга</label><label><input type="radio" name="leagueToggle" value="sundaygames"> Доросла ліга</label></div><select id="seasonSort" class="search-input"><option value="rating">Сортувати: рейтинг</option><option value="matches">Сортувати: ігри</option><option value="mvp">Сортувати: MVP</option><option value="delta">Сортувати: Δ рейтингу</option></select></div><p id="seasonState" class="px-card__text"></p></section>
 <section class="season-league-summary px-card"><h2>Summary ліги</h2><div id="seasonLeagueSummary"></div></section>
 <section class="season-awards px-card"><h2>Герої сезону</h2><div id="seasonAwards"></div></section>
 <section class="season-top10 px-card"><h2>ТОП-10 гравців сезону</h2><div id="seasonTop10"></div></section>
@@ -89,7 +89,7 @@ export async function initSeasonPage(params = {}) {
       document.getElementById('seasonPeriod').textContent = `Період: ${meta.period || meta.date_range || meta.dateRange || 'Немає даних'}`;
       document.getElementById('seasonUpdated').textContent = `Оновлення: ${meta.updated_at || meta.updated || 'Немає даних'}`;
 
-      document.getElementById('seasonLeagueSummary').innerHTML = `<div class="season-stat-card"><p>Матчі: <strong>${metrics.matches}</strong></p><p>Гравці: <strong>${metrics.activePlayers}</strong></p><p>Середній рейтинг: <strong>${metrics.avgRating ?? 'Немає даних'}</strong></p></div>`;
+      document.getElementById('seasonLeagueSummary').innerHTML = `<div class="season-stat-card"><p>Ігри: <strong>${metrics.matches}</strong></p><p>Гравці: <strong>${metrics.activePlayers}</strong></p><p>Середній рейтинг: <strong>${metrics.avgRating ?? 'Немає даних'}</strong></p></div>`;
 
       const awardsMap = { mvp: 'MVP сезону', progress: 'Найкращий прогрес', active: 'Найактивніший', stable: 'Найстабільніший' };
       document.getElementById('seasonAwards').innerHTML = awards.length
@@ -100,7 +100,7 @@ export async function initSeasonPage(params = {}) {
         }).join('')}</div>`
         : '<p class="px-card__text">Нагороди ще не сформовані</p>';
 
-      const renderTable = (rows) => `<div class="season-table-wrap"><table class="season-table"><thead><tr><th>#</th><th>Нік</th><th>Матчі</th><th>Перемоги</th><th>Нічиї</th><th>Поразки</th><th>MVP</th><th>Фін. рейтинг</th><th>Δ рейтингу</th><th>Ранг</th></tr></thead><tbody>${rows.map((p, idx) => `<tr><td>${idx + 1}</td><td>${esc(p.nickname || '—')}</td><td>${p.matches ?? '—'}</td><td>${p.wins ?? '—'}</td><td>${p.draws ?? '—'}</td><td>${p.losses ?? '—'}</td><td>${p.mvp_total ?? '—'}</td><td>${p.rating_end ?? '—'}</td><td>${(p.rating_delta > 0 ? '+' : '')}${p.rating_delta ?? 0}</td><td>${rankBadge(p.rank_final)}</td></tr>`).join('')}</tbody></table></div>`;
+      const renderTable = (rows) => `<div class="season-table-wrap"><table class="season-table"><thead><tr><th>#</th><th>Нік</th><th>Ігри</th><th>Перемоги</th><th>Нічиї</th><th>Поразки</th><th>MVP</th><th>Фін. рейтинг</th><th>Δ рейтингу</th><th>Ранг</th></tr></thead><tbody>${rows.map((p, idx) => `<tr><td>${idx + 1}</td><td>${esc(p.nickname || '—')}</td><td>${p.matches ?? '—'}</td><td>${p.wins ?? '—'}</td><td>${p.draws ?? '—'}</td><td>${p.losses ?? '—'}</td><td>${p.mvp_total ?? '—'}</td><td>${p.rating_end ?? '—'}</td><td>${(p.rating_delta > 0 ? '+' : '')}${p.rating_delta ?? 0}</td><td>${rankBadge(p.rank_final)}</td></tr>`).join('')}</tbody></table></div>`;
       document.getElementById('seasonTop10').innerHTML = top10.length ? renderTable(top10) : '<p class="px-card__text">Немає даних</p>';
       document.getElementById('seasonPlayers').innerHTML = players.length ? renderTable(sortPlayers(players, sort.value)) : '<p class="px-card__text">Немає даних</p>';
 
@@ -114,7 +114,7 @@ export async function initSeasonPage(params = {}) {
         return acc;
       }, {});
       const rankList = Object.entries(rankDist).sort(([a], [b]) => a.localeCompare(b));
-      document.getElementById('seasonChart').innerHTML = `<p>Матчі: <strong>${metrics.matches}</strong></p><p>Активні гравці: <strong>${metrics.activePlayers}</strong></p><p>Середній рейтинг: <strong>${metrics.avgRating ?? 'Немає даних'}</strong></p><p>Загальні MVP: <strong>${metrics.mvpTotal}</strong></p>${rankList.length ? `<div>${rankList.map(([rank, count]) => `<span class="tag">${rank}: ${count}</span>`).join(' ')}</div>` : '<p>Rank distribution: Немає даних</p>'}`;
+      document.getElementById('seasonChart').innerHTML = `<p>Ігри: <strong>${metrics.matches}</strong></p><p>Активні гравці: <strong>${metrics.activePlayers}</strong></p><p>Середній рейтинг: <strong>${metrics.avgRating ?? 'Немає даних'}</strong></p><p>Загальні MVP: <strong>${metrics.mvpTotal}</strong></p>${rankList.length ? `<div>${rankList.map(([rank, count]) => `<span class="tag">${rank}: ${count}</span>`).join(' ')}</div>` : '<p>Rank distribution: Немає даних</p>'}`;
 
       state.textContent = '';
     } catch (error) {

--- a/v2/pages/seasons.js
+++ b/v2/pages/seasons.js
@@ -8,7 +8,7 @@ function previewCard(seasonId, league, master) {
   const players = (master?.sections?.players || []).filter((p) => p.league === league);
   const top1 = [...players].sort((a, b) => (b.rating_end || 0) - (a.rating_end || 0))[0];
   const label = league === 'kids' ? 'Дитяча ліга' : 'Доросла ліга';
-  return `<article class="px-card season-list-card"><h3>${label}</h3><p>Матчі: <strong>${summary.matches ?? summary.games ?? 'Немає даних'}</strong></p><p>Гравці: <strong>${summary.players ?? players.length}</strong></p><p>Топ-1: <strong>${esc(top1?.nickname || 'Немає даних')}</strong></p><a class="btn btn--secondary" href="#season?season=${encodeURIComponent(seasonId)}&league=${league}">Відкрити лігу</a></article>`;
+  return `<article class="px-card season-list-card"><h3>${label}</h3><p>Ігри: <strong>${summary.matches ?? summary.games ?? 'Немає даних'}</strong></p><p>Гравці: <strong>${summary.players ?? players.length}</strong></p><p>Топ-1: <strong>${esc(top1?.nickname || 'Немає даних')}</strong></p><a class="btn btn--secondary" href="#season?season=${encodeURIComponent(seasonId)}&league=${league}">Відкрити лігу</a></article>`;
 }
 
 export async function initSeasonsPage() {


### PR DESCRIPTION
### Motivation
- Виправити відображення «Найбільшого приросту» на сторінці Ігровий день, прибрати технічний хвіст дати в логах, коректно рахувати нічиї та мінімально привести UI-лейбли з "Матчі" на "Ігри" у V2.
- Зробити зміни лише в `v2/` без редизайну та не ламати інші KPI/логіку сторінок.

### Description
- Додав у payload `getGameDay` сумісний ключ `bestDelta` і у UI зроблено fallback на `bestGain`, тож блок «Найбільший приріст» тепер читає існуючі дані і показує гравця/значення, якщо вони є. (файл: `v2/core/dataHub.js`, `v2/pages/gameday.js`)
- Розширив розпізнавання нічиїх у парсерах та таблицях (додаткові aliases для Draw/Tie/Нічиї/ничья тощо) і оновив `detectCols`/`buildSeasonEntry`, щоб `draws` правильно підтягувався. (файл: `v2/core/dataHub.js`)
- Додав утиліту `cleanDateLabel(...)` у GameDay UI і замінив відображення дати в картках матчу, щоб показувати лише читабельну дату без технічних цифр/timestamp-хвостів. (файл: `v2/pages/gameday.js`)
- Поміняв порядок і підписи в блоці активності (тепер головне — кількість ігор, у meta — бої) та оновив ряд user-facing лейблів і підписів: «Матчі» → «Ігри», «Лог матчів» → «Лог ігор», «Матч #» → «Гра #» у відповідних місцях V2. (файли: `v2/pages/league-stats.js`, `v2/pages/season.js`, `v2/pages/seasons.js`, `v2/pages/gameday.js`)
- Змінені файли: `v2/core/dataHub.js`, `v2/pages/gameday.js`, `v2/pages/league-stats.js`, `v2/pages/season.js`, `v2/pages/seasons.js`.

### Testing
- Запущено синтаксичну перевірку: `node --check v2/core/dataHub.js`, `node --check v2/pages/gameday.js`, `node --check v2/pages/league-stats.js`, `node --check v2/pages/season.js`, `node --check v2/pages/seasons.js` — всі перевірки пройшли успішно. ✅
- Зібрано проект з допоміжним скриптом: `npm run build:summer2025-og` — збірка виконана успішно і згенерувала social preview (успішно). ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e777e8b72883218fce7a6bddfe9678)