### PR TITLE
Redesign V2 player profile into a cohesive mobile-first dashboard

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -5091,7 +5091,7 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 /* Player Profile V2 */
 .profile-page-v2 {
   display: grid;
-  gap: .72rem;
+  gap: .75rem;
   width: 100%;
   max-width: 100%;
   min-width: 0;
@@ -5115,70 +5115,48 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 .profile-season-summary,
 .profile-logs-wrap,
 .profile-log-empty {
-  padding: .66rem !important;
+  padding: .75rem !important;
 }
 
 .profile-hero {
+  border: 1px solid rgba(132, 198, 255, .28);
+  background: linear-gradient(150deg, rgba(16, 28, 44, .96), rgba(8, 14, 26, .96));
   display: grid;
-  grid-template-columns: 86px 1fr;
-  gap: .52rem;
-  align-items: stretch;
-  border: 1px solid rgba(132, 198, 255, .3);
-  background: linear-gradient(145deg, rgba(15, 24, 40, .95), rgba(8, 14, 26, .96));
+  gap: .58rem;
 }
 
-.profile-hero__avatar-card,
-.profile-hero__info-card,
-.profile-rank-card,
-.profile-rank-progress-wrap {
-  border: 1px solid rgba(153, 214, 255, .18);
-  background: rgba(8, 14, 26, .84);
-  border-radius: 12px;
-  padding: .45rem;
+.profile-hero__back {
+  justify-self: start;
+  padding: .32rem .54rem;
+  min-height: 32px;
 }
 
-.profile-hero__avatar-card {
+.profile-hero__top {
   display: grid;
-  place-items: center;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: .55rem;
+  align-items: center;
 }
 
 .profile-avatar-frame {
   width: 72px;
   height: 72px;
-  border: 1px solid rgba(154, 216, 255, .36);
+  border: 1px solid rgba(160, 220, 255, .34);
+  background: rgba(7, 13, 25, .9);
   display: grid;
   place-items: center;
-  background: rgba(7, 13, 25, .9);
-  border-radius: 10px;
+  border-radius: 12px;
 }
 
-.profile-avatar-frame img { width: 100%; height: 100%; object-fit: cover; }
-
-.profile-hero__main { display: grid; gap: .34rem; }
-
-.profile-hero__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: .42rem;
+.profile-avatar-frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
-.profile-hero__head h1 {
+.profile-hero__identity h1 {
   margin: 0;
-  font-size: clamp(1.08rem, 3.2vw, 1.44rem);
-}
-
-.profile-rank-badge,
-.profile-place-badge,
-.profile-subtle-badge {
-  border: 1px solid currentColor;
-  padding: .2rem .4rem;
-  font-size: .66rem;
-  letter-spacing: .04em;
-  text-transform: uppercase;
-  display: inline-flex;
-  align-items: center;
-  border-radius: 8px;
+  font-size: clamp(1.08rem, 3.5vw, 1.38rem);
 }
 
 .profile-hero__meta,
@@ -5186,181 +5164,268 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 .profile-note {
   margin: 0;
   color: var(--muted);
-  font-size: .74rem;
+  font-size: .73rem;
 }
 
-.profile-hero__badges {
+.profile-hero__status {
+  margin-top: .32rem;
   display: flex;
-  gap: .34rem;
   flex-wrap: wrap;
+  gap: .34rem;
 }
 
-.profile-place-badge {
-  border-color: rgba(183, 255, 42, .56);
-  color: #d9ff91;
-  background: rgba(138, 194, 47, .14);
-  font-weight: 700;
+.profile-status-badge {
+  border: 1px solid rgba(162, 218, 255, .28);
+  background: rgba(10, 17, 30, .84);
+  font-size: .65rem;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  padding: .2rem .44rem;
+  color: #c9e8ff;
+  font-family: var(--font-mono);
 }
 
-.profile-subtle-badge {
-  border-color: rgba(165, 214, 255, .28);
-  color: #9fdfff;
-}
-
-.profile-hero__actions {
-  display: flex;
-  justify-content: flex-start;
-  margin-top: .2rem;
+.profile-status-badge--place {
+  border-color: rgba(189, 255, 72, .5);
+  color: #ddff9c;
 }
 
 .profile-rank-card {
+  border: 1px solid rgba(175, 225, 255, .26);
+  background: rgba(8, 14, 26, .82);
   display: grid;
-  align-content: center;
   justify-items: center;
-  gap: .18rem;
+  align-content: center;
+  gap: .14rem;
+  padding: .44rem;
 }
 
 .profile-rank-card__label {
   margin: 0;
   font-size: .62rem;
   letter-spacing: .08em;
-  color: var(--muted);
   text-transform: uppercase;
+  color: var(--muted);
 }
 
 .profile-rank-card__value {
-  font-size: 2rem;
+  font-size: 1.8rem;
   line-height: 1;
   font-family: var(--font-mono);
 }
 
 .profile-rank-progress-wrap {
+  border: 1px solid rgba(166, 220, 255, .22);
+  background: rgba(8, 14, 24, .72);
+  padding: .5rem;
   display: grid;
-  gap: .24rem;
-  grid-column: 1 / -1;
+  gap: .3rem;
 }
 
 .profile-rank-progress__labels {
   display: flex;
   justify-content: space-between;
+  align-items: baseline;
   gap: .4rem;
   font-size: .72rem;
 }
 
 .profile-rank-progress {
-  position: relative;
   height: 10px;
-  border: 1px solid rgba(172, 225, 255, .26);
-  background: rgba(4, 10, 20, .94);
-  border-radius: 8px;
+  border: 1px solid rgba(174, 225, 255, .24);
+  background: rgba(4, 9, 19, .92);
   overflow: hidden;
 }
 
 .profile-rank-progress span {
   display: block;
   height: 100%;
-  background: linear-gradient(90deg, #51d8ff, #b7ff2a);
+  background: linear-gradient(90deg, #53d8ff, #b7ff2a);
 }
 
-.profile-hero.rank-s .profile-rank-progress span {
+.profile-hero.rank-s .profile-rank-progress span,
+.profile-hero.rank-S .profile-rank-progress span {
   background: linear-gradient(90deg, #c87dff, #ff74bf);
 }
 
 .profile-section {
-  border: 1px solid rgba(173, 232, 255, .18);
-  background: linear-gradient(180deg, rgba(10, 18, 34, .84), rgba(7, 12, 24, .9));
+  border: 1px solid rgba(170, 228, 255, .18);
+  background: linear-gradient(180deg, rgba(10, 18, 34, .86), rgba(7, 12, 24, .92));
 }
 
+.profile-priority-main { border-color: rgba(186, 255, 80, .28); }
+.profile-priority-analytics { border-color: rgba(154, 218, 255, .24); }
+.profile-priority-history { border-color: rgba(143, 203, 255, .2); }
+
 .profile-section__title {
-  margin: 0 0 .45rem;
+  margin: 0 0 .52rem;
   font-size: .82rem;
+  letter-spacing: .08em;
   text-transform: uppercase;
-  letter-spacing: .07em;
   color: #9fdfff;
 }
 
-.profile-mini-grid {
+.profile-key-grid,
+.profile-mini-grid,
+.profile-season-kpis {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: .35rem;
+  gap: .38rem;
 }
 
 .profile-mini-card {
-  border: 1px solid rgba(153, 214, 255, .14);
-  background: rgba(10, 18, 31, .8);
+  border: 1px solid rgba(152, 212, 255, .14);
+  background: rgba(10, 17, 30, .78);
   padding: .52rem;
   min-height: 62px;
   display: grid;
-  gap: .14rem;
   align-content: center;
-  border-radius: 10px;
+  gap: .14rem;
 }
 
 .profile-mini-card span {
   font-size: .62rem;
   letter-spacing: .06em;
   text-transform: uppercase;
-  color: rgba(183, 204, 225, .86);
+  color: rgba(187, 206, 225, .86);
 }
 
 .profile-mini-card strong {
   font-size: 1.08rem;
-  line-height: 1.1;
+  line-height: 1.08;
   font-family: var(--font-mono);
 }
 
-.profile-mini-card.is-accent { border-color: rgba(183, 255, 42, .42); }
+.profile-mini-card.is-accent { border-color: rgba(183, 255, 42, .44); }
 .profile-mini-card.is-good strong,
-.profile-analysis__value.is-good { color: #86f488; }
+.profile-wr-panel__head strong.is-good { color: #86f488; }
 .profile-mini-card.is-mid strong,
-.profile-analysis__value.is-mid { color: #ffd45a; }
+.profile-wr-panel__head strong.is-mid { color: #ffd45a; }
 .profile-mini-card.is-bad strong,
-.profile-analysis__value.is-bad { color: #ff7f7f; }
+.profile-wr-panel__head strong.is-bad { color: #ff7f7f; }
 .profile-mini-card.is-positive strong { color: #86f488; }
 .profile-mini-card.is-negative strong { color: #ff7f7f; }
 
-.profile-analysis__row {
+.profile-wr-panel {
+  border: 1px solid rgba(161, 220, 255, .24);
+  background: rgba(8, 14, 25, .72);
+  padding: .48rem;
   display: grid;
-  grid-template-columns: 1fr;
-  gap: .45rem;
+  gap: .28rem;
 }
 
-.profile-analysis__label {
-  margin: 0 0 .22rem;
-  font-size: .66rem;
+.profile-wr-panel__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: .4rem;
+}
+
+.profile-wr-panel__head p {
+  margin: 0;
+  font-size: .69rem;
+  color: #9fdfff;
   text-transform: uppercase;
-  color: #a0daf5;
+  letter-spacing: .06em;
+}
+
+.profile-wr-panel__head strong {
+  font-size: 1.05rem;
+  font-family: var(--font-mono);
 }
 
 .profile-wr-bar {
   height: 10px;
-  border: 1px solid rgba(166, 221, 255, .2);
+  border: 1px solid rgba(168, 224, 255, .2);
   background: rgba(8, 13, 22, .86);
-  border-radius: 8px;
   overflow: hidden;
 }
 
-.profile-wr-bar span {
-  display: block;
-  height: 100%;
-}
-
+.profile-wr-bar span { display: block; height: 100%; }
 .profile-wr-bar.is-good span { background: linear-gradient(90deg, #5be67d, #8dfb80); }
 .profile-wr-bar.is-mid span { background: linear-gradient(90deg, #ffbf3e, #ffe06a); }
 .profile-wr-bar.is-bad span { background: linear-gradient(90deg, #ff6d6d, #ff9797); }
 .profile-wr-bar.is-neutral span { background: rgba(145, 208, 246, .45); }
 
-.profile-analysis__value {
-  display: inline-block;
-  margin-top: .2rem;
-  font-size: 1rem;
-  font-family: var(--font-mono);
-}
-
-.profile-analysis__compact-grid {
+.profile-analysis-row3,
+.profile-player-type__grid,
+.profile-season-wld-grid,
+.profile-season-career-row {
+  margin-top: .4rem;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: .35rem;
+}
+
+.profile-indicator-grid {
+  margin-top: .42rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: .35rem;
+}
+
+.profile-indicator-card {
+  border: 1px solid rgba(154, 216, 255, .2);
+  background: rgba(8, 14, 26, .8);
+  padding: .44rem .5rem;
+  display: grid;
+  gap: .22rem;
+}
+
+.profile-indicator-card p {
+  margin: 0;
+  font-size: .64rem;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.profile-indicator-card strong { font-size: .9rem; }
+.profile-indicator-card--form strong { color: #d9f3ff; }
+
+.profile-meter {
+  height: 8px;
+  background: rgba(255, 255, 255, .1);
+  overflow: hidden;
+}
+
+.profile-meter span { display: block; height: 100%; }
+.profile-meter.low span { background: linear-gradient(90deg, #ff7f7f, #ffb36d); }
+.profile-meter.medium span { background: linear-gradient(90deg, #ffd45a, #ffe87f); }
+.profile-meter.high span { background: linear-gradient(90deg, #72e28b, #95f7ad); }
+
+.profile-insights-grid {
+  margin-top: .42rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .35rem;
+}
+
+.profile-insights-card,
+.profile-player-type,
+.profile-season-trend {
+  border: 1px solid rgba(156, 218, 255, .2);
+  background: rgba(8, 13, 22, .78);
+  padding: .46rem .5rem;
+}
+
+.profile-player-type { margin-top: .42rem; }
+
+.profile-player-type h3,
+.profile-insights-card h3,
+.profile-season-trend__head span {
+  margin: 0;
+  font-size: .68rem;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: #9fdfff;
+}
+
+.profile-insights-card ul {
+  margin: .3rem 0 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: .22rem;
+  font-size: .75rem;
 }
 
 .profile-achievement-grid {
@@ -5371,30 +5436,24 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 
 .profile-achievement-card {
   border: 1px solid rgba(182, 255, 75, .24);
-  background: linear-gradient(160deg, rgba(18, 33, 23, .75), rgba(11, 20, 31, .84));
-  padding: .54rem;
+  background: linear-gradient(165deg, rgba(19, 36, 26, .78), rgba(10, 18, 30, .9));
+  padding: .55rem;
   display: grid;
-  gap: .28rem;
-  border-radius: 10px;
+  gap: .2rem;
 }
 
-.profile-achievement-card__head {
-  display: flex;
-  align-items: center;
-  gap: .34rem;
-}
-
-.profile-achievement-card__icon { font-size: .98rem; }
-
-.profile-achievement-card__head strong {
-  font-size: .7rem;
+.profile-achievement-card__icon { font-size: 1rem; }
+.profile-achievement-card__label {
+  margin: 0;
+  font-size: .66rem;
   text-transform: uppercase;
-  letter-spacing: .05em;
+  letter-spacing: .06em;
+  color: #d8efc0;
 }
 
 .profile-achievement-card__value {
   margin: 0;
-  font-size: 1.12rem;
+  font-size: 1.14rem;
   font-family: var(--font-mono);
 }
 
@@ -5407,22 +5466,20 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 .profile-season-tabs {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: .34rem;
-  width: 100%;
+  gap: .35rem;
 }
 
 .profile-season-tab {
   border: 1px solid rgba(160, 219, 255, .26);
   background: rgba(9, 15, 26, .82);
   color: var(--text);
-  padding: .44rem .48rem;
-  min-height: 36px;
+  padding: .45rem .48rem;
+  min-height: 40px;
   display: grid;
   justify-items: start;
   gap: .1rem;
   font-family: var(--font-mono);
   font-size: .69rem;
-  border-radius: 10px;
 }
 
 .profile-season-tab em {
@@ -5434,14 +5491,14 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 
 .profile-season-tab.is-active {
   border-color: rgba(183, 255, 42, .68);
-  color: #e6ffc2;
+  color: #ecffcd;
   background: linear-gradient(120deg, rgba(57, 89, 24, .54), rgba(23, 39, 55, .82));
 }
 
 .profile-season-summary {
   border: 1px solid rgba(170, 228, 255, .2);
-  background: rgba(8, 13, 24, .7);
-  margin-top: .38rem;
+  background: rgba(8, 13, 24, .72);
+  margin-top: .4rem;
 }
 
 .profile-season-summary h3,
@@ -5450,6 +5507,31 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   margin: 0 0 .3rem;
   font-size: .84rem;
 }
+
+.profile-season-trend { margin-top: .4rem; display: grid; gap: .26rem; }
+
+.profile-season-trend__head {
+  display: flex;
+  justify-content: space-between;
+  gap: .35rem;
+  align-items: baseline;
+}
+
+.profile-season-trend__head strong {
+  font-size: .8rem;
+  font-family: var(--font-mono);
+}
+
+.profile-season-trend__bar {
+  height: 8px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, .1);
+}
+
+.profile-season-trend__bar span { display: block; height: 100%; }
+.profile-season-trend__bar.is-positive span { background: linear-gradient(90deg, #6ce58d, #8ef8a1); }
+.profile-season-trend__bar.is-negative span { background: linear-gradient(90deg, #ff7c7c, #ff9f9f); }
+.profile-season-trend__bar.is-neutral span { background: linear-gradient(90deg, #9ec3db, #b4d5e8); }
 
 .profile-logs-wrap {
   margin-top: .42rem;
@@ -5467,9 +5549,8 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 }
 
 .profile-log-day {
-  border: 1px solid rgba(255,255,255,.12);
-  background: rgba(255,255,255,.02);
-  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, .12);
+  background: rgba(255, 255, 255, .02);
   overflow: hidden;
 }
 
@@ -5478,7 +5559,7 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   justify-content: space-between;
   flex-wrap: wrap;
   gap: .28rem;
-  border-bottom: 1px solid rgba(255,255,255,.08);
+  border-bottom: 1px solid rgba(255, 255, 255, .08);
   padding: .35rem .42rem;
   font-size: .72rem;
 }
@@ -5487,7 +5568,7 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 
 .profile-log-item {
   padding: .35rem .42rem;
-  border-bottom: 1px solid rgba(255,255,255,.07);
+  border-bottom: 1px solid rgba(255, 255, 255, .07);
   display: grid;
   gap: .24rem;
 }
@@ -5503,146 +5584,9 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 
 .profile-log-empty {
   margin-top: .42rem;
-  border: 1px dashed rgba(255,255,255,.22);
+  border: 1px dashed rgba(255, 255, 255, .22);
   color: var(--muted);
 }
-
-.profile-indicator-grid {
-  margin-top: .45rem;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: .35rem;
-}
-
-.profile-indicator-card {
-  border: 1px solid rgba(154, 216, 255, .2);
-  background: rgba(8, 14, 26, .8);
-  border-radius: 10px;
-  padding: .44rem .5rem;
-  display: grid;
-  gap: .22rem;
-}
-
-.profile-indicator-card p {
-  margin: 0;
-  font-size: .66rem;
-  color: var(--muted);
-  text-transform: uppercase;
-}
-
-.profile-indicator-card strong {
-  font-size: .92rem;
-}
-
-.profile-meter {
-  height: 8px;
-  border-radius: 7px;
-  background: rgba(255,255,255,.1);
-  overflow: hidden;
-}
-
-.profile-meter span {
-  display: block;
-  height: 100%;
-}
-
-.profile-meter.low span { background: linear-gradient(90deg, #ff7f7f, #ffb36d); }
-.profile-meter.medium span { background: linear-gradient(90deg, #ffd45a, #ffe87f); }
-.profile-meter.high span { background: linear-gradient(90deg, #72e28b, #95f7ad); }
-
-.profile-form-card,
-.profile-player-type {
-  margin-top: .42rem;
-  border: 1px solid rgba(157, 219, 255, .2);
-  background: rgba(8, 14, 24, .7);
-  border-radius: 10px;
-  padding: .5rem;
-}
-
-.profile-form-card p,
-.profile-player-type h3,
-.profile-insights-card h3,
-.profile-season-trend__head span {
-  margin: 0;
-  font-size: .68rem;
-  letter-spacing: .04em;
-  text-transform: uppercase;
-  color: #9fdfff;
-}
-
-.profile-form-card strong {
-  display: block;
-  margin-top: .2rem;
-  font-size: .96rem;
-}
-
-.profile-insights-grid {
-  margin-top: .42rem;
-  display: grid;
-  gap: .35rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.profile-insights-card {
-  border: 1px solid rgba(156, 218, 255, .2);
-  background: rgba(8, 13, 22, .78);
-  border-radius: 10px;
-  padding: .46rem .5rem;
-}
-
-.profile-insights-card ul {
-  margin: .3rem 0 0;
-  padding-left: 1rem;
-  display: grid;
-  gap: .22rem;
-  font-size: .76rem;
-}
-
-.profile-player-type__grid,
-.profile-season-wld-grid {
-  margin-top: .35rem;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: .35rem;
-}
-
-.profile-season-trend {
-  margin-top: .4rem;
-  border: 1px solid rgba(156, 216, 255, .2);
-  background: rgba(8, 14, 26, .8);
-  border-radius: 10px;
-  padding: .45rem .5rem;
-  display: grid;
-  gap: .26rem;
-}
-
-.profile-season-trend__head {
-  display: flex;
-  justify-content: space-between;
-  gap: .35rem;
-  align-items: baseline;
-}
-
-.profile-season-trend__head strong {
-  font-size: .8rem;
-  font-family: var(--font-mono);
-}
-
-.profile-season-trend__bar {
-  height: 8px;
-  border-radius: 7px;
-  overflow: hidden;
-  background: rgba(255,255,255,.1);
-}
-
-.profile-season-trend__bar span {
-  display: block;
-  height: 100%;
-}
-
-.profile-season-trend__bar.is-positive span { background: linear-gradient(90deg, #6ce58d, #8ef8a1); }
-.profile-season-trend__bar.is-negative span { background: linear-gradient(90deg, #ff7c7c, #ff9f9f); }
-.profile-season-trend__bar.is-neutral span { background: linear-gradient(90deg, #9ec3db, #b4d5e8); }
 
 .profile-page-v2 .rank-s,
 .profile-page-v2 .rank-S { color: #d38aff; }
@@ -5660,35 +5604,22 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 .profile-page-v2 .rank-F { color: #c8cfda; }
 
 @media (min-width: 821px) {
-  .profile-hero {
-    grid-template-columns: 94px minmax(0, 1fr) 90px;
-  }
-
-  .profile-rank-progress-wrap {
-    grid-column: 1 / -1;
+  .profile-hero__top {
+    grid-template-columns: 82px minmax(0, 1fr) 96px;
+    align-items: stretch;
   }
 
   .profile-avatar-frame {
     width: 82px;
     height: 82px;
   }
-
-  .profile-analysis__row {
-    grid-template-columns: 1.1fr 1fr;
-    align-items: end;
-  }
 }
 
 @media (max-width: 520px) {
-  .profile-achievement-grid,
-  .profile-mini-grid,
-  .profile-season-tabs {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .profile-analysis__compact-grid,
+  .profile-analysis-row3,
   .profile-player-type__grid,
   .profile-season-wld-grid,
+  .profile-season-career-row,
   .profile-indicator-grid,
   .profile-insights-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/v2/pages/profile.js
+++ b/v2/pages/profile.js
@@ -13,19 +13,38 @@ const placeholder = '../assets/default-avatar.svg';
 const RANK_ORDER = ['F', 'E', 'D', 'C', 'B', 'A', 'S'];
 const RANK_MIN_POINTS = { F: 0, E: 200, D: 400, C: 600, B: 800, A: 1000, S: 1200 };
 
-function esc(v) { return String(v ?? '').replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;'); }
+function esc(v) {
+  return String(v ?? '').replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
+}
+
+function isMissing(v) {
+  if (v === null || v === undefined) return true;
+  const raw = String(v).trim().toLowerCase();
+  return raw === '' || raw === 'null' || raw === '#null' || raw === 'undefined' || raw === 'nan';
+}
+
 function val(v, fallback = '—') {
-  return v === null || v === undefined || v === '' || Number.isNaN(v) ? fallback : String(v);
+  if (isMissing(v)) return fallback;
+  if (typeof v === 'number' && Number.isNaN(v)) return fallback;
+  return String(v);
 }
+
+function num(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
 function pct(v) {
-  const n = Number(v);
-  return Number.isFinite(n) ? `${n.toFixed(1)}%` : '—';
+  const n = num(v);
+  return n === null ? '—' : `${n.toFixed(1)}%`;
 }
+
 function signed(v) {
-  const n = Number(v);
-  if (!Number.isFinite(n)) return '—';
+  const n = num(v);
+  if (n === null) return '—';
   return `${n > 0 ? '+' : ''}${n}`;
 }
+
 function winnerText(winner = '') {
   if (winner === 'tie') return 'Нічия';
   if (!winner) return '—';
@@ -35,7 +54,7 @@ function winnerText(winner = '') {
 function buildHash(route, params = {}) {
   const query = new URLSearchParams();
   Object.entries(params).forEach(([key, value]) => {
-    if (value !== undefined && value !== null && String(value).trim() !== '') query.set(key, String(value));
+    if (!isMissing(value)) query.set(key, String(value));
   });
   const qs = query.toString();
   return `#${route}${qs ? `?${qs}` : ''}`;
@@ -61,16 +80,16 @@ function rankClass(rank = 'F') {
 }
 
 function wrTone(winRate) {
-  const wr = Number(winRate);
-  if (!Number.isFinite(wr)) return 'is-neutral';
-  if (wr > 60) return 'is-good';
-  if (wr >= 45) return 'is-mid';
+  const wr = num(winRate);
+  if (wr === null) return 'is-neutral';
+  if (wr >= 60) return 'is-good';
+  if (wr >= 48) return 'is-mid';
   return 'is-bad';
 }
 
 function deltaTone(delta) {
-  const n = Number(delta);
-  if (!Number.isFinite(n) || n === 0) return 'is-neutral';
+  const n = num(delta);
+  if (n === null || n === 0) return 'is-neutral';
   return n > 0 ? 'is-positive' : 'is-negative';
 }
 
@@ -112,12 +131,23 @@ function formatSeasonTitleUA(raw = '') {
     .trim();
 }
 
+function seasonOrderKey(label = '') {
+  const map = {
+    'Літо 2025': 0,
+    'Осінь 2025': 1,
+    'Зима 2025–2026': 2,
+    'Весна 2026': 3
+  };
+  return map[label] ?? 100;
+}
+
 function getRankProgress(points, rankLetter) {
   const rank = String(rankLetter || 'F').toUpperCase();
   const index = RANK_ORDER.indexOf(rank);
   const currentMin = RANK_MIN_POINTS[rank] ?? 0;
+  const pointsValue = num(points);
 
-  if (!Number.isFinite(Number(points))) {
+  if (pointsValue === null) {
     return { percent: 0, currentMin, nextMin: null, remain: null, nextRank: null, isMax: rank === 'S' };
   }
 
@@ -127,22 +157,21 @@ function getRankProgress(points, rankLetter) {
 
   const nextRank = RANK_ORDER[index + 1];
   const nextMin = RANK_MIN_POINTS[nextRank];
-  const value = Number(points);
   const span = Math.max(1, nextMin - currentMin);
-  const percent = Math.max(0, Math.min(100, ((value - currentMin) / span) * 100));
+  const percent = Math.max(0, Math.min(100, ((pointsValue - currentMin) / span) * 100));
 
   return {
     percent,
     currentMin,
     nextMin,
-    remain: Math.max(0, nextMin - value),
+    remain: Math.max(0, nextMin - pointsValue),
     nextRank,
     isMax: false
   };
 }
 
 function metricMini({ label, value, tone = '' }) {
-  return `<article class="profile-mini-card ${tone}"><strong>${esc(value)}</strong><span>${esc(label)}</span></article>`;
+  return `<article class="profile-mini-card ${tone}"><strong>${esc(val(value))}</strong><span>${esc(label)}</span></article>`;
 }
 
 function renderCareerHighlights(highlights = {}) {
@@ -153,72 +182,73 @@ function renderCareerHighlights(highlights = {}) {
   const mostActive = highlights.mostActiveSeason;
   const mvpRecord = highlights.bestMvpSeason;
 
-  if (bestPoints?.seasonTitle && Number.isFinite(bestPoints.ratingEnd)) cards.push({ icon: '🏆', label: 'Найкращий сезон', value: String(bestPoints.ratingEnd), season: formatSeasonTitleUA(bestPoints.seasonTitle) });
-  if (biggestDelta?.seasonTitle && Number.isFinite(biggestDelta.ratingDelta)) cards.push({ icon: '📈', label: 'Найбільший прогрес', value: signed(biggestDelta.ratingDelta), season: formatSeasonTitleUA(biggestDelta.seasonTitle) });
-  if (bestWr?.seasonTitle && Number.isFinite(bestWr.winrate)) cards.push({ icon: '🎯', label: 'Найкращий WR', value: `${bestWr.winrate.toFixed(1)}%`, season: formatSeasonTitleUA(bestWr.seasonTitle) });
-  if (mostActive?.seasonTitle && Number.isFinite(mostActive.matches)) cards.push({ icon: '🔥', label: 'Найбільша активність', value: `${mostActive.matches} ігор`, season: formatSeasonTitleUA(mostActive.seasonTitle) });
-  if (mvpRecord?.seasonTitle && Number.isFinite(mvpRecord.mvpTotal)) cards.push({ icon: '⭐', label: 'Рекорд MVP', value: String(mvpRecord.mvpTotal), season: formatSeasonTitleUA(mvpRecord.seasonTitle) });
+  if (bestPoints?.seasonTitle && num(bestPoints.ratingEnd) !== null) cards.push({ icon: '🏆', label: 'Найкращий сезон', value: String(bestPoints.ratingEnd), season: formatSeasonTitleUA(bestPoints.seasonTitle) });
+  if (biggestDelta?.seasonTitle && num(biggestDelta.ratingDelta) !== null) cards.push({ icon: '📈', label: 'Найбільший прогрес', value: signed(biggestDelta.ratingDelta), season: formatSeasonTitleUA(biggestDelta.seasonTitle) });
+  if (bestWr?.seasonTitle && num(bestWr.winrate) !== null) cards.push({ icon: '🎯', label: 'Найкращий WR', value: `${Number(bestWr.winrate).toFixed(1)}%`, season: formatSeasonTitleUA(bestWr.seasonTitle) });
+  if (mostActive?.seasonTitle && num(mostActive.matches) !== null) cards.push({ icon: '🔥', label: 'Найбільша активність', value: `${mostActive.matches} ігор`, season: formatSeasonTitleUA(mostActive.seasonTitle) });
+  if (mvpRecord?.seasonTitle && num(mvpRecord.mvpTotal) !== null) cards.push({ icon: '⭐', label: 'Рекорд MVP', value: String(mvpRecord.mvpTotal), season: formatSeasonTitleUA(mvpRecord.seasonTitle) });
 
   if (!cards.length) return '';
-  return `<section class="px-card profile-section profile-achievements"><h2 class="profile-section__title">Досягнення карʼєри</h2><div class="profile-achievement-grid">${cards.map((item) => `<article class="profile-achievement-card"><div class="profile-achievement-card__head"><span class="profile-achievement-card__icon">${item.icon}</span><strong>${esc(item.label)}</strong></div><p class="profile-achievement-card__value">${esc(item.value)}</p><p class="profile-achievement-card__season">${esc(item.season)}</p></article>`).join('')}</div></section>`;
+  return `<section class="px-card profile-section profile-achievements"><h2 class="profile-section__title">Досягнення карʼєри</h2><div class="profile-achievement-grid">${cards.map((item) => `<article class="profile-achievement-card"><span class="profile-achievement-card__icon">${item.icon}</span><p class="profile-achievement-card__label">${esc(item.label)}</p><p class="profile-achievement-card__value">${esc(item.value)}</p><p class="profile-achievement-card__season">${esc(item.season)}</p></article>`).join('')}</div></section>`;
 }
 
 function resolveGameplayInsights({ wins, losses, draws, wr, mvp, delta, place, games }) {
-  const w = Number(wins);
-  const l = Number(losses);
-  const d = Number(draws);
-  const winrate = Number(wr);
-  const mvpTotal = Number(mvp);
-  const rankDelta = Number(delta);
-  const currentPlace = Number(place);
-  const matches = Number(games);
-  const totalMatches = Number.isFinite(matches)
-    ? matches
-    : [w, l, d].reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0);
-  const wlBalance = Number.isFinite(w) && Number.isFinite(l) ? w - l : 0;
+  const w = num(wins) ?? 0;
+  const l = num(losses) ?? 0;
+  const d = num(draws) ?? 0;
+  const winrate = num(wr) ?? 0;
+  const mvpTotal = num(mvp) ?? 0;
+  const rankDelta = num(delta) ?? 0;
+  const currentPlace = num(place) ?? 999;
+  const totalMatches = num(games) ?? (w + l + d);
+  const wlBalance = w - l;
 
-  let stabilityScore = 0;
-  if (winrate >= 60) stabilityScore += 2;
-  else if (winrate >= 48) stabilityScore += 1;
-  if (wlBalance >= 6) stabilityScore += 2;
-  else if (wlBalance >= 1) stabilityScore += 1;
-  if (totalMatches >= 28) stabilityScore += 1;
-  const stabilityLevel = stabilityScore >= 4 ? 'high' : stabilityScore >= 2 ? 'medium' : 'low';
+  let stabilityScore = 15;
+  if (winrate >= 60) stabilityScore += 35;
+  else if (winrate >= 50) stabilityScore += 20;
+  if (wlBalance >= 8) stabilityScore += 30;
+  else if (wlBalance >= 2) stabilityScore += 15;
+  if (totalMatches >= 24) stabilityScore += 15;
 
-  let impactScore = 0;
-  if (mvpTotal >= 9) impactScore += 2;
-  else if (mvpTotal >= 4) impactScore += 1;
-  if (rankDelta >= 140) impactScore += 2;
-  else if (rankDelta >= 45) impactScore += 1;
-  if (currentPlace > 0 && currentPlace <= 5) impactScore += 1;
-  const impactLevel = impactScore >= 4 ? 'high' : impactScore >= 2 ? 'medium' : 'low';
+  let impactScore = 15;
+  if (mvpTotal >= 9) impactScore += 35;
+  else if (mvpTotal >= 4) impactScore += 20;
+  if (rankDelta >= 140) impactScore += 30;
+  else if (rankDelta >= 45) impactScore += 15;
+  if (currentPlace > 0 && currentPlace <= 5) impactScore += 15;
+
+  const stabilityLevel = stabilityScore >= 70 ? 'high' : stabilityScore >= 45 ? 'medium' : 'low';
+  const impactLevel = impactScore >= 70 ? 'high' : impactScore >= 45 ? 'medium' : 'low';
 
   const strengths = [];
   const growth = [];
-  if (winrate >= 58) strengths.push('Сильна реалізація матчів');
-  if (mvpTotal >= 7) strengths.push('Часто впливає на гру');
-  if (rankDelta >= 90) strengths.push('Швидкий прогрес у сезоні');
-  if (totalMatches >= 26) strengths.push('Висока ігрова активність');
-  if (winrate < 50 && totalMatches >= 24) growth.push('Висока активність, але є простір для стабільності');
-  if (losses > wins) growth.push('Потрібно покращити стабільність гри');
-  if (mvpTotal <= 2 && totalMatches >= 18) growth.push('Можна частіше брати ключову роль у матчах');
-  if (rankDelta <= 0) growth.push('Важливо посилити прогрес за очками');
 
-  const formScore = (winrate >= 57 ? 2 : winrate >= 49 ? 1 : 0)
+  if (winrate >= 58) strengths.push('Висока реалізація матчів');
+  if (mvpTotal >= 7) strengths.push('Сильний персональний вплив');
+  if (rankDelta >= 90) strengths.push('Швидко набирає рейтинг');
+  if (totalMatches >= 26) strengths.push('Тримає хороший темп сезону');
+
+  if (winrate < 50 && totalMatches >= 18) growth.push('Потрібна краща конверсія матчів');
+  if (l > w) growth.push('Потрібно зменшити серії поразок');
+  if (mvpTotal <= 2 && totalMatches >= 14) growth.push('Додати ініціативу в ключових раундах');
+  if (rankDelta <= 0) growth.push('Важливо повернути позитивний приріст');
+
+  const formScore =
+    (winrate >= 57 ? 2 : winrate >= 49 ? 1 : 0)
     + (rankDelta >= 60 ? 2 : rankDelta >= 1 ? 1 : 0)
-    + (currentPlace > 0 && currentPlace <= 7 ? 1 : 0)
+    + (currentPlace <= 7 ? 1 : 0)
     + (mvpTotal >= 6 ? 1 : 0)
     + (totalMatches >= 14 ? 1 : 0);
-  const formLabel = formScore >= 5 ? 'сильна' : formScore >= 3 ? 'стабільна' : 'нестабільна';
 
-  const playStyle = mvpTotal >= 8 ? 'Агресивний' : winrate >= 57 ? 'Результативний' : stabilityLevel === 'high' ? 'Дисциплінований' : 'Стабільний';
+  const formLabel = formScore >= 5 ? 'Сильна' : formScore >= 3 ? 'Стабільна' : 'Нестабільна';
+  const playStyle = mvpTotal >= 8 ? 'Агресивний' : winrate >= 57 ? 'Результативний' : stabilityLevel === 'high' ? 'Дисциплінований' : 'Балансний';
   const activityLevel = totalMatches >= 28 ? 'Висока' : totalMatches >= 14 ? 'Середня' : 'Низька';
-  const keyAdvantage = mvpTotal >= 8 ? 'MVP' : rankDelta >= 90 ? 'Прогрес' : winrate >= 58 ? 'WR' : 'Стабільність';
+  const keyAdvantage = mvpTotal >= 8 ? 'MVP' : rankDelta >= 90 ? 'Прогрес' : winrate >= 58 ? 'Winrate' : 'Стабільність';
 
   return {
     totalMatches,
-    stabilityScore: Math.min(100, stabilityScore * 20 + 20),
-    impactScore: Math.min(100, impactScore * 20 + 20),
+    stabilityScore: Math.min(100, stabilityScore),
+    impactScore: Math.min(100, impactScore),
     stabilityLevel,
     impactLevel,
     formLabel,
@@ -237,47 +267,41 @@ function meterLabel(level) {
 }
 
 function renderHero({ profileLeagueContext, livePlayer, currentSeason, displayNick, currentRank, topSeason }) {
-  const points = Number(livePlayer?.points ?? topSeason?.ratingEnd ?? topSeason?.points);
-  const place = Number(livePlayer?.place ?? topSeason?.place ?? topSeason?.finalPlace);
+  const points = livePlayer?.points ?? topSeason?.ratingEnd ?? topSeason?.points;
+  const place = livePlayer?.place ?? topSeason?.place ?? topSeason?.finalPlace;
   const progress = getRankProgress(points, currentRank);
   const seasonLabel = formatSeasonTitleUA(currentSeason?.uiLabel || topSeason?.seasonTitle || 'Поточний сезон');
   const leagueLabel = leagueLabelUA(profileLeagueContext);
 
   return `
     <article class="px-card profile-hero ${rankClass(currentRank)}">
-      <div class="profile-hero__avatar-card">
+      <a class="btn btn--secondary profile-hero__back" href="${buildHash('league-stats', { league: normalizeLeagueKey(profileLeagueContext) })}">← До ліги</a>
+      <div class="profile-hero__top">
         <div class="profile-avatar-frame ${rankClass(currentRank)}">
           <img src="${esc(topSeason?.avatar || livePlayer?.avatarUrl || placeholder)}" alt="${esc(displayNick)}" onerror="this.src='${placeholder}'">
         </div>
-      </div>
-      <div class="profile-hero__info-card">
-        <div class="profile-hero__main">
-          <div class="profile-hero__head">
-            <h1>${esc(displayNick)}</h1>
-          </div>
-          <p class="profile-hero__meta">${esc(leagueLabel)} • ${esc(seasonLabel)}</p>
-          <div class="profile-hero__badges">
-            <span class="profile-place-badge">${Number.isFinite(place) ? `Місце #${place}` : 'Місце —'}</span>
-            <span class="profile-subtle-badge">Ліга: ${esc(leagueLabel)}</span>
-          </div>
-          <div class="profile-hero__actions">
-            <a class="btn btn--secondary" href="${buildHash('league-stats', { league: normalizeLeagueKey(profileLeagueContext) })}">Назад до ліги</a>
+        <div class="profile-hero__identity">
+          <h1>${esc(displayNick)}</h1>
+          <p class="profile-hero__meta">${esc(leagueLabel)} · ${esc(seasonLabel)}</p>
+          <div class="profile-hero__status">
+            <span class="profile-status-badge profile-status-badge--place">${num(place) !== null ? `#${place} місце` : 'Місце —'}</span>
+            <span class="profile-status-badge profile-status-badge--rank">Ранг ${esc(val(currentRank))}</span>
           </div>
         </div>
-      </div>
-      <div class="profile-rank-card ${rankClass(currentRank)}">
-        <p class="profile-rank-card__label">Ранг</p>
-        <strong class="profile-rank-card__value">${esc(currentRank)}</strong>
+        <div class="profile-rank-card ${rankClass(currentRank)}">
+          <p class="profile-rank-card__label">Поточний ранг</p>
+          <strong class="profile-rank-card__value">${esc(val(currentRank))}</strong>
+        </div>
       </div>
       <div class="profile-rank-progress-wrap">
         <div class="profile-rank-progress__labels">
-          <span>Прогрес рангу</span>
-          <strong>${progress.isMax ? 'Максимальний ранг' : `${progress.percent.toFixed(0)}% до ${progress.nextRank}`}</strong>
+          <span>Прогрес до наступного рангу</span>
+          <strong>${progress.isMax ? 'Максимальний ранг досягнуто' : `${progress.percent.toFixed(0)}% до ${progress.nextRank}`}</strong>
         </div>
         <div class="profile-rank-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(progress.percent)}">
           <span style="width:${progress.percent.toFixed(1)}%"></span>
         </div>
-        <p class="profile-note">${progress.isMax ? 'Максимальний ранг досягнуто' : `Залишилось ${val(progress.remain, '—')} очок до рангу ${val(progress.nextRank, '—')}.`}</p>
+        <p class="profile-note">${progress.isMax ? 'Максимальний ранг досягнуто' : `Ще ${val(progress.remain)} очок до рангу ${val(progress.nextRank)}.`}</p>
       </div>
     </article>
   `;
@@ -287,12 +311,12 @@ function renderCompactStats({ livePlayer, topSeason }) {
   const wr = livePlayer?.winRate ?? topSeason?.winRate ?? topSeason?.winrate;
   const delta = livePlayer?.delta ?? topSeason?.delta ?? topSeason?.ratingDelta;
   return `
-    <section class="px-card profile-section">
+    <section class="px-card profile-section profile-priority-main">
       <h2 class="profile-section__title">Ключові метрики</h2>
-      <div class="profile-mini-grid">
-        ${metricMini({ label: 'Очки', value: val(livePlayer?.points ?? topSeason?.ratingEnd ?? topSeason?.points), tone: 'is-accent' })}
+      <div class="profile-key-grid">
+        ${metricMini({ label: 'Очки', value: livePlayer?.points ?? topSeason?.ratingEnd ?? topSeason?.points, tone: 'is-accent' })}
         ${metricMini({ label: 'WR', value: pct(wr), tone: wrTone(wr) })}
-        ${metricMini({ label: 'MVP', value: val(livePlayer?.mvpTotal ?? topSeason?.mvpTotal) })}
+        ${metricMini({ label: 'MVP', value: livePlayer?.mvpTotal ?? topSeason?.mvpTotal })}
         ${metricMini({ label: 'Δ рейтингу', value: signed(delta), tone: deltaTone(delta) })}
       </div>
     </section>
@@ -300,11 +324,12 @@ function renderCompactStats({ livePlayer, topSeason }) {
 }
 
 function renderGameAnalysis({ livePlayer, topSeason }) {
-  const wins = Number(livePlayer?.wins ?? topSeason?.wins);
-  const losses = Number(livePlayer?.losses ?? topSeason?.losses);
-  const draws = Number(livePlayer?.draws ?? topSeason?.draws);
-  const wr = Number(livePlayer?.winRate ?? topSeason?.winRate ?? topSeason?.winrate);
-  const total = [wins, losses, draws].reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0);
+  const wins = livePlayer?.wins ?? topSeason?.wins;
+  const losses = livePlayer?.losses ?? topSeason?.losses;
+  const draws = livePlayer?.draws ?? topSeason?.draws;
+  const wr = livePlayer?.winRate ?? topSeason?.winRate ?? topSeason?.winrate;
+  const games = livePlayer?.matches ?? topSeason?.matches;
+
   const insights = resolveGameplayInsights({
     wins,
     losses,
@@ -313,59 +338,66 @@ function renderGameAnalysis({ livePlayer, topSeason }) {
     mvp: livePlayer?.mvpTotal ?? topSeason?.mvpTotal,
     delta: livePlayer?.delta ?? topSeason?.delta ?? topSeason?.ratingDelta,
     place: livePlayer?.place ?? topSeason?.place ?? topSeason?.finalPlace,
-    games: livePlayer?.matches ?? topSeason?.matches ?? total
+    games
   });
 
   return `
-    <section class="px-card profile-section profile-analysis">
+    <section class="px-card profile-section profile-priority-analytics">
       <h2 class="profile-section__title">Аналіз гри</h2>
-      <div class="profile-analysis__row">
-        <div>
-          <p class="profile-analysis__label">Winrate</p>
-          <div class="profile-wr-bar ${wrTone(wr)}"><span style="width:${Number.isFinite(wr) ? Math.max(0, Math.min(100, wr)) : 0}%"></span></div>
-          <strong class="profile-analysis__value">${pct(wr)}</strong>
+      <article class="profile-wr-panel">
+        <div class="profile-wr-panel__head">
+          <p>Winrate</p>
+          <strong class="${wrTone(wr)}">${pct(wr)}</strong>
         </div>
-        <div class="profile-analysis__compact-grid">
-          ${metricMini({ label: 'Перемоги', value: val(wins), tone: 'is-good' })}
-          ${metricMini({ label: 'Поразки', value: val(losses), tone: 'is-bad' })}
-          ${metricMini({ label: 'Нічиї', value: val(draws), tone: 'is-mid' })}
-          ${metricMini({ label: 'Ігри', value: val(livePlayer?.matches ?? topSeason?.matches ?? total) })}
-          ${metricMini({ label: 'Бої', value: val(livePlayer?.battles ?? topSeason?.rounds) })}
-          ${metricMini({ label: 'MVP', value: val(livePlayer?.mvpTotal ?? topSeason?.mvpTotal) })}
-        </div>
+        <div class="profile-wr-bar ${wrTone(wr)}"><span style="width:${Math.max(0, Math.min(100, num(wr) ?? 0))}%"></span></div>
+      </article>
+
+      <div class="profile-analysis-row3">
+        ${metricMini({ label: 'Перемоги', value: wins, tone: 'is-good' })}
+        ${metricMini({ label: 'Поразки', value: losses, tone: 'is-bad' })}
+        ${metricMini({ label: 'Нічиї', value: draws, tone: 'is-mid' })}
       </div>
+
+      <div class="profile-analysis-row3">
+        ${metricMini({ label: 'Ігри', value: games ?? insights.totalMatches })}
+        ${metricMini({ label: 'Бої', value: livePlayer?.battles ?? topSeason?.rounds })}
+        ${metricMini({ label: 'MVP', value: livePlayer?.mvpTotal ?? topSeason?.mvpTotal })}
+      </div>
+
       <div class="profile-indicator-grid">
         <article class="profile-indicator-card">
-          <p>Стабільність гри</p>
+          <p>Стабільність</p>
           <strong>${meterLabel(insights.stabilityLevel)}</strong>
           <div class="profile-meter ${insights.stabilityLevel}"><span style="width:${insights.stabilityScore}%"></span></div>
         </article>
         <article class="profile-indicator-card">
-          <p>Вплив на гру</p>
+          <p>Вплив</p>
           <strong>${meterLabel(insights.impactLevel)}</strong>
           <div class="profile-meter ${insights.impactLevel}"><span style="width:${insights.impactScore}%"></span></div>
         </article>
+        <article class="profile-indicator-card profile-indicator-card--form">
+          <p>Поточна форма</p>
+          <strong>${esc(insights.formLabel)}</strong>
+        </article>
       </div>
-      <article class="profile-form-card">
-        <p>Поточна форма</p>
-        <strong>Форма: ${esc(insights.formLabel)}</strong>
-      </article>
+
       <div class="profile-insights-grid">
         <article class="profile-insights-card">
           <h3>Сильні сторони</h3>
-          <ul>${(insights.strengths.length ? insights.strengths : ['База для стабільного росту']).map((item) => `<li>${esc(item)}</li>`).join('')}</ul>
+          <ul>${(insights.strengths.length ? insights.strengths : ['Стабільна база для подальшого росту']).map((item) => `<li>${esc(item)}</li>`).join('')}</ul>
         </article>
         <article class="profile-insights-card">
           <h3>Зони росту</h3>
-          <ul>${(insights.growth.length ? insights.growth : ['Продовжувати поточний темп сезону']).map((item) => `<li>${esc(item)}</li>`).join('')}</ul>
+          <ul>${(insights.growth.length ? insights.growth : ['Підтримувати поточний темп гри']).map((item) => `<li>${esc(item)}</li>`).join('')}</ul>
         </article>
       </div>
+
       <article class="profile-player-type">
         <h3>Профіль гравця</h3>
         <div class="profile-player-type__grid">
-          ${metricMini({ label: 'Стиль гри', value: insights.playStyle })}
-          ${metricMini({ label: 'Рівень активності', value: insights.activityLevel })}
-          ${metricMini({ label: 'Ключова перевага', value: insights.keyAdvantage, tone: 'is-accent' })}
+          ${metricMini({ label: 'Стиль гри', value: `🎮 ${insights.playStyle}` })}
+          ${metricMini({ label: 'Активність', value: `⚡ ${insights.activityLevel}` })}
+          ${metricMini({ label: 'Перевага', value: `🏅 ${insights.keyAdvantage}`, tone: 'is-accent' })}
         </div>
       </article>
     </section>
@@ -382,49 +414,47 @@ function renderSeasonTabs(container, tabs, selectedId) {
 }
 
 function renderSeasonSummary(season, allTime) {
-  if (!season || season.id === 'all') {
-    return `
-      <section class="profile-season-summary">
-        <h3>Уся карʼєра</h3>
-        <p class="profile-muted">Зведені показники за всі сезони.</p>
-        <div class="profile-mini-grid">
-          ${metricMini({ label: 'Ігри', value: val(allTime.totalMatches ?? allTime.matches) })}
-          ${metricMini({ label: 'Раунди', value: val(allTime.totalRounds ?? allTime.rounds) })}
-          ${metricMini({ label: 'WR', value: pct(allTime.careerWR ?? allTime.winrate), tone: wrTone(allTime.careerWR ?? allTime.winrate) })}
-          ${metricMini({ label: 'MVP', value: val(allTime.totalMvp ?? allTime.mvpTotal) })}
-          ${metricMini({ label: 'Пік рейтингу', value: val(allTime.peakRating ?? allTime.peakPoints), tone: 'is-accent' })}
-          ${metricMini({ label: 'Найкращий ранг', value: val(allTime.bestRank), tone: 'is-accent' })}
-        </div>
-      </section>
-    `;
+  if (!season) {
+    return '<section class="profile-season-summary"><h3>Сезон</h3><p class="profile-muted">Немає даних сезону.</p></section>';
   }
 
   const seasonWr = season.winRate ?? season.winrate;
   const seasonDelta = season.delta ?? season.ratingDelta;
+  const start = season.ratingStart;
+  const finish = season.ratingEnd ?? season.points;
+  const trendWidth = Math.min(100, Math.max(8, num(seasonDelta) === null ? 8 : Math.abs(Number(seasonDelta)) / 2));
 
   return `
       <section class="profile-season-summary">
         <h3>${esc(formatSeasonTitleUA(season.seasonTitle || season.id))}</h3>
         <p class="profile-muted">${esc(leagueLabelUA(season.league || 'kids'))}</p>
-        <div class="profile-mini-grid">
-          ${metricMini({ label: 'Старт', value: val(season.ratingStart) })}
-          ${metricMini({ label: 'Фініш', value: val(season.ratingEnd ?? season.points), tone: 'is-accent' })}
+
+        <div class="profile-season-kpis">
+          ${metricMini({ label: 'Старт', value: start })}
+          ${metricMini({ label: 'Фініш', value: finish, tone: 'is-accent' })}
           ${metricMini({ label: 'Δ', value: signed(seasonDelta), tone: deltaTone(seasonDelta) })}
           ${metricMini({ label: 'WR', value: pct(seasonWr), tone: wrTone(seasonWr) })}
-          ${metricMini({ label: 'Ігри', value: val(season.matches ?? season.games) })}
-          ${metricMini({ label: 'MVP', value: val(season.mvpTotal) })}
-          ${metricMini({ label: 'Місце', value: Number.isFinite(Number(season.place ?? season.finalPlace)) ? `#${season.place ?? season.finalPlace}` : '—' })}
-          ${metricMini({ label: 'Ранг', value: val(season.rank), tone: 'is-accent' })}
+          ${metricMini({ label: 'Ігри', value: season.matches ?? season.games })}
+          ${metricMini({ label: 'MVP', value: season.mvpTotal })}
+          ${metricMini({ label: 'Ранг', value: season.rank, tone: 'is-accent' })}
+          ${metricMini({ label: 'Місце', value: num(season.place ?? season.finalPlace) !== null ? `#${season.place ?? season.finalPlace}` : '—' })}
         </div>
+
         <div class="profile-season-wld-grid">
-          ${metricMini({ label: 'Перемоги', value: val(season.wins), tone: 'is-good' })}
-          ${metricMini({ label: 'Поразки', value: val(season.losses), tone: 'is-bad' })}
-          ${metricMini({ label: 'Нічиї', value: val(season.draws), tone: 'is-mid' })}
+          ${metricMini({ label: 'Перемоги', value: season.wins, tone: 'is-good' })}
+          ${metricMini({ label: 'Поразки', value: season.losses, tone: 'is-bad' })}
+          ${metricMini({ label: 'Нічиї', value: season.draws, tone: 'is-mid' })}
         </div>
+
         <div class="profile-season-trend">
-          <div class="profile-season-trend__head"><span>Прогрес сезону</span><strong>${esc(val(season.ratingStart))} → ${esc(val(season.ratingEnd ?? season.points))}</strong></div>
-          <div class="profile-season-trend__bar ${deltaTone(seasonDelta)}"><span style="width:${Math.min(100, Math.max(8, Number.isFinite(Number(seasonDelta)) ? Math.min(100, Math.abs(Number(seasonDelta)) / 2) : 8))}%"></span></div>
-          <p class="profile-note">${Number(seasonDelta) > 0 ? 'Сезон із зростанням рейтингу' : Number(seasonDelta) < 0 ? 'Є просідання, є куди додати' : 'Рейтинг тримається стабільно'}</p>
+          <div class="profile-season-trend__head"><span>Прогрес сезону</span><strong>${esc(val(start))} → ${esc(val(finish))}</strong></div>
+          <div class="profile-season-trend__bar ${deltaTone(seasonDelta)}"><span style="width:${trendWidth}%"></span></div>
+          <p class="profile-note">${num(seasonDelta) > 0 ? 'Рейтинг росте стабільно.' : num(seasonDelta) < 0 ? 'Є просідання, варто підсилити гру.' : 'Рейтинг без помітних змін.'}</p>
+        </div>
+
+        <div class="profile-season-career-row">
+          ${metricMini({ label: 'Матчів за карʼєру', value: allTime.totalMatches ?? allTime.matches })}
+          ${metricMini({ label: 'Карʼєрний WR', value: pct(allTime.careerWR ?? allTime.winrate), tone: wrTone(allTime.careerWR ?? allTime.winrate) })}
         </div>
       </section>
   `;
@@ -436,7 +466,7 @@ function renderLogs(logData) {
   }
 
   return `<details class="profile-logs-wrap">
-    <summary>Матч-логи (${logData.groups.length} днів)</summary>
+    <summary>Логи сезону (${logData.groups.length} днів)</summary>
     ${logData.groups.map((group) => `
       <article class="profile-log-day">
         <header class="profile-log-day__head">
@@ -449,12 +479,12 @@ function renderLogs(logData) {
                 <div class="profile-log-item__teams">${entry.teams.map((team, idx) => `<span>К${idx + 1}: ${esc(team.join(', ') || '—')}</span>`).join('')}</div>
                 <div class="profile-log-item__meta">
                   <span>Переможець: ${esc(winnerText(entry.winnerLabel))}</span>
-                  <span>MVP: ${esc(entry.mvp1 || '—')} / ${esc(entry.mvp2 || '—')} / ${esc(entry.mvp3 || '—')}</span>
+                  <span>MVP: ${esc(val(entry.mvp1))} / ${esc(val(entry.mvp2))} / ${esc(val(entry.mvp3))}</span>
                   <span>Раунди: ${esc(val(entry.rounds))}</span>
                 </div>
               </li>
             `).join('')}</ul>`
-    : '<p class="profile-muted">Матчів за дату не знайдено, доступні лише зміни рейтингу.</p>'}
+    : '<p class="profile-muted">Матчі за дату відсутні, є лише зміни рейтингу.</p>'}
       </article>
     `).join('')}
   </details>`;
@@ -462,6 +492,10 @@ function renderLogs(logData) {
 
 function sortTabsByChronology(tabs = []) {
   return [...tabs].sort((a, b) => {
+    const aOrder = seasonOrderKey(a.label);
+    const bOrder = seasonOrderKey(b.label);
+    if (aOrder !== bOrder) return aOrder - bOrder;
+
     const aTime = Number.isFinite(Date.parse(a.dateFrom || '')) ? Date.parse(a.dateFrom) : 0;
     const bTime = Number.isFinite(Date.parse(b.dateFrom || '')) ? Date.parse(b.dateFrom) : 0;
     return aTime - bTime;
@@ -503,6 +537,7 @@ export async function initProfilePage(params = {}) {
       || profile?.league
       || league
     ) || 'kids';
+
     const displayNick = livePlayer?.nickname || profile?.nick || nick;
     const seasonRows = profile?.seasons || [];
     const seasonRowsById = new Map(seasonRows.map((row) => [row.seasonId, row]));
@@ -516,7 +551,7 @@ export async function initProfilePage(params = {}) {
         ${renderGameAnalysis({ livePlayer: livePlayer || {}, topSeason })}
         ${renderCareerHighlights(profile?.highlights || {})}
 
-        <section class="px-card profile-section">
+        <section class="px-card profile-section profile-priority-history">
           <h2 class="profile-section__title">Сезони</h2>
           <div class="profile-season-tabs" id="seasonTabs"></div>
           <div id="seasonSummaryHost"></div>
@@ -538,17 +573,11 @@ export async function initProfilePage(params = {}) {
           current: season.seasonId === currentSeason?.id,
           dateFrom: meta?.dateFrom
         };
-      });
+      })
+      .filter((tab) => !isMissing(tab.id));
 
-    const labelOrder = new Map([
-      ['Літо 2025', 0],
-      ['Осінь 2025', 1],
-      ['Зима 2025–2026', 2],
-      ['Весна 2026', 3]
-    ]);
-
-    const tabs = sortTabsByChronology(available).sort((a, b) => (labelOrder.get(a.label) ?? 99) - (labelOrder.get(b.label) ?? 99));
-    const fallbackSeasonId = tabs[0]?.id || null;
+    const tabs = sortTabsByChronology(available);
+    const fallbackSeasonId = tabs[tabs.length - 1]?.id || tabs[0]?.id || null;
     const state = {
       seasonId: currentSeason?.id && seasonRowsById.has(currentSeason.id)
         ? currentSeason.id


### PR DESCRIPTION
### Motivation
- Remove capsule/oval-dominated UI on the profile page and rebuild it as a compact, mobile-first player dashboard with clear visual hierarchy. 
- Improve readability and priority of core data (hero/status, key metrics, analytics) and present season history as a compact, visual dashboard. 
- Provide simple, rule-based insights from real fields and ensure no technical placeholders like `null`/`#null`/`undefined` appear in UI. 

### Description
- Rebuilt profile rendering in `v2/pages/profile.js`: added normalization helpers (`isMissing`, `num`, `val`, `pct`) and replaced fragile numeric checks so missing/technical values render as `—` and numerical flows are robust. 
- Reworked hero into a compact, status-first header with back button, avatar, nickname, league/season meta, status badges (place/rank), a strong rank card and a clean rank progress bar with max-rank messaging. 
- Converted key metrics into a fast 2x2 stat grid and upgraded the analytics area into a dashboard: stronger WR panel with toned progress bar, 3-column W/L/D tiles, games/battles/MVP tiles, indicator meters (stability/impact/form) and concise rule-based insights (play style, activity, strengths, growth). 
- Transformed career achievements into trophy-like tiles (icon, Ukrainian label, large value, season subtitle) and rebuilt season UX: Ukrainian season formatting, chronological ordering (`seasonOrderKey`), clear active tab state with `поточний` marker, compact season dashboard with trend/progress bar and concise season logs. 
- Updated profile-specific styling in `v2/assets/css/main.css` to remove capsule dominance and apply a unified soft-card rectangular style (12px radii), reduced nested rounded outlines, clearer section priorities and mobile-first spacing. 
- Exact files changed: `v2/pages/profile.js`, `v2/assets/css/main.css`.

### Testing
- Ran JS syntax/type check with `node --check v2/pages/profile.js` and it passed. 
- Searched for technical placeholders with `rg -n "#null|null|undefined" v2/pages/profile.js v2/assets/css/main.css` to validate null handling; checks were run and code updated to avoid these values in UI. 
- Executed project build task `npm run build:summer2025-og` to validate scripts and asset pipeline and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78e39a4cc832185a87287e0e58e38)