### PR TITLE
Redesign v2 player profile page UI hierarchy and styles

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -5124,7 +5124,7 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   background: rgba(17, 25, 42, .9);
   border: 1px solid rgba(255, 255, 255, .08);
   padding: 14px;
-  border-radius: var(--radius) !important;
+  border-radius: 12px !important;
 }
 
 .profile-hero,
@@ -5137,7 +5137,7 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 
 .profile-metric,
 .profile-achievement-card {
-  border-radius: var(--radius) !important;
+  border-radius: 10px !important;
 }
 
 .profile-hero {
@@ -5292,6 +5292,7 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 }
 
 .profile-key-grid,
+.profile-stats-grid,
 .profile-mini-grid,
 .profile-season-kpis {
   display: grid;
@@ -5307,7 +5308,11 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
   display: grid;
   align-content: center;
   gap: .14rem;
-  border-radius: var(--radius) !important;
+  border-radius: 10px !important;
+}
+
+.profile-metric * {
+  border: none !important;
 }
 
 .profile-metric span {
@@ -5502,17 +5507,17 @@ body.theme-game .league-page #leagueExpandBtn.button-primary[aria-disabled='true
 }
 
 .profile-tab {
-  border: 1px solid rgba(160, 219, 255, .26);
+  border: 1px solid rgba(255,255,255,0.1);
   background: rgba(9, 15, 26, .82);
   color: var(--text);
-  padding: 8px 12px;
+  padding: 8px;
   min-height: 40px;
   display: grid;
   justify-items: start;
   gap: .1rem;
   font-family: var(--font-mono);
   font-size: .69rem;
-  border-radius: 10px !important;
+  border-radius: 8px !important;
 }
 
 .profile-tab em {

--- a/v2/pages/profile.js
+++ b/v2/pages/profile.js
@@ -132,13 +132,12 @@ function formatSeasonTitleUA(raw = '') {
 }
 
 function seasonOrderKey(label = '') {
-  const map = {
-    'Літо 2025': 0,
-    'Осінь 2025': 1,
-    'Зима 2025–2026': 2,
-    'Весна 2026': 3
-  };
-  return map[label] ?? 100;
+  const normalized = String(label ?? '').toLowerCase();
+  if (normalized.includes('літо')) return 0;
+  if (normalized.includes('осінь')) return 1;
+  if (normalized.includes('зима')) return 2;
+  if (normalized.includes('весна')) return 3;
+  return 99;
 }
 
 function getRankProgress(points, rankLetter) {
@@ -189,7 +188,7 @@ function renderCareerHighlights(highlights = {}) {
   if (mvpRecord?.seasonTitle && num(mvpRecord.mvpTotal) !== null) cards.push({ icon: '⭐', label: 'Рекорд MVP', value: String(mvpRecord.mvpTotal), season: formatSeasonTitleUA(mvpRecord.seasonTitle) });
 
   if (!cards.length) return '';
-  return `<section class="profile-panel profile-section profile-achievements"><h2 class="profile-section__title">Досягнення карʼєри</h2><div class="profile-achievement-grid">${cards.map((item) => `<article class="profile-achievement-card"><span class="profile-achievement-card__icon">${item.icon}</span><p class="profile-achievement-card__label">${esc(item.label)}</p><p class="profile-achievement-card__value">${esc(item.value)}</p><p class="profile-achievement-card__season">${esc(item.season)}</p></article>`).join('')}</div></section>`;
+  return `<section class="profile-panel profile-section profile-achievements"><h2 class="profile-section__title">Досягнення карʼєри</h2><div class="profile-achievement-grid">${cards.map((item) => `<article class="profile-achievement-card"><div class="profile-achievement-card__icon icon">${item.icon}</div><div class="profile-achievement-card__value value">${esc(item.value)}</div><div class="profile-achievement-card__label label">${esc(item.label)}</div><div class="profile-achievement-card__season meta">${esc(item.season)}</div></article>`).join('')}</div></section>`;
 }
 
 function resolveGameplayInsights({ wins, losses, draws, wr, mvp, delta, place, games }) {
@@ -270,7 +269,7 @@ function renderHero({ profileLeagueContext, livePlayer, currentSeason, displayNi
   const points = livePlayer?.points ?? topSeason?.ratingEnd ?? topSeason?.points;
   const place = livePlayer?.place ?? topSeason?.place ?? topSeason?.finalPlace;
   const progress = getRankProgress(points, currentRank);
-  const seasonLabel = formatSeasonTitleUA(currentSeason?.uiLabel || topSeason?.seasonTitle || 'Поточний сезон');
+  const seasonLabel = formatSeasonTitleUA(currentSeason?.uiLabel ?? topSeason?.seasonTitle ?? 'Поточний сезон');
   const leagueLabel = leagueLabelUA(profileLeagueContext);
 
   return `
@@ -278,17 +277,17 @@ function renderHero({ profileLeagueContext, livePlayer, currentSeason, displayNi
       <a class="btn btn--secondary profile-hero__back" href="${buildHash('league-stats', { league: normalizeLeagueKey(profileLeagueContext) })}">← До ліги</a>
       <div class="profile-hero__top">
         <div class="profile-avatar-frame ${rankClass(currentRank)}">
-          <img src="${esc(topSeason?.avatar || livePlayer?.avatarUrl || placeholder)}" alt="${esc(displayNick)}" onerror="this.src='${placeholder}'">
+          <img class="avatar" src="${esc(topSeason?.avatar ?? livePlayer?.avatarUrl ?? placeholder)}" alt="${esc(displayNick)}" onerror="this.src='${placeholder}'">
         </div>
         <div class="profile-hero__identity">
-          <h1>${esc(displayNick)}</h1>
+          <h1 class="name">${esc(displayNick)}</h1>
           <p class="profile-hero__meta">${esc(leagueLabel)} · ${esc(seasonLabel)}</p>
-          <div class="profile-hero__status">
+          <div class="profile-hero__status badges">
             <span class="profile-status-badge profile-status-badge--place">${num(place) !== null ? `#${place} місце` : 'Місце —'}</span>
             <span class="profile-status-badge profile-status-badge--rank">Ранг ${esc(val(currentRank))}</span>
           </div>
         </div>
-        <div class="profile-rank-card ${rankClass(currentRank)}">
+        <div class="profile-rank-card rank-big ${rankClass(currentRank)}">
           <p class="profile-rank-card__label">Поточний ранг</p>
           <strong class="profile-rank-card__value">${esc(val(currentRank))}</strong>
         </div>
@@ -298,7 +297,7 @@ function renderHero({ profileLeagueContext, livePlayer, currentSeason, displayNi
           <span>Прогрес до наступного рангу</span>
           <strong>${progress.isMax ? 'Максимальний ранг досягнуто' : `${progress.percent.toFixed(0)}% до ${progress.nextRank}`}</strong>
         </div>
-        <div class="profile-rank-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(progress.percent)}">
+        <div class="profile-rank-progress progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(progress.percent)}">
           <span style="width:${progress.percent.toFixed(1)}%"></span>
         </div>
         <p class="profile-note">${progress.isMax ? 'Максимальний ранг досягнуто' : `Ще ${val(progress.remain)} очок до рангу ${val(progress.nextRank)}.`}</p>
@@ -313,7 +312,7 @@ function renderCompactStats({ livePlayer, topSeason }) {
   return `
     <section class="profile-panel profile-section profile-priority-main">
       <h2 class="profile-section__title">Ключові метрики</h2>
-      <div class="profile-key-grid">
+      <div class="profile-stats-grid">
         ${metricMini({ label: 'Очки', value: livePlayer?.points ?? topSeason?.ratingEnd ?? topSeason?.points, tone: 'is-accent' })}
         ${metricMini({ label: 'WR', value: pct(wr), tone: wrTone(wr) })}
         ${metricMini({ label: 'MVP', value: livePlayer?.mvpTotal ?? topSeason?.mvpTotal })}
@@ -426,8 +425,8 @@ function renderSeasonSummary(season, allTime) {
 
   return `
       <section class="profile-season-summary">
-        <h3>${esc(formatSeasonTitleUA(season.seasonTitle || season.id))}</h3>
-        <p class="profile-muted">${esc(leagueLabelUA(season.league || 'kids'))}</p>
+        <h3>${esc(formatSeasonTitleUA(season.seasonTitle ?? season.id))}</h3>
+        <p class="profile-muted">${esc(leagueLabelUA(season.league ?? 'kids'))}</p>
 
         <div class="profile-season-kpis">
           ${metricMini({ label: 'Старт', value: start })}
@@ -476,7 +475,7 @@ function renderLogs(logData) {
         ${group.entries.length
     ? `<ul class="profile-log-list">${group.entries.map((entry) => `
               <li class="profile-log-item">
-                <div class="profile-log-item__teams">${entry.teams.map((team, idx) => `<span>К${idx + 1}: ${esc(team.join(', ') || '—')}</span>`).join('')}</div>
+                <div class="profile-log-item__teams">${entry.teams.map((team, idx) => `<span>К${idx + 1}: ${esc(team.join(', ') ?? '—')}</span>`).join('')}</div>
                 <div class="profile-log-item__meta">
                   <span>Переможець: ${esc(winnerText(entry.winnerLabel))}</span>
                   <span>MVP: ${esc(val(entry.mvp1))} / ${esc(val(entry.mvp2))} / ${esc(val(entry.mvp3))}</span>


### PR DESCRIPTION
### Motivation
- Apply the v2 redesign for the player profile: remove oval/capsule UI and nested borders, produce a clean block hierarchy, and add clearer gamification/analytics while keeping changes scoped to `.profile-page`.

### Description
- Update `v2/pages/profile.js` markup for the hero and achievements: add `avatar`, `name`, `badges`, `rank-big`, and `progress-bar` classes and convert achievements to `icon/value/label/meta` layout for clearer hierarchy.
- Replace the key metrics wrapper with `profile-stats-grid` and tighten season/summary fallbacks to use nullish-safe checks (`??`) to avoid showing `null`/`undefined` in UI.
- Improve season ordering by implementing `seasonOrderKey` that ranks seasons Summer → Autumn → Winter → Spring and keep date as a tie-breaker.
- Scope visual changes in `v2/assets/css/main.css`: enforce profile-local radius reset, set controlled radii (`profile-panel: 12px`, `profile-metric`/`profile-achievement-card: 10px`, `profile-tab: 8px`), remove nested borders inside metric cards (`.profile-metric * { border: none !important; }`), adjust `.profile-tab` padding and border to the requested compact style, and add `profile-stats-grid` CSS hook.

### Testing
- Ran `node --check v2/pages/profile.js` and the syntax check passed.
- Ran `npm run build:summer2025-og` and the build step completed successfully (social preview generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a77eb5ac83218e7fe8787df7ab8d)