### PR TITLE
v2: redesign player profile — compact layout, analytics & gamification

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -5091,7 +5091,7 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 /* Player Profile V2 */
 .profile-page-v2 {
   display: grid;
-  gap: .9rem;
+  gap: .65rem;
   width: 100%;
   max-width: 100%;
   min-width: 0;
@@ -5110,239 +5110,291 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   border-radius: 0;
 }
 
+.profile-hero,
+.profile-section,
+.profile-season-summary,
+.profile-logs-wrap,
+.profile-log-empty {
+  padding: .62rem !important;
+}
+
 .profile-hero {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: .8rem;
+  grid-template-columns: 72px 1fr;
+  gap: .62rem;
   align-items: start;
   border: 1px solid rgba(132, 198, 255, .32);
   background: linear-gradient(145deg, rgba(26, 37, 66, .94), rgba(9, 15, 27, .96));
-  box-shadow: inset 0 0 0 1px rgba(175, 225, 255, .08), 0 12px 28px rgba(5, 11, 21, .44);
-}
-
-.profile-hero__left {
-  display: grid;
-  gap: .42rem;
-  justify-items: start;
-  width: 100%;
+  box-shadow: inset 0 0 0 1px rgba(175, 225, 255, .08);
 }
 
 .profile-avatar-frame {
-  width: 92px;
-  height: 92px;
+  width: 72px;
+  height: 72px;
   border: 1px solid rgba(154, 216, 255, .36);
-  border-radius: 0;
   display: grid;
   place-items: center;
   background: rgba(7, 13, 25, .9);
-  box-shadow: inset 0 0 0 1px rgba(255,255,255,.06);
 }
 
-.profile-avatar-frame img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 0;
-}
+.profile-avatar-frame img { width: 100%; height: 100%; object-fit: cover; }
 
-.profile-rank-badge {
-  min-width: 42px;
-  min-height: 42px;
-  border: 1px solid currentColor;
-  border-radius: 0;
-  padding: .22rem .66rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  font-size: 1.12rem;
-  letter-spacing: .06em;
-  background: color-mix(in srgb, currentColor 20%, transparent);
-}
+.profile-hero__main { display: grid; gap: .3rem; }
 
 .profile-hero__head {
   display: flex;
-  align-items: baseline;
-  gap: .5rem;
+  align-items: center;
   justify-content: space-between;
-  flex-wrap: wrap;
+  gap: .42rem;
 }
 
 .profile-hero__head h1 {
   margin: 0;
-  font-size: clamp(1.4rem, 2.6vw, 2rem);
-  letter-spacing: .02em;
+  font-size: clamp(1.08rem, 3.2vw, 1.44rem);
 }
 
-.profile-status {
-  font-size: .65rem;
-  letter-spacing: .03em;
+.profile-rank-badge,
+.profile-place-badge,
+.profile-subtle-badge {
+  border: 1px solid currentColor;
+  padding: .18rem .45rem;
+  font-size: .68rem;
+  letter-spacing: .04em;
   text-transform: uppercase;
-  color: #9be8ff;
-  border: 1px solid rgba(155, 232, 255, .38);
-  padding: .18rem .5rem;
-  border-radius: 0;
-  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+}
+
+.profile-rank-badge {
+  font-size: .95rem;
+  font-weight: 700;
+  color: #e4f2ff;
+  background: color-mix(in srgb, currentColor 18%, transparent);
 }
 
 .profile-hero__meta,
 .profile-muted,
 .profile-note {
-  margin: .35rem 0;
+  margin: 0;
   color: var(--muted);
+  font-size: .76rem;
+}
+
+.profile-hero__badges {
+  display: flex;
+  gap: .36rem;
+  flex-wrap: wrap;
+}
+
+.profile-place-badge {
+  border-color: rgba(183, 255, 42, .62);
+  color: #d9ff91;
+  background: rgba(138, 194, 47, .16);
+  font-weight: 700;
+}
+
+.profile-subtle-badge {
+  border-color: rgba(165, 214, 255, .33);
+  color: #9fdfff;
+}
+
+.profile-rank-progress-wrap {
+  display: grid;
+  gap: .24rem;
+}
+
+.profile-rank-progress__labels {
+  display: flex;
+  justify-content: space-between;
+  gap: .4rem;
+  font-size: .72rem;
+}
+
+.profile-rank-progress {
+  position: relative;
+  height: 8px;
+  border: 1px solid rgba(172, 225, 255, .2);
+  background: rgba(6, 12, 21, .8);
+}
+
+.profile-rank-progress span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, #79f975, #b7ff2a);
 }
 
 .profile-hero__actions {
-  align-self: end;
+  grid-column: 1 / -1;
   display: flex;
-  justify-content: flex-start;
-  width: 100%;
-}
-
-.profile-hero__actions .btn {
-  max-width: 100%;
+  justify-content: flex-end;
 }
 
 .profile-section {
   border: 1px solid rgba(173, 232, 255, .2);
   background: linear-gradient(180deg, rgba(10, 18, 34, .86), rgba(7, 12, 24, .9));
-  box-shadow: inset 0 0 0 1px rgba(255,255,255,.03);
 }
 
 .profile-section__title {
-  margin: 0 0 .65rem;
-  font-size: .95rem;
+  margin: 0 0 .45rem;
+  font-size: .82rem;
   text-transform: uppercase;
   letter-spacing: .07em;
   color: #9fdfff;
 }
 
-.profile-metrics-grid {
+.profile-mini-grid {
   display: grid;
-  grid-template-columns: repeat(1, minmax(0, 1fr));
-  gap: .46rem;
-  width: 100%;
-}
-
-.profile-metrics-grid.is-hero {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .35rem;
 }
 
-.profile-metric-card {
-  border: 1px solid rgba(153, 214, 255, .17);
-  background: linear-gradient(180deg, rgba(15, 24, 43, .8), rgba(11, 17, 32, .8));
-  padding: .52rem .55rem;
-  min-height: 70px;
+.profile-mini-card {
+  border: 1px solid rgba(153, 214, 255, .14);
+  background: rgba(10, 18, 31, .82);
+  padding: .42rem .45rem;
+  min-height: 58px;
   display: grid;
+  gap: .12rem;
   align-content: center;
-  gap: .16rem;
 }
 
-.profile-metric-card.is-accent {
-  border-color: rgba(183, 255, 42, .46);
-  box-shadow: inset 0 0 0 1px rgba(183, 255, 42, .18);
-}
-
-.profile-metric-card__label {
-  color: rgba(183, 204, 225, .86);
-  font-size: .66rem;
+.profile-mini-card span {
+  font-size: .62rem;
+  letter-spacing: .06em;
   text-transform: uppercase;
-  letter-spacing: .08em;
-  background: transparent !important;
-  border: 0 !important;
-  box-shadow: none !important;
-  border-radius: 0 !important;
-  padding: 0 !important;
+  color: rgba(183, 204, 225, .86);
 }
 
-.profile-metric-card__value {
-  font-size: clamp(1rem, 1.8vw, 1.45rem);
+.profile-mini-card strong {
+  font-size: 1rem;
   line-height: 1.1;
-  font-weight: 700;
-  background: transparent !important;
-  border: 0 !important;
-  box-shadow: none !important;
-  border-radius: 0 !important;
-  padding: 0 !important;
-}
-
-.profile-metric-card.is-mono .profile-metric-card__value {
   font-family: var(--font-mono);
 }
 
-.profile-highlight-grid {
+.profile-mini-card.is-accent { border-color: rgba(183, 255, 42, .44); }
+.profile-mini-card.is-good strong,
+.profile-analysis__value.is-good { color: #86f488; }
+.profile-mini-card.is-mid strong,
+.profile-analysis__value.is-mid { color: #ffd45a; }
+.profile-mini-card.is-bad strong,
+.profile-analysis__value.is-bad { color: #ff7f7f; }
+.profile-mini-card.is-positive strong { color: #86f488; }
+.profile-mini-card.is-negative strong { color: #ff7f7f; }
+
+.profile-analysis__row {
   display: grid;
-  grid-template-columns: repeat(1, minmax(0, 1fr));
-  gap: .42rem;
+  grid-template-columns: 1fr;
+  gap: .45rem;
 }
 
-.profile-highlight-card {
+.profile-analysis__label {
+  margin: 0 0 .22rem;
+  font-size: .66rem;
+  text-transform: uppercase;
+  color: #a0daf5;
+}
+
+.profile-wr-bar {
+  height: 10px;
+  border: 1px solid rgba(166, 221, 255, .2);
+  background: rgba(8, 13, 22, .86);
+}
+
+.profile-wr-bar span {
+  display: block;
+  height: 100%;
+}
+
+.profile-wr-bar.is-good span { background: linear-gradient(90deg, #5be67d, #8dfb80); }
+.profile-wr-bar.is-mid span { background: linear-gradient(90deg, #ffbf3e, #ffe06a); }
+.profile-wr-bar.is-bad span { background: linear-gradient(90deg, #ff6d6d, #ff9797); }
+.profile-wr-bar.is-neutral span { background: rgba(145, 208, 246, .45); }
+
+.profile-analysis__value {
+  display: inline-block;
+  margin-top: .2rem;
+  font-size: 1rem;
+  font-family: var(--font-mono);
+}
+
+.profile-analysis__compact {
+  display: grid;
+  gap: .25rem;
+}
+
+.profile-analysis__compact p,
+.profile-wld-pill {
+  margin: 0;
+  display: flex;
+  justify-content: space-between;
+  gap: .4rem;
+  font-size: .78rem;
+  border: 1px solid rgba(161, 214, 250, .16);
+  background: rgba(9, 15, 27, .72);
+  padding: .3rem .42rem;
+}
+
+.profile-analysis__compact strong,
+.profile-wld-pill strong {
+  font-family: var(--font-mono);
+}
+
+.profile-achievement-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .35rem;
+}
+
+.profile-achievement-card {
   border: 1px solid rgba(182, 255, 75, .28);
   background: linear-gradient(130deg, rgba(36, 71, 31, .36), rgba(15, 28, 20, .58));
-  padding: .52rem .6rem;
+  padding: .42rem .45rem;
   display: grid;
   gap: .2rem;
 }
 
-.profile-highlight-card span {
-  font-size: .68rem;
-  color: rgba(193, 229, 198, .82);
-  letter-spacing: .07em;
-  background: transparent !important;
-  border: 0 !important;
-  box-shadow: none !important;
-  border-radius: 0 !important;
-  padding: 0 !important;
+.profile-achievement-card__head {
+  display: flex;
+  align-items: center;
+  gap: .28rem;
 }
 
-.profile-highlight-card strong {
-  font-size: .96rem;
-  background: transparent !important;
-  border: 0 !important;
-  box-shadow: none !important;
-  border-radius: 0 !important;
-  padding: 0 !important;
+.profile-achievement-card__icon { font-size: .92rem; }
+
+.profile-achievement-card__head strong {
+  font-size: .72rem;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+
+.profile-achievement-card p {
+  margin: 0;
+  font-size: .77rem;
 }
 
 .profile-season-tabs {
-  display: flex;
-  gap: .38rem;
-  overflow-x: auto;
-  overflow-y: hidden;
-  max-width: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .34rem;
   width: 100%;
-  padding-bottom: .42rem;
-  scrollbar-width: thin;
-  -webkit-overflow-scrolling: touch;
-}
-
-.profile-season-tabs::after {
-  content: "";
-  flex: 0 0 .1px;
-}
-
-.profile-season-tabs > * {
-  flex: 0 0 auto;
 }
 
 .profile-season-tab {
   border: 1px solid rgba(160, 219, 255, .23);
   background: rgba(9, 15, 26, .82);
   color: var(--text);
-  border-radius: 0;
-  padding: .4rem .72rem;
-  white-space: nowrap;
+  padding: .4rem .5rem;
   min-height: 34px;
-  display: inline-flex;
-  align-items: center;
-  gap: .4rem;
+  display: grid;
+  justify-items: start;
+  gap: .1rem;
   font-family: var(--font-mono);
-  font-size: .75rem;
+  font-size: .69rem;
 }
 
 .profile-season-tab em {
   font-style: normal;
-  font-size: .62rem;
+  font-size: .6rem;
   color: #91e1ff;
   text-transform: uppercase;
 }
@@ -5351,43 +5403,38 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   border-color: rgba(183, 255, 42, .58);
   color: #d8ff8d;
   background: linear-gradient(90deg, rgba(57, 89, 24, .52), rgba(36, 57, 17, .44));
-  box-shadow: 0 0 0 1px rgba(183, 255, 42, .16);
 }
 
 .profile-season-summary {
   border: 1px solid rgba(170, 228, 255, .24);
-  border-radius: 0;
   background: rgba(8, 13, 24, .72);
-  padding: .66rem;
-  margin-top: .15rem;
+  margin-top: .38rem;
 }
 
 .profile-season-summary h3,
 .profile-logs-wrap h3,
 .profile-log-empty h3 {
-  margin: 0 0 .4rem;
-  font-size: .95rem;
+  margin: 0 0 .3rem;
+  font-size: .84rem;
+}
+
+.profile-wld-pill {
+  margin-top: .35rem;
 }
 
 .profile-logs-wrap {
-  margin-top: .55rem;
+  margin-top: .42rem;
   display: grid;
-  gap: .55rem;
+  gap: .45rem;
   border: 1px solid rgba(145, 208, 246, .22);
-  border-radius: 0;
-  padding: .45rem .55rem;
   background: rgba(6, 11, 20, .72);
 }
 
 .profile-logs-wrap > summary {
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: .82rem;
+  font-size: .76rem;
   color: #9fdfff;
-  background: transparent !important;
-  border: 0 !important;
-  box-shadow: none !important;
-  border-radius: 0 !important;
 }
 
 .profile-log-day {
@@ -5399,79 +5446,34 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: .3rem;
+  gap: .28rem;
   border-bottom: 1px solid rgba(255,255,255,.08);
-  padding: .45rem .55rem;
-  font-size: .78rem;
+  padding: .35rem .42rem;
+  font-size: .72rem;
 }
 
-.profile-log-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
+.profile-log-list { list-style: none; margin: 0; padding: 0; }
 
 .profile-log-item {
-  padding: .45rem .55rem;
+  padding: .35rem .42rem;
   border-bottom: 1px solid rgba(255,255,255,.07);
   display: grid;
-  gap: .28rem;
+  gap: .24rem;
 }
 
-.profile-log-item:last-child {
-  border-bottom: 0;
-}
+.profile-log-item:last-child { border-bottom: 0; }
 
 .profile-log-item__teams,
 .profile-log-item__meta {
   display: grid;
-  gap: .2rem;
-  font-size: .78rem;
+  gap: .18rem;
+  font-size: .72rem;
 }
 
 .profile-log-empty {
-  margin-top: .55rem;
+  margin-top: .42rem;
   border: 1px dashed rgba(255,255,255,.22);
   color: var(--muted);
-  padding: .65rem;
-}
-
-.profile-page-v2 .profile-hero,
-.profile-page-v2 .profile-section,
-.profile-page-v2 .profile-metric-card,
-.profile-page-v2 .profile-highlight-card,
-.profile-page-v2 .profile-season-tab,
-.profile-page-v2 .profile-season-summary,
-.profile-page-v2 .profile-logs-wrap,
-.profile-page-v2 .profile-log-day,
-.profile-page-v2 .profile-log-item,
-.profile-page-v2 .profile-log-empty,
-.profile-page-v2 .profile-status,
-.profile-page-v2 .profile-rank-badge,
-.profile-page-v2 .profile-avatar-frame,
-.profile-page-v2 .profile-avatar-frame img,
-.profile-page-v2 .btn,
-.profile-page-v2 button {
-  border-radius: 0 !important;
-}
-
-.profile-page-v2 .profile-status,
-.profile-page-v2 .profile-hero__meta,
-.profile-page-v2 .profile-section__title,
-.profile-page-v2 .profile-season-summary h3,
-.profile-page-v2 .profile-log-empty h3,
-.profile-page-v2 .profile-log-empty p,
-.profile-page-v2 .profile-season-tab span,
-.profile-page-v2 .profile-season-tab em,
-.profile-page-v2 .profile-metric-card__label,
-.profile-page-v2 .profile-metric-card__value,
-.profile-page-v2 .profile-highlight-card span,
-.profile-page-v2 .profile-highlight-card strong {
-  background: transparent !important;
-  border: 0 !important;
-  box-shadow: none !important;
-  outline: 0 !important;
-  border-radius: 0 !important;
 }
 
 .profile-page-v2 .rank-s,
@@ -5489,98 +5491,33 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 .profile-page-v2 .rank-f,
 .profile-page-v2 .rank-F { color: #c8cfda; }
 
-.profile-page-v2,
-.profile-page-v2 *,
-.profile-page-v2 *::before,
-.profile-page-v2 *::after {
-  border-radius: 0 !important;
-}
-
-.profile-page-v2 .profile-status,
-.profile-page-v2 .profile-rank-badge,
-.profile-page-v2 .profile-hero__meta,
-.profile-page-v2 .profile-section__title,
-.profile-page-v2 .profile-season-tab,
-.profile-page-v2 .profile-season-tab span,
-.profile-page-v2 .profile-season-tab em,
-.profile-page-v2 .profile-metric-card__label,
-.profile-page-v2 .profile-metric-card__value,
-.profile-page-v2 .profile-highlight-card span,
-.profile-page-v2 .profile-highlight-card strong,
-.profile-page-v2 .profile-season-summary h3,
-.profile-page-v2 .profile-season-summary p,
-.profile-page-v2 .profile-log-empty h3,
-.profile-page-v2 .profile-log-empty p {
-  background: transparent !important;
-  border: 0 !important;
-  box-shadow: none !important;
-  outline: 0 !important;
-}
-
-.profile-page-v2 .profile-metric-card > *,
-.profile-page-v2 .profile-highlight-card > *,
-.profile-page-v2 .profile-season-summary > *,
-.profile-page-v2 .profile-log-empty > *,
-.profile-page-v2 .profile-hero__main > *,
-.profile-page-v2 .profile-section > p,
-.profile-page-v2 .profile-section > h2,
-.profile-page-v2 .profile-section > h3,
-.profile-page-v2 .profile-section > span,
-.profile-page-v2 .profile-section > strong,
-.profile-page-v2 .profile-section > em,
-.profile-page-v2 .profile-season-summary span,
-.profile-page-v2 .profile-season-summary strong,
-.profile-page-v2 .profile-season-summary em,
-.profile-page-v2 .profile-muted,
-.profile-page-v2 .profile-note {
-  background: transparent !important;
-  border: 0 !important;
-  box-shadow: none !important;
-  outline: 0 !important;
-  border-radius: 0 !important;
-}
-
-.profile-page-v2 .profile-metric-card__value,
-.profile-page-v2 .profile-metric-card__label,
-.profile-page-v2 .profile-highlight-card span,
-.profile-page-v2 .profile-highlight-card strong,
-.profile-page-v2 .profile-season-summary h3,
-.profile-page-v2 .profile-season-summary p,
-.profile-page-v2 .profile-log-empty h3,
-.profile-page-v2 .profile-log-empty p,
-.profile-page-v2 .profile-status {
-  display: block;
-  width: auto !important;
-  max-width: none !important;
-  min-height: 0 !important;
-  padding: 0 !important;
-}
-
 @media (min-width: 821px) {
   .profile-hero {
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: 84px 1fr auto;
+    align-items: stretch;
+  }
+
+  .profile-avatar-frame {
+    width: 84px;
+    height: 84px;
   }
 
   .profile-hero__actions {
-    justify-content: flex-end;
+    grid-column: auto;
+    align-items: flex-end;
   }
 
-  .profile-metrics-grid {
-    grid-template-columns: repeat(auto-fit, minmax(124px, 1fr));
-  }
-
-  .profile-metrics-grid.is-hero {
-    grid-template-columns: repeat(5, minmax(88px, 1fr));
-  }
-
-  .profile-highlight-grid {
-    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  .profile-analysis__row {
+    grid-template-columns: 1.1fr 1fr;
+    align-items: end;
   }
 }
 
 @media (max-width: 520px) {
-  .profile-metric-card__value {
-    font-size: 1.08rem;
+  .profile-achievement-grid,
+  .profile-mini-grid,
+  .profile-season-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/v2/core/seasons.config.js
+++ b/v2/core/seasons.config.js
@@ -8,10 +8,10 @@ const seasonsConfig = {
     sundaygames: { label: 'Старша', aliases: ['olds', 'adults', 'sunday'] }
   },
   seasons: [
-    { id: 'spring_2026', uiLabel: 'Весна 2026', enabled: true, dateStart: '2026-03-01', dateEnd: '2026-06-30', isStatic: false },
-    { id: 'winter_2025_2026', uiLabel: 'Зима 2025/26', enabled: true, dateStart: '2025-12-01', dateEnd: '2026-02-28', isStatic: false },
-    { id: 'autumn_2025', uiLabel: 'Autumn 2025', enabled: true, dateStart: '2025-09-01', dateEnd: '2025-11-30', isStatic: false },
-    { id: 'summer_2025', uiLabel: 'Summer 2025', enabled: true, dateStart: '2025-06-01', dateEnd: '2025-08-31', isStatic: false }
+    { id: 'spring_2026', uiLabel: 'Весна 2026 (поточний)', enabled: true, dateStart: '2026-03-01', dateEnd: '2026-06-30', isStatic: false },
+    { id: 'winter_2025_2026', uiLabel: 'Зима 2025–2026', enabled: true, dateStart: '2025-12-01', dateEnd: '2026-02-28', isStatic: false },
+    { id: 'autumn_2025', uiLabel: 'Осінь 2025', enabled: true, dateStart: '2025-09-01', dateEnd: '2025-11-30', isStatic: false },
+    { id: 'summer_2025', uiLabel: 'Літо 2025', enabled: true, dateStart: '2025-06-01', dateEnd: '2025-08-31', isStatic: false }
   ]
 };
 

--- a/v2/pages/profile.js
+++ b/v2/pages/profile.js
@@ -1,8 +1,17 @@
-import { buildPlayerCareer, getCurrentLeagueLiveStats, getCurrentSeason, getPlayerSeasonLogs, safeErrorMessage } from '../core/dataHub.js';
+import {
+  buildPlayerCareer,
+  getCurrentLeagueLiveStats,
+  getCurrentSeason,
+  getPlayerSeasonLogs,
+  getSeasonsList,
+  safeErrorMessage
+} from '../core/dataHub.js';
 import { normalizeLeague, normalizeLeagueKey, leagueLabelUA } from '../core/naming.js';
 import { decodeParam, getRouteState, normalizePlayerKey } from '../core/utils.js';
 
 const placeholder = '../assets/default-avatar.svg';
+const RANK_ORDER = ['F', 'E', 'D', 'C', 'B', 'A', 'S'];
+const RANK_MIN_POINTS = { F: 0, E: 200, D: 400, C: 600, B: 800, A: 1000, S: 1200 };
 
 function esc(v) { return String(v ?? '').replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;'); }
 function val(v, fallback = '—') {
@@ -21,10 +30,6 @@ function winnerText(winner = '') {
   if (winner === 'tie') return 'Нічия';
   if (!winner) return '—';
   return winner;
-}
-
-function seasonTabLabel(label = '') {
-  return String(label || '').toUpperCase();
 }
 
 function buildHash(route, params = {}) {
@@ -55,12 +60,89 @@ function rankClass(rank = 'F') {
   return `rank-${String(rank || 'F').toLowerCase()}`;
 }
 
-function metricCard({ label, value, accent = false, mono = false }) {
-  return `<article class="profile-metric-card ${accent ? 'is-accent' : ''} ${mono ? 'is-mono' : ''}"><strong class="profile-metric-card__value">${esc(value)}</strong><span class="profile-metric-card__label">${esc(label)}</span></article>`;
+function wrTone(winRate) {
+  const wr = Number(winRate);
+  if (!Number.isFinite(wr)) return 'is-neutral';
+  if (wr > 60) return 'is-good';
+  if (wr >= 45) return 'is-mid';
+  return 'is-bad';
 }
 
-function metricsGrid(items = [], classes = '') {
-  return `<div class="profile-metrics-grid ${classes}">${items.map(metricCard).join('')}</div>`;
+function deltaTone(delta) {
+  const n = Number(delta);
+  if (!Number.isFinite(n) || n === 0) return 'is-neutral';
+  return n > 0 ? 'is-positive' : 'is-negative';
+}
+
+function formatSeasonTitleUA(raw = '') {
+  const value = String(raw || '').trim();
+  if (!value) return '—';
+
+  const known = {
+    spring: 'Весна',
+    summer: 'Літо',
+    autumn: 'Осінь',
+    fall: 'Осінь',
+    winter: 'Зима'
+  };
+
+  const lower = value.toLowerCase().replace(/[–—]/g, '-').replace(/\//g, '-').replace(/\s+/g, '_');
+  const direct = Object.keys(known).find((key) => lower.startsWith(key));
+  if (direct) {
+    const years = lower.match(/(20\d{2})(?:[-_](20\d{2}|\d{2}))?/);
+    if (years) {
+      const y1 = years[1];
+      const y2 = years[2];
+      if (y2) {
+        const fullY2 = y2.length === 2 ? `${String(y1).slice(0, 2)}${y2}` : y2;
+        return `${known[direct]} ${y1}–${fullY2}`;
+      }
+      return `${known[direct]} ${y1}`;
+    }
+  }
+
+  return value
+    .replace(/summer/ig, 'Літо')
+    .replace(/autumn/ig, 'Осінь')
+    .replace(/fall/ig, 'Осінь')
+    .replace(/winter/ig, 'Зима')
+    .replace(/spring/ig, 'Весна')
+    .replace(/[_-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function getRankProgress(points, rankLetter) {
+  const rank = String(rankLetter || 'F').toUpperCase();
+  const index = RANK_ORDER.indexOf(rank);
+  const currentMin = RANK_MIN_POINTS[rank] ?? 0;
+
+  if (!Number.isFinite(Number(points))) {
+    return { percent: 0, currentMin, nextMin: null, remain: null, nextRank: null, isMax: rank === 'S' };
+  }
+
+  if (index === -1 || rank === 'S') {
+    return { percent: 100, currentMin, nextMin: null, remain: 0, nextRank: null, isMax: true };
+  }
+
+  const nextRank = RANK_ORDER[index + 1];
+  const nextMin = RANK_MIN_POINTS[nextRank];
+  const value = Number(points);
+  const span = Math.max(1, nextMin - currentMin);
+  const percent = Math.max(0, Math.min(100, ((value - currentMin) / span) * 100));
+
+  return {
+    percent,
+    currentMin,
+    nextMin,
+    remain: Math.max(0, nextMin - value),
+    nextRank,
+    isMax: false
+  };
+}
+
+function metricMini({ label, value, tone = '' }) {
+  return `<article class="profile-mini-card ${tone}"><strong>${esc(value)}</strong><span>${esc(label)}</span></article>`;
 }
 
 function renderCareerHighlights(highlights = {}) {
@@ -71,55 +153,94 @@ function renderCareerHighlights(highlights = {}) {
   const mostActive = highlights.mostActiveSeason;
   const mvpRecord = highlights.bestMvpSeason;
 
-  if (bestPoints?.seasonTitle && Number.isFinite(bestPoints.ratingEnd)) cards.push({ label: 'BEST SEASON', value: `${bestPoints.seasonTitle} • ${bestPoints.ratingEnd}` });
-  if (biggestDelta?.seasonTitle && Number.isFinite(biggestDelta.ratingDelta)) cards.push({ label: 'BIGGEST GROWTH', value: `${biggestDelta.seasonTitle} • ${signed(biggestDelta.ratingDelta)}` });
-  if (bestWr?.seasonTitle && Number.isFinite(bestWr.winrate)) cards.push({ label: 'BEST WR', value: `${bestWr.seasonTitle} • ${bestWr.winrate.toFixed(1)}%` });
-  if (mostActive?.seasonTitle && Number.isFinite(mostActive.matches)) cards.push({ label: 'MOST ACTIVE', value: `${mostActive.seasonTitle} • ${mostActive.matches}` });
-  if (mvpRecord?.seasonTitle && Number.isFinite(mvpRecord.mvpTotal)) cards.push({ label: 'MVP RECORD', value: `${mvpRecord.seasonTitle} • ${mvpRecord.mvpTotal}` });
+  if (bestPoints?.seasonTitle && Number.isFinite(bestPoints.ratingEnd)) cards.push({ icon: '🏆', label: 'Найкращий сезон', value: `${formatSeasonTitleUA(bestPoints.seasonTitle)} • ${bestPoints.ratingEnd}` });
+  if (biggestDelta?.seasonTitle && Number.isFinite(biggestDelta.ratingDelta)) cards.push({ icon: '📈', label: 'Найбільший прогрес', value: `${formatSeasonTitleUA(biggestDelta.seasonTitle)} • ${signed(biggestDelta.ratingDelta)}` });
+  if (bestWr?.seasonTitle && Number.isFinite(bestWr.winrate)) cards.push({ icon: '🎯', label: 'Найкращий WR', value: `${formatSeasonTitleUA(bestWr.seasonTitle)} • ${bestWr.winrate.toFixed(1)}%` });
+  if (mostActive?.seasonTitle && Number.isFinite(mostActive.matches)) cards.push({ icon: '🔥', label: 'Найбільша активність', value: `${formatSeasonTitleUA(mostActive.seasonTitle)} • ${mostActive.matches} ігор` });
+  if (mvpRecord?.seasonTitle && Number.isFinite(mvpRecord.mvpTotal)) cards.push({ icon: '⭐', label: 'Рекорд MVP', value: `${formatSeasonTitleUA(mvpRecord.seasonTitle)} • ${mvpRecord.mvpTotal}` });
 
   if (!cards.length) return '';
-  return `<section class="px-card profile-section"><h2 class="profile-section__title">Відзнаки кар'єри</h2><div class="profile-highlight-grid">${cards.map((item) => `<article class="profile-highlight-card"><span>${esc(item.label)}</span><strong>${esc(item.value)}</strong></article>`).join('')}</div></section>`;
+  return `<section class="px-card profile-section profile-achievements"><h2 class="profile-section__title">Відзнаки кар'єри</h2><div class="profile-achievement-grid">${cards.map((item) => `<article class="profile-achievement-card"><div class="profile-achievement-card__head"><span class="profile-achievement-card__icon">${item.icon}</span><strong>${esc(item.label)}</strong></div><p>${esc(item.value)}</p></article>`).join('')}</div></section>`;
 }
 
-function renderCurrentSummary({ league, livePlayer, currentSeason }) {
-  const currentRank = String(livePlayer?.rankLetter || livePlayer?.rankText || 'F').toUpperCase();
+function renderHero({ profileLeagueContext, livePlayer, currentSeason, displayNick, currentRank, topSeason }) {
+  const points = Number(livePlayer?.points ?? topSeason?.ratingEnd ?? topSeason?.points);
+  const place = Number(livePlayer?.place ?? topSeason?.place ?? topSeason?.finalPlace);
+  const progress = getRankProgress(points, currentRank);
+  const seasonLabel = formatSeasonTitleUA(currentSeason?.uiLabel || topSeason?.seasonTitle || 'Поточний сезон');
+  const leagueLabel = leagueLabelUA(profileLeagueContext);
+
+  return `
+    <article class="px-card profile-hero ${rankClass(currentRank)}">
+      <div class="profile-avatar-frame ${rankClass(currentRank)}">
+        <img src="${esc(topSeason?.avatar || livePlayer?.avatarUrl || placeholder)}" alt="${esc(displayNick)}" onerror="this.src='${placeholder}'">
+      </div>
+      <div class="profile-hero__main">
+        <div class="profile-hero__head">
+          <h1>${esc(displayNick)}</h1>
+          <span class="profile-rank-badge ${rankClass(currentRank)}">${esc(currentRank)}</span>
+        </div>
+        <p class="profile-hero__meta">${esc(leagueLabel)} • ${esc(seasonLabel)}</p>
+        <div class="profile-hero__badges">
+          <span class="profile-place-badge">${Number.isFinite(place) ? `#${place}` : '—'}</span>
+          <span class="profile-subtle-badge">Ранг ${esc(currentRank)}</span>
+        </div>
+        <div class="profile-rank-progress-wrap">
+          <div class="profile-rank-progress__labels">
+            <span>Прогрес рангу</span>
+            <strong>${progress.isMax ? 'Максимальний ранг' : `${progress.percent.toFixed(0)}% до ${progress.nextRank}`}</strong>
+          </div>
+          <div class="profile-rank-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(progress.percent)}">
+            <span style="width:${progress.percent.toFixed(1)}%"></span>
+          </div>
+          <p class="profile-note">${progress.isMax ? 'Досягнуто найвищий ранг S.' : `Залишилось ${val(progress.remain, '—')} очок до рангу ${val(progress.nextRank, '—')}.`}</p>
+        </div>
+      </div>
+      <div class="profile-hero__actions">
+        <a class="btn btn--secondary" href="${buildHash('league-stats', { league: normalizeLeagueKey(profileLeagueContext) })}">Назад до ліги</a>
+      </div>
+    </article>
+  `;
+}
+
+function renderCompactStats({ livePlayer, topSeason }) {
+  const wr = livePlayer?.winRate ?? topSeason?.winRate ?? topSeason?.winrate;
+  const delta = livePlayer?.delta ?? topSeason?.delta ?? topSeason?.ratingDelta;
   return `
     <section class="px-card profile-section">
-      <h2 class="profile-section__title">Поточний стан</h2>
-      ${metricsGrid([
-    { label: 'POINTS', value: val(livePlayer?.points), accent: true, mono: true },
-    { label: 'RANK', value: currentRank, accent: true },
-    { label: 'PLACE', value: Number.isFinite(Number(livePlayer?.place)) ? `#${livePlayer.place}` : '—', mono: true },
-    { label: 'WR', value: pct(livePlayer?.winRate), accent: true, mono: true },
-    { label: 'MVP', value: val(livePlayer?.mvpTotal), accent: true, mono: true },
-    { label: 'DELTA', value: signed(livePlayer?.delta), accent: true, mono: true },
-    { label: 'MATCHES', value: val(livePlayer?.matches), mono: true },
-    { label: 'BATTLES', value: val(livePlayer?.battles), mono: true },
-    { label: 'LEAGUE', value: leagueLabelUA(league) },
-    { label: 'SEASON', value: currentSeason?.uiLabel || '—' }
-  ])}
+      <h2 class="profile-section__title">Ключові метрики</h2>
+      <div class="profile-mini-grid">
+        ${metricMini({ label: 'Очки', value: val(livePlayer?.points ?? topSeason?.ratingEnd ?? topSeason?.points), tone: 'is-accent' })}
+        ${metricMini({ label: 'WR', value: pct(wr), tone: wrTone(wr) })}
+        ${metricMini({ label: 'MVP', value: val(livePlayer?.mvpTotal ?? topSeason?.mvpTotal) })}
+        ${metricMini({ label: 'Δ рейтингу', value: signed(delta), tone: deltaTone(delta) })}
+      </div>
     </section>
   `;
 }
 
-function renderCareerSummary(profile) {
-  const allTime = profile?.allTime || {};
+function renderGameAnalysis({ livePlayer, topSeason }) {
+  const wins = Number(livePlayer?.wins ?? topSeason?.wins);
+  const losses = Number(livePlayer?.losses ?? topSeason?.losses);
+  const draws = Number(livePlayer?.draws ?? topSeason?.draws);
+  const wr = Number(livePlayer?.winRate ?? topSeason?.winRate ?? topSeason?.winrate);
+  const total = [wins, losses, draws].reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0);
+
   return `
-    <section class="px-card profile-section">
-      <h2 class="profile-section__title">Загальна статистика</h2>
-      ${metricsGrid([
-    { label: 'SEASONS', value: val(allTime.seasonsPlayed), mono: true },
-    { label: 'MATCHES', value: val(allTime.totalMatches ?? allTime.matches), accent: true, mono: true },
-    { label: 'ROUNDS', value: val(allTime.totalRounds ?? allTime.rounds), mono: true },
-    { label: 'TOTAL MVP', value: val(allTime.totalMvp ?? allTime.mvpTotal), accent: true, mono: true },
-    { label: 'CAREER WR', value: pct(allTime.careerWR ?? allTime.winrate), accent: true, mono: true },
-    { label: 'PEAK RATING', value: val(allTime.peakRating ?? allTime.peakPoints), accent: true, mono: true },
-    { label: 'CUMULATIVE Δ', value: signed(allTime.cumulativeDelta), accent: true, mono: true },
-    { label: 'BEST RANK', value: val(allTime.bestRank), accent: true },
-    { label: 'WINS', value: val(allTime.totalWins ?? allTime.wins), mono: true },
-    { label: 'LOSSES', value: val(allTime.totalLosses ?? allTime.losses), mono: true },
-    { label: 'DRAWS', value: val(allTime.totalDraws ?? allTime.draws), mono: true }
-  ])}
+    <section class="px-card profile-section profile-analysis">
+      <h2 class="profile-section__title">Аналіз гри</h2>
+      <div class="profile-analysis__row">
+        <div>
+          <p class="profile-analysis__label">Winrate</p>
+          <div class="profile-wr-bar ${wrTone(wr)}"><span style="width:${Number.isFinite(wr) ? Math.max(0, Math.min(100, wr)) : 0}%"></span></div>
+          <strong class="profile-analysis__value">${pct(wr)}</strong>
+        </div>
+        <div class="profile-analysis__compact">
+          <p><span>W / L / D</span><strong>${val(wins)} / ${val(losses)} / ${val(draws)}</strong></p>
+          <p><span>Ігри</span><strong>${val(livePlayer?.matches ?? topSeason?.matches ?? total)}</strong></p>
+          <p><span>Бої</span><strong>${val(livePlayer?.battles ?? topSeason?.rounds)}</strong></p>
+        </div>
+      </div>
     </section>
   `;
 }
@@ -128,7 +249,7 @@ function renderSeasonTabs(container, tabs, selectedId) {
   container.innerHTML = tabs.map((tab) => `
     <button type="button" class="profile-season-tab ${tab.id === selectedId ? 'is-active' : ''}" data-season-id="${esc(tab.id)}">
       <span>${esc(tab.label)}</span>
-      ${tab.current ? '<em>CURRENT</em>' : ''}
+      ${tab.current ? '<em>поточний</em>' : ''}
     </button>
   `).join('');
 }
@@ -137,37 +258,37 @@ function renderSeasonSummary(season, allTime) {
   if (!season || season.id === 'all') {
     return `
       <section class="profile-season-summary">
-        <h3>Усі сезони</h3>
-        <p class="profile-muted">Повний зріз карʼєри по всіх сезонах.</p>
-        ${metricsGrid([
-      { label: 'MATCHES', value: val(allTime.totalMatches ?? allTime.matches), mono: true },
-      { label: 'ROUNDS', value: val(allTime.totalRounds ?? allTime.rounds), mono: true },
-      { label: 'WR', value: pct(allTime.careerWR ?? allTime.winrate), accent: true, mono: true },
-      { label: 'MVP', value: val(allTime.totalMvp ?? allTime.mvpTotal), accent: true, mono: true },
-      { label: 'PEAK', value: val(allTime.peakRating ?? allTime.peakPoints), accent: true, mono: true },
-      { label: 'BEST RANK', value: val(allTime.bestRank), accent: true }
-    ])}
+        <h3>Уся карʼєра</h3>
+        <p class="profile-muted">Зведені показники за всі сезони.</p>
+        <div class="profile-mini-grid">
+          ${metricMini({ label: 'Ігри', value: val(allTime.totalMatches ?? allTime.matches) })}
+          ${metricMini({ label: 'Раунди', value: val(allTime.totalRounds ?? allTime.rounds) })}
+          ${metricMini({ label: 'WR', value: pct(allTime.careerWR ?? allTime.winrate), tone: wrTone(allTime.careerWR ?? allTime.winrate) })}
+          ${metricMini({ label: 'MVP', value: val(allTime.totalMvp ?? allTime.mvpTotal) })}
+          ${metricMini({ label: 'Пік рейтингу', value: val(allTime.peakRating ?? allTime.peakPoints), tone: 'is-accent' })}
+          ${metricMini({ label: 'Найкращий ранг', value: val(allTime.bestRank), tone: 'is-accent' })}
+        </div>
       </section>
     `;
   }
 
+  const seasonWr = season.winRate ?? season.winrate;
+  const seasonDelta = season.delta ?? season.ratingDelta;
+
   return `
       <section class="profile-season-summary">
-        <h3>${esc(season.seasonTitle || season.id)}</h3>
-      <p class="profile-muted">${esc(leagueLabelUA(season.league || 'kids'))}</p>
-      ${metricsGrid([
-    { label: 'RATING START', value: val(season.ratingStart), mono: true },
-    { label: 'RATING END', value: val(season.ratingEnd ?? season.points), accent: true, mono: true },
-    { label: 'DELTA', value: signed(season.delta ?? season.ratingDelta), accent: true, mono: true },
-    { label: 'MATCHES', value: val(season.matches ?? season.games), mono: true },
-    { label: 'WR', value: pct(season.winRate ?? season.winrate), accent: true, mono: true },
-    { label: 'MVP', value: val(season.mvpTotal), accent: true, mono: true },
-    { label: 'PLACE', value: Number.isFinite(Number(season.place ?? season.finalPlace)) ? `#${season.place ?? season.finalPlace}` : '—', mono: true },
-    { label: 'RANK', value: val(season.rank), accent: true, mono: true },
-    { label: 'ROUNDS', value: val(season.rounds), mono: true },
-    { label: 'W/L/D', value: `${val(season.wins)} / ${val(season.losses)} / ${val(season.draws)}`, mono: true }
-  ])}
-    </section>
+        <h3>${esc(formatSeasonTitleUA(season.seasonTitle || season.id))}</h3>
+        <p class="profile-muted">${esc(leagueLabelUA(season.league || 'kids'))}</p>
+        <div class="profile-mini-grid">
+          ${metricMini({ label: 'Старт', value: val(season.ratingStart) })}
+          ${metricMini({ label: 'Фініш', value: val(season.ratingEnd ?? season.points), tone: 'is-accent' })}
+          ${metricMini({ label: 'Δ', value: signed(seasonDelta), tone: deltaTone(seasonDelta) })}
+          ${metricMini({ label: 'WR', value: pct(seasonWr), tone: wrTone(seasonWr) })}
+          ${metricMini({ label: 'Ігри', value: val(season.matches ?? season.games) })}
+          ${metricMini({ label: 'MVP', value: val(season.mvpTotal) })}
+        </div>
+        <div class="profile-wld-pill">W / L / D: <strong>${val(season.wins)} / ${val(season.losses)} / ${val(season.draws)}</strong></div>
+      </section>
   `;
 }
 
@@ -177,7 +298,7 @@ function renderLogs(logData) {
   }
 
   return `<details class="profile-logs-wrap">
-    <summary>Match logs (${logData.groups.length} днів)</summary>
+    <summary>Матч-логи (${logData.groups.length} днів)</summary>
     ${logData.groups.map((group) => `
       <article class="profile-log-day">
         <header class="profile-log-day__head">
@@ -189,9 +310,9 @@ function renderLogs(logData) {
               <li class="profile-log-item">
                 <div class="profile-log-item__teams">${entry.teams.map((team, idx) => `<span>К${idx + 1}: ${esc(team.join(', ') || '—')}</span>`).join('')}</div>
                 <div class="profile-log-item__meta">
-                  <span>Winner: ${esc(winnerText(entry.winnerLabel))}</span>
+                  <span>Переможець: ${esc(winnerText(entry.winnerLabel))}</span>
                   <span>MVP: ${esc(entry.mvp1 || '—')} / ${esc(entry.mvp2 || '—')} / ${esc(entry.mvp3 || '—')}</span>
-                  <span>Rounds: ${esc(val(entry.rounds))}</span>
+                  <span>Раунди: ${esc(val(entry.rounds))}</span>
                 </div>
               </li>
             `).join('')}</ul>`
@@ -199,6 +320,14 @@ function renderLogs(logData) {
       </article>
     `).join('')}
   </details>`;
+}
+
+function sortTabsByChronology(tabs = []) {
+  return [...tabs].sort((a, b) => {
+    const aTime = Number.isFinite(Date.parse(a.dateFrom || '')) ? Date.parse(a.dateFrom) : 0;
+    const bTime = Number.isFinite(Date.parse(b.dateFrom || '')) ? Date.parse(b.dateFrom) : 0;
+    return aTime - bTime;
+  });
 }
 
 export async function initProfilePage(params = {}) {
@@ -214,10 +343,11 @@ export async function initProfilePage(params = {}) {
   renderSkeleton(root);
 
   try {
-    const [profile, liveStats, currentSeason] = await Promise.all([
+    const [profile, liveStats, currentSeason, seasonOptions] = await Promise.all([
       buildPlayerCareer(nick, { profileLeagueContext: routeLeagueContext }),
       getCurrentLeagueLiveStats(league),
-      getCurrentSeason()
+      getCurrentSeason(),
+      getSeasonsList()
     ]);
 
     const normalizedNick = normalizePlayerKey(nick);
@@ -238,46 +368,18 @@ export async function initProfilePage(params = {}) {
     const displayNick = livePlayer?.nickname || profile?.nick || nick;
     const seasonRows = profile?.seasons || [];
     const seasonRowsById = new Map(seasonRows.map((row) => [row.seasonId, row]));
-    const currentRank = String(livePlayer?.rankLetter || seasonRows[0]?.rank || profile?.allTime?.bestRank || 'F').toUpperCase();
-    const statusLine = [
-      livePlayer?.place ? `#${livePlayer.place}` : '—',
-      currentSeason?.uiLabel || 'Поточний сезон',
-      leagueLabelUA(profileLeagueContext)
-    ].join(' • ');
+    const topSeason = seasonRows[0] || {};
+    const currentRank = String(livePlayer?.rankLetter || topSeason?.rank || profile?.allTime?.bestRank || 'F').toUpperCase();
 
     root.innerHTML = `
       <section class="profile-page-v2">
-        <article class="px-card profile-hero ${rankClass(currentRank)}">
-          <div class="profile-hero__left">
-            <div class="profile-avatar-frame ${rankClass(currentRank)}">
-              <img src="${esc(profile?.avatar || livePlayer?.avatarUrl || placeholder)}" alt="${esc(displayNick)}" onerror="this.src='${placeholder}'">
-            </div>
-            <span class="profile-rank-badge ${rankClass(currentRank)}">${esc(currentRank)}</span>
-          </div>
-          <div class="profile-hero__main">
-            <div class="profile-hero__head">
-              <h1>${esc(displayNick)}</h1>
-            </div>
-            <p class="profile-hero__meta">${esc(statusLine)}</p>
-            ${metricsGrid([
-      { label: 'POINTS', value: val(livePlayer?.points ?? seasonRows[0]?.ratingEnd ?? seasonRows[0]?.points), accent: true, mono: true },
-      { label: 'RANK', value: currentRank, accent: true },
-      { label: 'WR', value: pct(livePlayer?.winRate ?? seasonRows[0]?.winRate ?? seasonRows[0]?.winrate), accent: true, mono: true },
-      { label: 'MVP', value: val(livePlayer?.mvpTotal ?? seasonRows[0]?.mvpTotal), accent: true, mono: true },
-      { label: 'DELTA', value: signed(livePlayer?.delta ?? seasonRows[0]?.delta ?? seasonRows[0]?.ratingDelta), accent: true, mono: true }
-    ], 'is-hero')}
-          </div>
-          <div class="profile-hero__actions">
-            <a class="btn btn--secondary" href="${buildHash('league-stats', { league: normalizeLeagueKey(profileLeagueContext) })}">Назад до ліги</a>
-          </div>
-        </article>
-
-        ${renderCurrentSummary({ league: profileLeagueContext, livePlayer: livePlayer || {}, currentSeason })}
-        ${renderCareerSummary(profile || { allTime: {} })}
+        ${renderHero({ profileLeagueContext, livePlayer: livePlayer || {}, currentSeason, displayNick, currentRank, topSeason })}
+        ${renderCompactStats({ livePlayer: livePlayer || {}, topSeason })}
+        ${renderGameAnalysis({ livePlayer: livePlayer || {}, topSeason })}
         ${renderCareerHighlights(profile?.highlights || {})}
 
         <section class="px-card profile-section">
-          <h2 class="profile-section__title">Вибір сезону</h2>
+          <h2 class="profile-section__title">Сезони</h2>
           <div class="profile-season-tabs" id="seasonTabs"></div>
           <div id="seasonSummaryHost"></div>
           <div id="seasonLogsHost"></div>
@@ -288,13 +390,21 @@ export async function initProfilePage(params = {}) {
     const seasonTabsEl = root.querySelector('#seasonTabs');
     const summaryEl = root.querySelector('#seasonSummaryHost');
     const logsEl = root.querySelector('#seasonLogsHost');
-    const tabs = [{ id: 'all', label: 'ALL', current: false }]
-      .concat(
-        seasonRows
-          .map((season) => ({ id: season.seasonId, label: seasonTabLabel(season.seasonTitle || season.seasonId), current: season.seasonId === currentSeason?.id }))
-      );
 
-    const state = { seasonId: 'all' };
+    const available = seasonRows
+      .map((season) => {
+        const meta = (seasonOptions || []).find((item) => item.id === season.seasonId);
+        return {
+          id: season.seasonId,
+          label: formatSeasonTitleUA(meta?.title || season.seasonTitle || season.seasonId),
+          current: season.seasonId === currentSeason?.id,
+          dateFrom: meta?.dateFrom
+        };
+      });
+
+    const tabs = [{ id: 'all', label: 'Усі сезони', current: false }].concat(sortTabsByChronology(available));
+
+    const state = { seasonId: currentSeason?.id && seasonRowsById.has(currentSeason.id) ? currentSeason.id : 'all' };
 
     const renderState = async () => {
       renderSeasonTabs(seasonTabsEl, tabs, state.seasonId);


### PR DESCRIPTION
### Motivation

- Позбутися дублювання і зайвого простору на сторінці профілю та зробити її швидко читаємою (5–10 секунд). 
- Додати інфографіку й елементи геймефікації (прогрес-бар рангу, кольорові індикатори, бейджі позиції). 
- Уніфікувати вигляд під стиль V2 та забезпечити компактність і мобільну адаптацію.

### Description

- Переписано рендеринг профілю в `v2/pages/profile.js`: видалено дубль «Поточний стан», введено компактний Hero з аватаром/рангом/бейджем місця, прогрес-бар рангу, 2x2 міні-метрики (Очки / WR / MVP / Δ) та новий блок «Аналіз гри» з WR-баром і W/L/D; додані допоміжні функції `getRankProgress`, `formatSeasonTitleUA`, `wrTone` і `deltaTone`.
- Перетворено кар’єрні відзнаки на achievement-картки з іконками та українськими підписами, перероблено відображення season summary у компактну 2-колоночну сітку з окремим W/L/D pill.
- Оновлено стилі `v2/assets/css/main.css`: ущільнені відступи, зменшені картки, нові класи для міні-карток, прогрес-барів, секції аналітики та achievement-карт; селектор сезонів зроблено компактним (максимум 2 колонки на мобілі).
- Локалізовано і нормалізовано назви сезонів у конфігу `v2/core/seasons.config.js` (наприклад `Осінь 2025`, `Літо 2025`, `Зима 2025–2026`, `Весна 2026 (поточний)`), і таби тепер формуються та сортуються хронологічно за `dateFrom`.

### Testing

- Запущена перевірка синтаксису JavaScript: `node --check v2/pages/profile.js` — пройшла успішно. 
- Запущена перевірка синтаксису конфіга: `node --check v2/core/seasons.config.js` — пройшла успішно. 
- Наявних автоматизованих тестів не виявлено в проекті; додаткових тестових скріншотів UI у цьому середовищі зробити не вдалось (інструмент недоступний).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7813b76a08321b503e6a01d6d7d0b)