### PR TITLE
Player profile v2 — remove pill UI, strengthen composition, add player analytics & achievements

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -5107,7 +5107,7 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 .profile-page-v2 .px-card,
 .profile-page-v2 .btn,
 .profile-page-v2 button {
-  border-radius: 0;
+  border-radius: 14px;
 }
 
 .profile-hero,
@@ -5157,12 +5157,13 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 .profile-place-badge,
 .profile-subtle-badge {
   border: 1px solid currentColor;
-  padding: .18rem .45rem;
+  padding: .24rem .5rem;
   font-size: .68rem;
   letter-spacing: .04em;
   text-transform: uppercase;
   display: inline-flex;
   align-items: center;
+  border-radius: 10px;
 }
 
 .profile-rank-badge {
@@ -5212,15 +5213,21 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 
 .profile-rank-progress {
   position: relative;
-  height: 8px;
-  border: 1px solid rgba(172, 225, 255, .2);
-  background: rgba(6, 12, 21, .8);
+  height: 10px;
+  border: 1px solid rgba(172, 225, 255, .32);
+  background: linear-gradient(180deg, rgba(4, 10, 20, .94), rgba(12, 20, 34, .9));
+  border-radius: 999px;
+  overflow: hidden;
 }
 
 .profile-rank-progress span {
   display: block;
   height: 100%;
-  background: linear-gradient(90deg, #79f975, #b7ff2a);
+  background: linear-gradient(90deg, #51d8ff, #b7ff2a);
+}
+
+.profile-hero.rank-s .profile-rank-progress span {
+  background: linear-gradient(90deg, #c87dff, #ff74bf);
 }
 
 .profile-hero__actions {
@@ -5251,11 +5258,12 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 .profile-mini-card {
   border: 1px solid rgba(153, 214, 255, .14);
   background: rgba(10, 18, 31, .82);
-  padding: .42rem .45rem;
+  padding: .5rem .52rem;
   min-height: 58px;
   display: grid;
   gap: .12rem;
   align-content: center;
+  border-radius: 12px;
 }
 
 .profile-mini-card span {
@@ -5322,21 +5330,10 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   gap: .25rem;
 }
 
-.profile-analysis__compact p,
-.profile-wld-pill {
-  margin: 0;
-  display: flex;
-  justify-content: space-between;
-  gap: .4rem;
-  font-size: .78rem;
-  border: 1px solid rgba(161, 214, 250, .16);
-  background: rgba(9, 15, 27, .72);
-  padding: .3rem .42rem;
-}
-
-.profile-analysis__compact strong,
-.profile-wld-pill strong {
-  font-family: var(--font-mono);
+.profile-analysis__compact-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: .35rem;
 }
 
 .profile-achievement-grid {
@@ -5346,11 +5343,12 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 }
 
 .profile-achievement-card {
-  border: 1px solid rgba(182, 255, 75, .28);
-  background: linear-gradient(130deg, rgba(36, 71, 31, .36), rgba(15, 28, 20, .58));
-  padding: .42rem .45rem;
+  border: 1px solid rgba(182, 255, 75, .22);
+  background: linear-gradient(160deg, rgba(18, 33, 23, .76), rgba(11, 20, 31, .85));
+  padding: .5rem .56rem;
   display: grid;
-  gap: .2rem;
+  gap: .28rem;
+  border-radius: 12px;
 }
 
 .profile-achievement-card__head {
@@ -5367,9 +5365,16 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   letter-spacing: .04em;
 }
 
-.profile-achievement-card p {
+.profile-achievement-card__value {
   margin: 0;
-  font-size: .77rem;
+  font-size: .98rem;
+  font-family: var(--font-mono);
+}
+
+.profile-achievement-card__season {
+  margin: 0;
+  font-size: .68rem;
+  color: var(--muted);
 }
 
 .profile-season-tabs {
@@ -5390,6 +5395,7 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   gap: .1rem;
   font-family: var(--font-mono);
   font-size: .69rem;
+  border-radius: 12px;
 }
 
 .profile-season-tab em {
@@ -5400,9 +5406,10 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 }
 
 .profile-season-tab.is-active {
-  border-color: rgba(183, 255, 42, .58);
-  color: #d8ff8d;
-  background: linear-gradient(90deg, rgba(57, 89, 24, .52), rgba(36, 57, 17, .44));
+  border-color: rgba(183, 255, 42, .72);
+  color: #e6ffc2;
+  background: linear-gradient(120deg, rgba(57, 89, 24, .64), rgba(23, 39, 55, .82));
+  box-shadow: inset 0 0 0 1px rgba(204, 255, 126, .25);
 }
 
 .profile-season-summary {
@@ -5416,10 +5423,6 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 .profile-log-empty h3 {
   margin: 0 0 .3rem;
   font-size: .84rem;
-}
-
-.profile-wld-pill {
-  margin-top: .35rem;
 }
 
 .profile-logs-wrap {
@@ -5440,6 +5443,8 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 .profile-log-day {
   border: 1px solid rgba(255,255,255,.12);
   background: rgba(255,255,255,.02);
+  border-radius: 10px;
+  overflow: hidden;
 }
 
 .profile-log-day__head {
@@ -5475,6 +5480,143 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   border: 1px dashed rgba(255,255,255,.22);
   color: var(--muted);
 }
+
+.profile-indicator-grid {
+  margin-top: .45rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .35rem;
+}
+
+.profile-indicator-card {
+  border: 1px solid rgba(154, 216, 255, .2);
+  background: rgba(8, 14, 26, .8);
+  border-radius: 12px;
+  padding: .42rem .5rem;
+  display: grid;
+  gap: .2rem;
+}
+
+.profile-indicator-card p {
+  margin: 0;
+  font-size: .66rem;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.profile-indicator-card strong {
+  font-size: .9rem;
+}
+
+.profile-meter {
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(255,255,255,.1);
+  overflow: hidden;
+}
+
+.profile-meter span {
+  display: block;
+  height: 100%;
+}
+
+.profile-meter.low span { background: linear-gradient(90deg, #ff7f7f, #ffb36d); }
+.profile-meter.medium span { background: linear-gradient(90deg, #ffd45a, #ffe87f); }
+.profile-meter.high span { background: linear-gradient(90deg, #72e28b, #95f7ad); }
+
+.profile-form-card,
+.profile-player-type {
+  margin-top: .42rem;
+  border: 1px solid rgba(157, 219, 255, .2);
+  background: rgba(8, 14, 24, .7);
+  border-radius: 12px;
+  padding: .5rem;
+}
+
+.profile-form-card p,
+.profile-player-type h3,
+.profile-insights-card h3,
+.profile-season-trend__head span {
+  margin: 0;
+  font-size: .68rem;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: #9fdfff;
+}
+
+.profile-form-card strong {
+  display: block;
+  margin-top: .2rem;
+  font-size: .96rem;
+}
+
+.profile-insights-grid {
+  margin-top: .42rem;
+  display: grid;
+  gap: .35rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.profile-insights-card {
+  border: 1px solid rgba(156, 218, 255, .2);
+  background: rgba(8, 13, 22, .78);
+  border-radius: 12px;
+  padding: .46rem .5rem;
+}
+
+.profile-insights-card ul {
+  margin: .3rem 0 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: .22rem;
+  font-size: .76rem;
+}
+
+.profile-player-type__grid,
+.profile-season-wld-grid {
+  margin-top: .35rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: .35rem;
+}
+
+.profile-season-trend {
+  margin-top: .4rem;
+  border: 1px solid rgba(156, 216, 255, .2);
+  background: rgba(8, 14, 26, .8);
+  border-radius: 12px;
+  padding: .45rem .5rem;
+  display: grid;
+  gap: .26rem;
+}
+
+.profile-season-trend__head {
+  display: flex;
+  justify-content: space-between;
+  gap: .35rem;
+  align-items: baseline;
+}
+
+.profile-season-trend__head strong {
+  font-size: .8rem;
+  font-family: var(--font-mono);
+}
+
+.profile-season-trend__bar {
+  height: 8px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255,255,255,.1);
+}
+
+.profile-season-trend__bar span {
+  display: block;
+  height: 100%;
+}
+
+.profile-season-trend__bar.is-positive span { background: linear-gradient(90deg, #6ce58d, #8ef8a1); }
+.profile-season-trend__bar.is-negative span { background: linear-gradient(90deg, #ff7c7c, #ff9f9f); }
+.profile-season-trend__bar.is-neutral span { background: linear-gradient(90deg, #9ec3db, #b4d5e8); }
 
 .profile-page-v2 .rank-s,
 .profile-page-v2 .rank-S { color: #d38aff; }
@@ -5517,6 +5659,14 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   .profile-achievement-grid,
   .profile-mini-grid,
   .profile-season-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .profile-analysis__compact-grid,
+  .profile-player-type__grid,
+  .profile-season-wld-grid,
+  .profile-indicator-grid,
+  .profile-insights-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/v2/pages/profile.js
+++ b/v2/pages/profile.js
@@ -153,14 +153,87 @@ function renderCareerHighlights(highlights = {}) {
   const mostActive = highlights.mostActiveSeason;
   const mvpRecord = highlights.bestMvpSeason;
 
-  if (bestPoints?.seasonTitle && Number.isFinite(bestPoints.ratingEnd)) cards.push({ icon: '🏆', label: 'Найкращий сезон', value: `${formatSeasonTitleUA(bestPoints.seasonTitle)} • ${bestPoints.ratingEnd}` });
-  if (biggestDelta?.seasonTitle && Number.isFinite(biggestDelta.ratingDelta)) cards.push({ icon: '📈', label: 'Найбільший прогрес', value: `${formatSeasonTitleUA(biggestDelta.seasonTitle)} • ${signed(biggestDelta.ratingDelta)}` });
-  if (bestWr?.seasonTitle && Number.isFinite(bestWr.winrate)) cards.push({ icon: '🎯', label: 'Найкращий WR', value: `${formatSeasonTitleUA(bestWr.seasonTitle)} • ${bestWr.winrate.toFixed(1)}%` });
-  if (mostActive?.seasonTitle && Number.isFinite(mostActive.matches)) cards.push({ icon: '🔥', label: 'Найбільша активність', value: `${formatSeasonTitleUA(mostActive.seasonTitle)} • ${mostActive.matches} ігор` });
-  if (mvpRecord?.seasonTitle && Number.isFinite(mvpRecord.mvpTotal)) cards.push({ icon: '⭐', label: 'Рекорд MVP', value: `${formatSeasonTitleUA(mvpRecord.seasonTitle)} • ${mvpRecord.mvpTotal}` });
+  if (bestPoints?.seasonTitle && Number.isFinite(bestPoints.ratingEnd)) cards.push({ icon: '🏆', label: 'Найкращий сезон', value: String(bestPoints.ratingEnd), season: formatSeasonTitleUA(bestPoints.seasonTitle) });
+  if (biggestDelta?.seasonTitle && Number.isFinite(biggestDelta.ratingDelta)) cards.push({ icon: '📈', label: 'Найбільший прогрес', value: signed(biggestDelta.ratingDelta), season: formatSeasonTitleUA(biggestDelta.seasonTitle) });
+  if (bestWr?.seasonTitle && Number.isFinite(bestWr.winrate)) cards.push({ icon: '🎯', label: 'Найкращий WR', value: `${bestWr.winrate.toFixed(1)}%`, season: formatSeasonTitleUA(bestWr.seasonTitle) });
+  if (mostActive?.seasonTitle && Number.isFinite(mostActive.matches)) cards.push({ icon: '🔥', label: 'Найбільша активність', value: `${mostActive.matches} ігор`, season: formatSeasonTitleUA(mostActive.seasonTitle) });
+  if (mvpRecord?.seasonTitle && Number.isFinite(mvpRecord.mvpTotal)) cards.push({ icon: '⭐', label: 'Рекорд MVP', value: String(mvpRecord.mvpTotal), season: formatSeasonTitleUA(mvpRecord.seasonTitle) });
 
   if (!cards.length) return '';
-  return `<section class="px-card profile-section profile-achievements"><h2 class="profile-section__title">Відзнаки кар'єри</h2><div class="profile-achievement-grid">${cards.map((item) => `<article class="profile-achievement-card"><div class="profile-achievement-card__head"><span class="profile-achievement-card__icon">${item.icon}</span><strong>${esc(item.label)}</strong></div><p>${esc(item.value)}</p></article>`).join('')}</div></section>`;
+  return `<section class="px-card profile-section profile-achievements"><h2 class="profile-section__title">Досягнення карʼєри</h2><div class="profile-achievement-grid">${cards.map((item) => `<article class="profile-achievement-card"><div class="profile-achievement-card__head"><span class="profile-achievement-card__icon">${item.icon}</span><strong>${esc(item.label)}</strong></div><p class="profile-achievement-card__value">${esc(item.value)}</p><p class="profile-achievement-card__season">${esc(item.season)}</p></article>`).join('')}</div></section>`;
+}
+
+function resolveGameplayInsights({ wins, losses, draws, wr, mvp, delta, place, games }) {
+  const w = Number(wins);
+  const l = Number(losses);
+  const d = Number(draws);
+  const winrate = Number(wr);
+  const mvpTotal = Number(mvp);
+  const rankDelta = Number(delta);
+  const currentPlace = Number(place);
+  const matches = Number(games);
+  const totalMatches = Number.isFinite(matches)
+    ? matches
+    : [w, l, d].reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0);
+  const wlBalance = Number.isFinite(w) && Number.isFinite(l) ? w - l : 0;
+
+  let stabilityScore = 0;
+  if (winrate >= 60) stabilityScore += 2;
+  else if (winrate >= 48) stabilityScore += 1;
+  if (wlBalance >= 6) stabilityScore += 2;
+  else if (wlBalance >= 1) stabilityScore += 1;
+  if (totalMatches >= 28) stabilityScore += 1;
+  const stabilityLevel = stabilityScore >= 4 ? 'high' : stabilityScore >= 2 ? 'medium' : 'low';
+
+  let impactScore = 0;
+  if (mvpTotal >= 9) impactScore += 2;
+  else if (mvpTotal >= 4) impactScore += 1;
+  if (rankDelta >= 140) impactScore += 2;
+  else if (rankDelta >= 45) impactScore += 1;
+  if (currentPlace > 0 && currentPlace <= 5) impactScore += 1;
+  const impactLevel = impactScore >= 4 ? 'high' : impactScore >= 2 ? 'medium' : 'low';
+
+  const strengths = [];
+  const growth = [];
+  if (winrate >= 58) strengths.push('Сильна реалізація матчів');
+  if (mvpTotal >= 7) strengths.push('Часто впливає на гру');
+  if (rankDelta >= 90) strengths.push('Швидкий прогрес у сезоні');
+  if (totalMatches >= 26) strengths.push('Висока ігрова активність');
+  if (winrate < 50 && totalMatches >= 24) growth.push('Висока активність, але є простір для стабільності');
+  if (losses > wins) growth.push('Потрібно покращити стабільність гри');
+  if (mvpTotal <= 2 && totalMatches >= 18) growth.push('Можна частіше брати ключову роль у матчах');
+  if (rankDelta <= 0) growth.push('Важливо посилити прогрес за очками');
+
+  const formScore = (winrate >= 57 ? 2 : winrate >= 49 ? 1 : 0)
+    + (rankDelta >= 60 ? 2 : rankDelta >= 1 ? 1 : 0)
+    + (currentPlace > 0 && currentPlace <= 7 ? 1 : 0)
+    + (mvpTotal >= 6 ? 1 : 0)
+    + (totalMatches >= 14 ? 1 : 0);
+  const formLabel = formScore >= 5 ? 'сильна' : formScore >= 3 ? 'стабільна' : 'нестабільна';
+
+  const playStyle = mvpTotal >= 8 ? 'Агресивний' : winrate >= 57 ? 'Результативний' : stabilityLevel === 'high' ? 'Дисциплінований' : 'Стабільний';
+  const activityLevel = totalMatches >= 28 ? 'Висока' : totalMatches >= 14 ? 'Середня' : 'Низька';
+  const keyAdvantage = mvpTotal >= 8 ? 'MVP' : rankDelta >= 90 ? 'Прогрес' : winrate >= 58 ? 'WR' : 'Стабільність';
+
+  return {
+    totalMatches,
+    stabilityScore: Math.min(100, stabilityScore * 20 + 20),
+    impactScore: Math.min(100, impactScore * 20 + 20),
+    stabilityLevel,
+    impactLevel,
+    formLabel,
+    strengths: strengths.slice(0, 2),
+    growth: growth.slice(0, 2),
+    playStyle,
+    activityLevel,
+    keyAdvantage
+  };
+}
+
+function meterLabel(level) {
+  if (level === 'high') return 'Високий';
+  if (level === 'medium') return 'Середній';
+  return 'Низький';
 }
 
 function renderHero({ profileLeagueContext, livePlayer, currentSeason, displayNick, currentRank, topSeason }) {
@@ -182,8 +255,8 @@ function renderHero({ profileLeagueContext, livePlayer, currentSeason, displayNi
         </div>
         <p class="profile-hero__meta">${esc(leagueLabel)} • ${esc(seasonLabel)}</p>
         <div class="profile-hero__badges">
-          <span class="profile-place-badge">${Number.isFinite(place) ? `#${place}` : '—'}</span>
-          <span class="profile-subtle-badge">Ранг ${esc(currentRank)}</span>
+          <span class="profile-place-badge">${Number.isFinite(place) ? `Місце #${place}` : 'Місце —'}</span>
+          <span class="profile-subtle-badge">Ліга: ${esc(leagueLabel)}</span>
         </div>
         <div class="profile-rank-progress-wrap">
           <div class="profile-rank-progress__labels">
@@ -193,7 +266,7 @@ function renderHero({ profileLeagueContext, livePlayer, currentSeason, displayNi
           <div class="profile-rank-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(progress.percent)}">
             <span style="width:${progress.percent.toFixed(1)}%"></span>
           </div>
-          <p class="profile-note">${progress.isMax ? 'Досягнуто найвищий ранг S.' : `Залишилось ${val(progress.remain, '—')} очок до рангу ${val(progress.nextRank, '—')}.`}</p>
+          <p class="profile-note">${progress.isMax ? 'Максимальний ранг досягнуто' : `Залишилось ${val(progress.remain, '—')} очок до рангу ${val(progress.nextRank, '—')}.`}</p>
         </div>
       </div>
       <div class="profile-hero__actions">
@@ -225,6 +298,16 @@ function renderGameAnalysis({ livePlayer, topSeason }) {
   const draws = Number(livePlayer?.draws ?? topSeason?.draws);
   const wr = Number(livePlayer?.winRate ?? topSeason?.winRate ?? topSeason?.winrate);
   const total = [wins, losses, draws].reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0);
+  const insights = resolveGameplayInsights({
+    wins,
+    losses,
+    draws,
+    wr,
+    mvp: livePlayer?.mvpTotal ?? topSeason?.mvpTotal,
+    delta: livePlayer?.delta ?? topSeason?.delta ?? topSeason?.ratingDelta,
+    place: livePlayer?.place ?? topSeason?.place ?? topSeason?.finalPlace,
+    games: livePlayer?.matches ?? topSeason?.matches ?? total
+  });
 
   return `
     <section class="px-card profile-section profile-analysis">
@@ -235,12 +318,49 @@ function renderGameAnalysis({ livePlayer, topSeason }) {
           <div class="profile-wr-bar ${wrTone(wr)}"><span style="width:${Number.isFinite(wr) ? Math.max(0, Math.min(100, wr)) : 0}%"></span></div>
           <strong class="profile-analysis__value">${pct(wr)}</strong>
         </div>
-        <div class="profile-analysis__compact">
-          <p><span>W / L / D</span><strong>${val(wins)} / ${val(losses)} / ${val(draws)}</strong></p>
-          <p><span>Ігри</span><strong>${val(livePlayer?.matches ?? topSeason?.matches ?? total)}</strong></p>
-          <p><span>Бої</span><strong>${val(livePlayer?.battles ?? topSeason?.rounds)}</strong></p>
+        <div class="profile-analysis__compact-grid">
+          ${metricMini({ label: 'Перемоги', value: val(wins), tone: 'is-good' })}
+          ${metricMini({ label: 'Поразки', value: val(losses), tone: 'is-bad' })}
+          ${metricMini({ label: 'Нічиї', value: val(draws), tone: 'is-mid' })}
+          ${metricMini({ label: 'Ігри', value: val(livePlayer?.matches ?? topSeason?.matches ?? total) })}
+          ${metricMini({ label: 'Бої', value: val(livePlayer?.battles ?? topSeason?.rounds) })}
+          ${metricMini({ label: 'MVP', value: val(livePlayer?.mvpTotal ?? topSeason?.mvpTotal) })}
         </div>
       </div>
+      <div class="profile-indicator-grid">
+        <article class="profile-indicator-card">
+          <p>Стабільність гри</p>
+          <strong>${meterLabel(insights.stabilityLevel)}</strong>
+          <div class="profile-meter ${insights.stabilityLevel}"><span style="width:${insights.stabilityScore}%"></span></div>
+        </article>
+        <article class="profile-indicator-card">
+          <p>Вплив на гру</p>
+          <strong>${meterLabel(insights.impactLevel)}</strong>
+          <div class="profile-meter ${insights.impactLevel}"><span style="width:${insights.impactScore}%"></span></div>
+        </article>
+      </div>
+      <article class="profile-form-card">
+        <p>Поточна форма</p>
+        <strong>Форма: ${esc(insights.formLabel)}</strong>
+      </article>
+      <div class="profile-insights-grid">
+        <article class="profile-insights-card">
+          <h3>Сильні сторони</h3>
+          <ul>${(insights.strengths.length ? insights.strengths : ['База для стабільного росту']).map((item) => `<li>${esc(item)}</li>`).join('')}</ul>
+        </article>
+        <article class="profile-insights-card">
+          <h3>Зони росту</h3>
+          <ul>${(insights.growth.length ? insights.growth : ['Продовжувати поточний темп сезону']).map((item) => `<li>${esc(item)}</li>`).join('')}</ul>
+        </article>
+      </div>
+      <article class="profile-player-type">
+        <h3>Профіль гравця</h3>
+        <div class="profile-player-type__grid">
+          ${metricMini({ label: 'Стиль гри', value: insights.playStyle })}
+          ${metricMini({ label: 'Рівень активності', value: insights.activityLevel })}
+          ${metricMini({ label: 'Ключова перевага', value: insights.keyAdvantage, tone: 'is-accent' })}
+        </div>
+      </article>
     </section>
   `;
 }
@@ -286,8 +406,19 @@ function renderSeasonSummary(season, allTime) {
           ${metricMini({ label: 'WR', value: pct(seasonWr), tone: wrTone(seasonWr) })}
           ${metricMini({ label: 'Ігри', value: val(season.matches ?? season.games) })}
           ${metricMini({ label: 'MVP', value: val(season.mvpTotal) })}
+          ${metricMini({ label: 'Місце', value: Number.isFinite(Number(season.place ?? season.finalPlace)) ? `#${season.place ?? season.finalPlace}` : '—' })}
+          ${metricMini({ label: 'Ранг', value: val(season.rank), tone: 'is-accent' })}
         </div>
-        <div class="profile-wld-pill">W / L / D: <strong>${val(season.wins)} / ${val(season.losses)} / ${val(season.draws)}</strong></div>
+        <div class="profile-season-wld-grid">
+          ${metricMini({ label: 'Перемоги', value: val(season.wins), tone: 'is-good' })}
+          ${metricMini({ label: 'Поразки', value: val(season.losses), tone: 'is-bad' })}
+          ${metricMini({ label: 'Нічиї', value: val(season.draws), tone: 'is-mid' })}
+        </div>
+        <div class="profile-season-trend">
+          <div class="profile-season-trend__head"><span>Прогрес сезону</span><strong>${esc(val(season.ratingStart))} → ${esc(val(season.ratingEnd ?? season.points))}</strong></div>
+          <div class="profile-season-trend__bar ${deltaTone(seasonDelta)}"><span style="width:${Math.min(100, Math.max(8, Number.isFinite(Number(seasonDelta)) ? Math.min(100, Math.abs(Number(seasonDelta)) / 2) : 8))}%"></span></div>
+          <p class="profile-note">${Number(seasonDelta) > 0 ? 'Сезон із зростанням рейтингу' : Number(seasonDelta) < 0 ? 'Є просідання, є куди додати' : 'Рейтинг тримається стабільно'}</p>
+        </div>
       </section>
   `;
 }


### PR DESCRIPTION
### Motivation
- Remove remaining oval/pill visual artifacts and finish the V2 card language so the profile feels cohesive and HUD-like while staying mobile-first.
- Improve composition and information hierarchy (hero, key metrics, analytics, seasons) without redesigning from scratch.
- Provide simple, rule-based player analytics and light gamification so the profile gives actionable insights and more game-like feedback.

### Description
- Updated only `v2/pages/profile.js` and `v2/assets/css/main.css` to scope changes to V2 and avoid touching data-layer code or other pages.
- Reworked career highlights into compact achievement cards with `icon + title + primary value + season label` and Ukrainian labels (`Досягнення карʼєри`), moving raw combined labels into separate fields (`value` and `season`).
- Replaced oval/pill elements with clean card language and controlled radii (`12–14px`) by adjusting component CSS and removing capsule text-rows; tightened hero composition and improved rank progress visuals and copy (e.g. `Максимальний ранг досягнуто`).
- Added rule-based analytics helpers (`resolveGameplayInsights`) and UI blocks: `Сильні сторони / Зони росту`, `Стабільність гри` meter, `Вплив на гру` meter, `Поточна форма`, and a new compact `Профіль гравця` block (play style / activity / key advantage).
- Improved game infographic layout: stronger winrate bar, expanded W/L/D and Games/Battles into mini stat cards, and a more compact 2x2 key-metrics grid; enhanced season UX with clearer active tab state and a `Прогрес сезону` trend row.

### Testing
- Ran syntax check: `node --check v2/pages/profile.js` — passed.
- Verified removal of old pill-style selectors with: `rg -n "profile-wld-pill|profile-analysis__compact p" v2/pages/profile.js v2/assets/css/main.css` — no matches (old dry pill rows removed).
- Commit was created with the changes and only these files were modified: `v2/pages/profile.js`, `v2/assets/css/main.css` (commit present in repo history).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7852928b483219bd81b6d464a5bad)