### PR TITLE
fix(balance2): use MAX_LOBBY_PLAYERS for all lobby selection limits

### DIFF
--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -9,6 +9,7 @@ import {
   getAvailableTeamKeys,
   getActiveMatchTeams,
   getTeamLabel,
+  MAX_LOBBY_PLAYERS,
 } from './state.js';
 import { autoBalance2, balanceIntoNTeams } from './balance.js';
 import { clearTeams, syncSelectedFromTeamsAndBench } from './manual.js';
@@ -273,7 +274,7 @@ function toggleSelectedPlayer(nick) {
     Object.keys(state.teamsState.teams).forEach((key) => {
       state.teamsState.teams[key] = state.teamsState.teams[key].filter((n) => n !== nick);
     });
-  } else if (state.playersState.selected.length < 15) {
+  } else if (state.playersState.selected.length < MAX_LOBBY_PLAYERS) {
     state.playersState.selected = [...state.playersState.selected, nick];
   }
   syncSelectedMap();

--- a/v2/scripts/balance2/manual.js
+++ b/v2/scripts/balance2/manual.js
@@ -1,4 +1,4 @@
-import { state, syncSelectedMap } from './state.js';
+import { state, syncSelectedMap, MAX_LOBBY_PLAYERS } from './state.js';
 
 export function clearTeams() {
   state.teamsState.teams.team1 = [];
@@ -13,7 +13,7 @@ export function syncSelectedFromTeamsAndBench() {
   for (const nick of state.playersState.selected) {
     if (!inTeams.has(nick)) withBench.push(nick);
   }
-  state.playersState.selected = [...new Set(withBench)].slice(0, 15);
+  state.playersState.selected = [...new Set(withBench)].slice(0, MAX_LOBBY_PLAYERS);
   syncSelectedMap();
 }
 

--- a/v2/scripts/balance2/storage.js
+++ b/v2/scripts/balance2/storage.js
@@ -1,4 +1,10 @@
-import { state, normalizeLeague, computeSeriesSummary, syncSelectedMap } from './state.js';
+import {
+  state,
+  normalizeLeague,
+  computeSeriesSummary,
+  syncSelectedMap,
+  MAX_LOBBY_PLAYERS,
+} from './state.js';
 
 const KEY = 'balance2:lobby';
 const PLAYERS_KEY = 'balance2:playersCache';
@@ -34,7 +40,7 @@ export function restoreLobby() {
   state.app.query = '';
 
   state.playersState.selected = Array.isArray(data?.playersState?.selected || data?.selected)
-    ? (data.playersState?.selected || data.selected).slice(0, 15)
+    ? (data.playersState?.selected || data.selected).slice(0, MAX_LOBBY_PLAYERS)
     : [];
   syncSelectedMap();
 


### PR DESCRIPTION
### Motivation
- The UI already displayed "Обрано: X / 30" but some logic still enforced the legacy cap of 15, preventing adding more than 15 players despite the UI showing 30.

### Description
- Replaced hardcoded 15 with `MAX_LOBBY_PLAYERS` (30) in the remaining logic paths so UI and logic share one constant; `MAX_LOBBY_PLAYERS` is defined in `state.js` and kept at 30.
- Changes made: `app.js` — `toggleSelectedPlayer` guard now uses `MAX_LOBBY_PLAYERS`; `manual.js` — `syncSelectedFromTeamsAndBench` truncation uses `MAX_LOBBY_PLAYERS` instead of `.slice(0, 15)`; `storage.js` — `restoreLobby` uses `.slice(0, MAX_LOBBY_PLAYERS)` when restoring selection from storage.
- Where the old 15-limit was found: `toggleSelectedPlayer` in `v2/scripts/balance2/app.js`, `syncSelectedFromTeamsAndBench` in `v2/scripts/balance2/manual.js`, and `restoreLobby` in `v2/scripts/balance2/storage.js`.
- Files changed: `v2/scripts/balance2/app.js`, `v2/scripts/balance2/manual.js`, `v2/scripts/balance2/storage.js`.
- Manual verification steps: load the adult league, add players up to 15, then add 16..30 (each should be accepted) and verify 31st is blocked; remove one and add another to ensure add/remove still works; verify counter shows `Обрано: X / 30` and any max message mentions 30.

### Testing
- Ran `node --check v2/scripts/balance2/app.js`, `node --check v2/scripts/balance2/manual.js`, and `node --check v2/scripts/balance2/storage.js`; all checks passed.
- Ran a search (`rg`) for remaining occurrences of `slice(0, 15)`, `selected.length < 15` and related patterns across affected files and verified replacements to `MAX_LOBBY_PLAYERS` — results show no remaining hardcoded 15 in those logic spots.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd5987534832185fa8502bc965403)