### PR TITLE
Compact Rules scoring block and add colored rank letters

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -7650,17 +7650,39 @@ body.theme-game .rules-v2.rules-v2--clean > .px-card::after,
   border-top: 1px solid rgba(255, 255, 255, .1);
 }
 
+.rules-v2--clean .rules-v2__score-row {
+  gap: .48rem;
+  padding: .38rem 0;
+}
+
 .rules-v2--clean .rules-v2__score-event {
   min-width: 0;
-  line-height: 1.4;
+  line-height: 1.3;
+  font-size: .95rem;
 }
+
+.rules-v2--clean .rules-v2__score-event--rank {
+  color: var(--muted);
+}
+
+.rules-v2--clean .rules-v2__score-event--rank .rank-letter {
+  font-weight: 700;
+}
+
+.rules-v2--clean .rules-v2__score-event--rank .rank-s { color: var(--rank-s); }
+.rules-v2--clean .rules-v2__score-event--rank .rank-a { color: var(--rank-a); }
+.rules-v2--clean .rules-v2__score-event--rank .rank-b { color: var(--rank-b); }
+.rules-v2--clean .rules-v2__score-event--rank .rank-c { color: #ffd98a; }
+.rules-v2--clean .rules-v2__score-event--rank .rank-d { color: var(--accent); }
+.rules-v2--clean .rules-v2__score-event--rank .rank-e { color: var(--accent-2); }
+.rules-v2--clean .rules-v2__score-event--rank .rank-f { color: var(--muted); }
 
 .rules-v2--clean .rules-v2__score-badge,
 .rules-v2--clean .rules-v2__rank-value {
   border-radius: 999px !important;
   border: 1px solid rgba(255, 255, 255, .2);
-  padding: .17rem .48rem;
-  font-size: .82rem;
+  padding: .16rem .45rem;
+  font-size: .8rem;
   font-weight: 700;
   white-space: nowrap;
 }

--- a/v2/pages/rules.html
+++ b/v2/pages/rules.html
@@ -55,13 +55,13 @@
       <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (1 місце)</span><strong class="rules-v2__score-badge rules-v2__score-badge--plus">+12</strong></li>
       <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (2 місце)</span><strong class="rules-v2__score-badge rules-v2__score-badge--plus">+7</strong></li>
       <li class="rules-v2__score-row"><span class="rules-v2__score-event">MVP (3 місце)</span><strong class="rules-v2__score-badge rules-v2__score-badge--plus">+3</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: F</span><strong class="rules-v2__score-badge rules-v2__score-badge--neutral">0</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: E</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-4</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: D</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-6</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: C</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-8</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: B</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-10</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: A</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-12</strong></li>
-      <li class="rules-v2__score-row"><span class="rules-v2__score-event">Участь за рангом: S</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-14</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event rules-v2__score-event--rank"><span class="rank-letter rank-f">F</span> ранг</span><strong class="rules-v2__score-badge rules-v2__score-badge--neutral">0</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event rules-v2__score-event--rank"><span class="rank-letter rank-e">E</span> ранг</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-4</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event rules-v2__score-event--rank"><span class="rank-letter rank-d">D</span> ранг</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-6</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event rules-v2__score-event--rank"><span class="rank-letter rank-c">C</span> ранг</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-8</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event rules-v2__score-event--rank"><span class="rank-letter rank-b">B</span> ранг</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-10</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event rules-v2__score-event--rank"><span class="rank-letter rank-a">A</span> ранг</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-12</strong></li>
+      <li class="rules-v2__score-row"><span class="rules-v2__score-event rules-v2__score-event--rank"><span class="rank-letter rank-s">S</span> ранг</span><strong class="rules-v2__score-badge rules-v2__score-badge--minus">-14</strong></li>
     </ul>
   </article>
 


### PR DESCRIPTION
### Motivation

- Make the “Нарахування балів” block more compact and readable, especially on mobile devices.  
- Remove repeated long label `Участь за рангом:` and reduce vertical visual noise while preserving existing layout.  
- Ensure rank letters `F / E / D / C / B / A / S` are shown in the canonical V2 colors and only the letter is color-accented.

### Description

- Changed markup in `v2/pages/rules.html` to shorten rank participation labels from `Участь за рангом: X` to `X ранг` and wrapped the rank token in `<span class="rank-letter rank-...">` so only the letter gets colored.  
- Updated styles in `v2/assets/css/main.css` to tighten scoring rows by reducing `gap` and `padding`, lowering `line-height` and font-size for score labels, and slightly reducing badge padding and font-size for a denser look.  
- Added `.rules-v2__score-event--rank` CSS plus per-rank color rules that map to existing V2 palette tokens so the letter colors follow the canonical mapping: `S → var(--rank-s)`, `A → var(--rank-a)`, `B → var(--rank-b)`, `C → #ffd98a`, `D → var(--accent)`, `E → var(--accent-2)`, `F → var(--muted)`.  
- The changes are isolated to the scoring block only (files modified: `v2/pages/rules.html`, `v2/assets/css/main.css`) and avoid adding new containers, glows, or extra decorative elements.

### Testing

- Built the project with `npm run build:summer2025-og` and the build completed successfully.  
- Ran `git diff --check` to validate there are no whitespace/errors reported and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77de6602483219c7c8fac1044c5be)