### PR TITLE
Remove capsule/px-card UI from profile page (profile-panel)

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -5088,8 +5088,9 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   cursor: not-allowed;
 }
 
-/* Player Profile V2 */
-.profile-page-v2 {
+/* Player Profile */
+.profile-page {
+  --radius: 12px;
   display: grid;
   gap: .75rem;
   width: 100%;
@@ -5099,15 +5100,31 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   box-sizing: border-box;
 }
 
-.profile-page-v2 * {
+.profile-page * {
   box-sizing: border-box;
   min-width: 0;
+  border-radius: 0 !important;
 }
 
-.profile-page-v2 .px-card,
-.profile-page-v2 .btn,
-.profile-page-v2 button {
-  border-radius: 12px;
+.profile-page .btn,
+.profile-page button {
+  border-radius: var(--radius) !important;
+}
+
+.profile-page .px-badge::before {
+  display: none;
+}
+
+.profile-page .px-card,
+.profile-page .px-badge {
+  background-image: none !important;
+}
+
+.profile-panel {
+  background: rgba(17, 25, 42, .9);
+  border: 1px solid rgba(255, 255, 255, .08);
+  padding: 14px;
+  border-radius: var(--radius) !important;
 }
 
 .profile-hero,
@@ -5116,6 +5133,11 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 .profile-logs-wrap,
 .profile-log-empty {
   padding: .75rem !important;
+}
+
+.profile-metric,
+.profile-achievement-card {
+  border-radius: var(--radius) !important;
 }
 
 .profile-hero {
@@ -5129,6 +5151,10 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   justify-self: start;
   padding: .32rem .54rem;
   min-height: 32px;
+}
+
+.profile-actions {
+  margin-top: .55rem;
 }
 
 .profile-hero__top {
@@ -5273,7 +5299,7 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   gap: .38rem;
 }
 
-.profile-mini-card {
+.profile-metric {
   border: 1px solid rgba(152, 212, 255, .14);
   background: rgba(10, 17, 30, .78);
   padding: .52rem;
@@ -5281,30 +5307,31 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   display: grid;
   align-content: center;
   gap: .14rem;
+  border-radius: var(--radius) !important;
 }
 
-.profile-mini-card span {
+.profile-metric span {
   font-size: .62rem;
   letter-spacing: .06em;
   text-transform: uppercase;
   color: rgba(187, 206, 225, .86);
 }
 
-.profile-mini-card strong {
+.profile-metric strong {
   font-size: 1.08rem;
   line-height: 1.08;
   font-family: var(--font-mono);
 }
 
-.profile-mini-card.is-accent { border-color: rgba(183, 255, 42, .44); }
-.profile-mini-card.is-good strong,
+.profile-metric.is-accent { border-color: rgba(183, 255, 42, .44); }
+.profile-metric.is-good strong,
 .profile-wr-panel__head strong.is-good { color: #86f488; }
-.profile-mini-card.is-mid strong,
+.profile-metric.is-mid strong,
 .profile-wr-panel__head strong.is-mid { color: #ffd45a; }
-.profile-mini-card.is-bad strong,
+.profile-metric.is-bad strong,
 .profile-wr-panel__head strong.is-bad { color: #ff7f7f; }
-.profile-mini-card.is-positive strong { color: #86f488; }
-.profile-mini-card.is-negative strong { color: #ff7f7f; }
+.profile-metric.is-positive strong { color: #86f488; }
+.profile-metric.is-negative strong { color: #ff7f7f; }
 
 .profile-wr-panel {
   border: 1px solid rgba(161, 220, 255, .24);
@@ -5442,6 +5469,11 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   gap: .2rem;
 }
 
+.profile-achievement-card * {
+  border: none !important;
+  background: none !important;
+}
+
 .profile-achievement-card__icon { font-size: 1rem; }
 .profile-achievement-card__label {
   margin: 0;
@@ -5469,27 +5501,28 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   gap: .35rem;
 }
 
-.profile-season-tab {
+.profile-tab {
   border: 1px solid rgba(160, 219, 255, .26);
   background: rgba(9, 15, 26, .82);
   color: var(--text);
-  padding: .45rem .48rem;
+  padding: 8px 12px;
   min-height: 40px;
   display: grid;
   justify-items: start;
   gap: .1rem;
   font-family: var(--font-mono);
   font-size: .69rem;
+  border-radius: 10px !important;
 }
 
-.profile-season-tab em {
+.profile-tab em {
   font-style: normal;
   font-size: .58rem;
   color: #91e1ff;
   text-transform: uppercase;
 }
 
-.profile-season-tab.is-active {
+.profile-tab.is-active {
   border-color: rgba(183, 255, 42, .68);
   color: #ecffcd;
   background: linear-gradient(120deg, rgba(57, 89, 24, .54), rgba(23, 39, 55, .82));
@@ -5588,20 +5621,20 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   color: var(--muted);
 }
 
-.profile-page-v2 .rank-s,
-.profile-page-v2 .rank-S { color: #d38aff; }
-.profile-page-v2 .rank-a,
-.profile-page-v2 .rank-A { color: #ff6a79; }
-.profile-page-v2 .rank-b,
-.profile-page-v2 .rank-B { color: #ffc457; }
-.profile-page-v2 .rank-c,
-.profile-page-v2 .rank-C { color: #ffd84d; }
-.profile-page-v2 .rank-d,
-.profile-page-v2 .rank-D { color: #45c7ff; }
-.profile-page-v2 .rank-e,
-.profile-page-v2 .rank-E { color: #6fd77c; }
-.profile-page-v2 .rank-f,
-.profile-page-v2 .rank-F { color: #c8cfda; }
+.profile-page .rank-s,
+.profile-page .rank-S { color: #d38aff; }
+.profile-page .rank-a,
+.profile-page .rank-A { color: #ff6a79; }
+.profile-page .rank-b,
+.profile-page .rank-B { color: #ffc457; }
+.profile-page .rank-c,
+.profile-page .rank-C { color: #ffd84d; }
+.profile-page .rank-d,
+.profile-page .rank-D { color: #45c7ff; }
+.profile-page .rank-e,
+.profile-page .rank-E { color: #6fd77c; }
+.profile-page .rank-f,
+.profile-page .rank-F { color: #c8cfda; }
 
 @media (min-width: 821px) {
   .profile-hero__top {

--- a/v2/pages/profile.js
+++ b/v2/pages/profile.js
@@ -72,7 +72,7 @@ function resolveParams(params = {}) {
 }
 
 function renderSkeleton(root) {
-  root.innerHTML = '<section class="px-card profile-loading-shell"><h1 class="px-card__title">Профіль гравця</h1><p class="px-card__text">Завантаження профілю…</p><div class="profile-loading-bar" aria-hidden="true"></div></section>';
+  root.innerHTML = '<section class="profile-panel profile-loading-shell"><h1 class="profile-section__title">Профіль гравця</h1><p class="profile-muted">Завантаження профілю…</p><div class="profile-loading-bar" aria-hidden="true"></div></section>';
 }
 
 function rankClass(rank = 'F') {
@@ -171,7 +171,7 @@ function getRankProgress(points, rankLetter) {
 }
 
 function metricMini({ label, value, tone = '' }) {
-  return `<article class="profile-mini-card ${tone}"><strong>${esc(val(value))}</strong><span>${esc(label)}</span></article>`;
+  return `<article class="profile-metric ${tone}"><strong>${esc(val(value))}</strong><span>${esc(label)}</span></article>`;
 }
 
 function renderCareerHighlights(highlights = {}) {
@@ -189,7 +189,7 @@ function renderCareerHighlights(highlights = {}) {
   if (mvpRecord?.seasonTitle && num(mvpRecord.mvpTotal) !== null) cards.push({ icon: '⭐', label: 'Рекорд MVP', value: String(mvpRecord.mvpTotal), season: formatSeasonTitleUA(mvpRecord.seasonTitle) });
 
   if (!cards.length) return '';
-  return `<section class="px-card profile-section profile-achievements"><h2 class="profile-section__title">Досягнення карʼєри</h2><div class="profile-achievement-grid">${cards.map((item) => `<article class="profile-achievement-card"><span class="profile-achievement-card__icon">${item.icon}</span><p class="profile-achievement-card__label">${esc(item.label)}</p><p class="profile-achievement-card__value">${esc(item.value)}</p><p class="profile-achievement-card__season">${esc(item.season)}</p></article>`).join('')}</div></section>`;
+  return `<section class="profile-panel profile-section profile-achievements"><h2 class="profile-section__title">Досягнення карʼєри</h2><div class="profile-achievement-grid">${cards.map((item) => `<article class="profile-achievement-card"><span class="profile-achievement-card__icon">${item.icon}</span><p class="profile-achievement-card__label">${esc(item.label)}</p><p class="profile-achievement-card__value">${esc(item.value)}</p><p class="profile-achievement-card__season">${esc(item.season)}</p></article>`).join('')}</div></section>`;
 }
 
 function resolveGameplayInsights({ wins, losses, draws, wr, mvp, delta, place, games }) {
@@ -274,7 +274,7 @@ function renderHero({ profileLeagueContext, livePlayer, currentSeason, displayNi
   const leagueLabel = leagueLabelUA(profileLeagueContext);
 
   return `
-    <article class="px-card profile-hero ${rankClass(currentRank)}">
+    <article class="profile-panel profile-hero ${rankClass(currentRank)}">
       <a class="btn btn--secondary profile-hero__back" href="${buildHash('league-stats', { league: normalizeLeagueKey(profileLeagueContext) })}">← До ліги</a>
       <div class="profile-hero__top">
         <div class="profile-avatar-frame ${rankClass(currentRank)}">
@@ -311,7 +311,7 @@ function renderCompactStats({ livePlayer, topSeason }) {
   const wr = livePlayer?.winRate ?? topSeason?.winRate ?? topSeason?.winrate;
   const delta = livePlayer?.delta ?? topSeason?.delta ?? topSeason?.ratingDelta;
   return `
-    <section class="px-card profile-section profile-priority-main">
+    <section class="profile-panel profile-section profile-priority-main">
       <h2 class="profile-section__title">Ключові метрики</h2>
       <div class="profile-key-grid">
         ${metricMini({ label: 'Очки', value: livePlayer?.points ?? topSeason?.ratingEnd ?? topSeason?.points, tone: 'is-accent' })}
@@ -342,7 +342,7 @@ function renderGameAnalysis({ livePlayer, topSeason }) {
   });
 
   return `
-    <section class="px-card profile-section profile-priority-analytics">
+    <section class="profile-panel profile-section profile-priority-analytics">
       <h2 class="profile-section__title">Аналіз гри</h2>
       <article class="profile-wr-panel">
         <div class="profile-wr-panel__head">
@@ -406,7 +406,7 @@ function renderGameAnalysis({ livePlayer, topSeason }) {
 
 function renderSeasonTabs(container, tabs, selectedId) {
   container.innerHTML = tabs.map((tab) => `
-    <button type="button" class="profile-season-tab ${tab.id === selectedId ? 'is-active' : ''}" data-season-id="${esc(tab.id)}">
+    <button type="button" class="profile-tab ${tab.id === selectedId ? 'is-active' : ''}" data-season-id="${esc(tab.id)}">
       <span>${esc(tab.label)}</span>
       ${tab.current ? '<em>поточний</em>' : ''}
     </button>
@@ -508,7 +508,7 @@ export async function initProfilePage(params = {}) {
 
   const { nick, league, profileLeagueContext: routeLeagueContext } = resolveParams(params);
   if (!nick) {
-    root.innerHTML = `<section class="px-card"><h1 class="px-card__title">Профіль гравця</h1><p class="px-card__text">Не вказано нікнейм гравця.</p><div class="px-card__actions"><a class="btn btn--secondary" href="${buildHash('league-stats', { league })}">Назад до ліги</a></div></section>`;
+    root.innerHTML = `<section class="profile-panel"><h1 class="profile-section__title">Профіль гравця</h1><p class="profile-muted">Не вказано нікнейм гравця.</p><div class="profile-actions"><a class="btn btn--secondary" href="${buildHash('league-stats', { league })}">Назад до ліги</a></div></section>`;
     return;
   }
 
@@ -526,7 +526,7 @@ export async function initProfilePage(params = {}) {
     const livePlayer = (liveStats?.players || []).find((player) => normalizePlayerKey(player.nickname) === normalizedNick) || null;
 
     if (!profile && !livePlayer) {
-      root.innerHTML = `<section class="px-card"><h1 class="px-card__title">Профіль гравця</h1><p class="px-card__text">Гравця не знайдено.</p><div class="px-card__actions"><a class="btn btn--secondary" href="${buildHash('league-stats', { league })}">Назад до ліги</a></div></section>`;
+      root.innerHTML = `<section class="profile-panel"><h1 class="profile-section__title">Профіль гравця</h1><p class="profile-muted">Гравця не знайдено.</p><div class="profile-actions"><a class="btn btn--secondary" href="${buildHash('league-stats', { league })}">Назад до ліги</a></div></section>`;
       return;
     }
 
@@ -545,13 +545,13 @@ export async function initProfilePage(params = {}) {
     const currentRank = String(livePlayer?.rankLetter || topSeason?.rank || profile?.allTime?.bestRank || 'F').toUpperCase();
 
     root.innerHTML = `
-      <section class="profile-page-v2">
+      <section class="profile-page">
         ${renderHero({ profileLeagueContext, livePlayer: livePlayer || {}, currentSeason, displayNick, currentRank, topSeason })}
         ${renderCompactStats({ livePlayer: livePlayer || {}, topSeason })}
         ${renderGameAnalysis({ livePlayer: livePlayer || {}, topSeason })}
         ${renderCareerHighlights(profile?.highlights || {})}
 
-        <section class="px-card profile-section profile-priority-history">
+        <section class="profile-panel profile-section profile-priority-history">
           <h2 class="profile-section__title">Сезони</h2>
           <div class="profile-season-tabs" id="seasonTabs"></div>
           <div id="seasonSummaryHost"></div>
@@ -608,6 +608,6 @@ export async function initProfilePage(params = {}) {
 
     await renderState();
   } catch (error) {
-    root.innerHTML = `<section class="px-card"><h1 class="px-card__title">Профіль гравця</h1><p class="px-card__text">${esc(safeErrorMessage(error, 'Дані тимчасово недоступні'))}</p></section>`;
+    root.innerHTML = `<section class="profile-panel"><h1 class="profile-section__title">Профіль гравця</h1><p class="profile-muted">${esc(safeErrorMessage(error, 'Дані тимчасово недоступні'))}</p></section>`;
   }
 }


### PR DESCRIPTION
### Motivation

- Усунути овальні / капсульні UI-ефекти на сторінці профілю, не ламаючи інші сторінки, шляхом локальної заміни загальних «card/chip» класів і додавання профільного простору стилів.

### Description

- Замінено використання `px-card` у профілі на новий обгортковий клас `profile-panel` для hero, метрик, аналітики, achievements, секції сезонів та loading/empty/error станів (файл `v2/pages/profile.js`).
- Заміни класів: `profile-mini-card` → `profile-metric`, `profile-season-tab` → `profile-tab`, і оновлено `metricMini()` для генерації `.profile-metric` HTML (файл `v2/pages/profile.js`).
- Додано ізоляцію стилів у `v2/assets/css/main.css` для профілю: ` .profile-page * { border-radius: 0 !important; }`, відключено pixel-декорації (`.profile-page .px-badge::before`, `background-image` для `.px-card/.px-badge`) і введено новий базовий `.profile-panel` з фоном/рамкою/падінгом.
- Контрольоване відновлення радіусів для потрібних елементів `.profile-panel`, `.profile-metric`, `.profile-achievement-card` та видалення вкладених рамок в achievements через `.profile-achievement-card * { border: none !important; background: none !important; }`.

### Testing

- `node --check v2/pages/profile.js` — пройшов successfully.
- `git diff --check` — пройшов successfully (перевірка змін на синтаксичні/whitespace конфлікти).
- Пошук великих радіусів: `rg -n "border-radius:\s*(999px|1[7-9]px|[2-9][0-9]px)" v2/assets/css/main.css` — виконувався та виявив кілька записів з великими `border-radius` поза профільною областю (наприклад `999px`, `18px`), що залишаються в інших секціях файлу; зміни до профілю застосовують контрольовані значення (`0/10/12`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7922232648321bed0112231b49c85)