### PR TITLE
balance2: додати підтримку 5 команд у v2 UI

### DIFF
--- a/v2/scripts/balance2/state.js
+++ b/v2/scripts/balance2/state.js
@@ -47,6 +47,7 @@ export const state = {
 
 export const MAX_LOBBY_PLAYERS = 30;
 export const TEAM_KEYS = ['team1', 'team2', 'team3', 'team4', 'team5', 'team6'];
+export const TEAM_COUNT_OPTIONS = [2, 3, 4, 5, 6];
 export const MIN_TEAM_COUNT = 2;
 export const MAX_TEAM_COUNT = 6;
 

--- a/v2/scripts/balance2/ui.js
+++ b/v2/scripts/balance2/ui.js
@@ -8,6 +8,7 @@ import {
   getActiveMatchTeams,
   syncSelectedMap,
   TEAM_KEYS,
+  TEAM_COUNT_OPTIONS,
   MAX_LOBBY_PLAYERS,
   normalizeTeamCount,
 } from './state.js';
@@ -104,8 +105,23 @@ export function render() {
 export function renderLeagueControls() {
   const select = document.getElementById('leagueSelect');
   const sortSelect = document.getElementById('sortMode');
+  const teamCountControl = document.getElementById('teamCountControl');
   if (select && select.value !== state.app.league) select.value = state.app.league;
   if (sortSelect && sortSelect.value !== state.app.sortMode) sortSelect.value = state.app.sortMode;
+  if (teamCountControl) {
+    const existing = new Set(Array.from(teamCountControl.querySelectorAll('[data-team-count]'))
+      .map((btn) => Number(btn.dataset.teamCount))
+      .filter(Number.isFinite));
+    TEAM_COUNT_OPTIONS.forEach((count) => {
+      if (existing.has(count)) return;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'chip';
+      btn.dataset.teamCount = String(count);
+      btn.textContent = `${count} команд${count < 5 ? 'и' : ''}`;
+      teamCountControl.appendChild(btn);
+    });
+  }
 
   document.querySelectorAll('[data-team-count]').forEach((btn) => {
     btn.classList.toggle('active', Number(btn.dataset.teamCount) === state.teamsState.teamCount);


### PR DESCRIPTION
### Motivation
- Додати можливість вибрати 5 команд у балансері v2 без зміни формул або редизайну, щоб покрити випадки 5/10/.../30 гравців.

### Description
- Додано централізований список дозволених значень `TEAM_COUNT_OPTIONS = [2, 3, 4, 5, 6]` у `v2/scripts/balance2/state.js` (місце, де зберігаються allowed team counts). 
- Оновлено `renderLeagueControls()` в `v2/scripts/balance2/ui.js`, щоб динамічно додавати кнопки для всіх значень з `TEAM_COUNT_OPTIONS`, через що UI тепер пропонує вибір 5 команд без редизайну статичного HTML. 
- Балансування не мінялося: існуюча логіка приймає динамічний `teamCount` і розподіляє гравців за цільовими розмірами команд, а рендер команд використовує `TEAM_KEYS.slice(0, teamCount)`, тому `team5` рендериться як інші. 
- Manual checks to run: 1) 5 players → choose 5 teams → balance; 2) 10 players → 5 teams → balance; 3) 30 players → 5 teams → balance (expect 5×6); 4) verify 2,3,4,6 teams; 5) try 5 teams with 3 players and confirm an alert is shown rather than an error.

### Testing
- Ran `node --check v2/scripts/balance2/state.js` and it succeeded. 
- Ran `node --check v2/scripts/balance2/ui.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd8841a908321ad4915965c69d92e)