### PR TITLE
balance2: add tournament mode with GAS JSON API (create/save teams/games)

### DIFF
--- a/v2/scripts/balance2/api.js
+++ b/v2/scripts/balance2/api.js
@@ -2,6 +2,7 @@ import { normalizeLeague, state } from './state.js';
 import { loadPlayersCache, savePlayersCache } from './storage.js';
 
 const PROXY_ORIGIN = 'https://laser-proxy.vartaclub.workers.dev';
+const TOURNAMENT_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxzIEh2-gluSxvtUqCDmpGodhFntF-t59Q9OSBEjTxqdfURS3MlYwm6vcZ-1s4XPd0kHQ/exec';
 
 function toFormUrlEncoded(obj = {}) {
   return Object.entries(obj).map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v ?? '')}`).join('&');
@@ -63,4 +64,89 @@ export async function saveMatch(payload, timeoutMs = 20000) {
   } catch (e) {
     return { ok: false, message: e?.name === 'AbortError' ? 'Не вдалося отримати відповідь від сервера' : (e?.message || 'Помилка мережі') };
   }
+}
+
+export async function postTournamentJson(payload, timeoutMs = 20000) {
+  try {
+    const res = await fetchWithTimeout(TOURNAMENT_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload || {}),
+    }, timeoutMs);
+    const data = await res.json();
+    const status = String(data?.status || '').toUpperCase();
+    if (status === 'OK') return { ok: true, data, message: data?.message || 'OK' };
+    return { ok: false, data: data || null, message: data?.message || data?.error || 'Невідома помилка' };
+  } catch (e) {
+    return {
+      ok: false,
+      data: null,
+      message: e?.name === 'AbortError' ? 'Не вдалося отримати відповідь від сервера' : (e?.message || 'Помилка мережі'),
+    };
+  }
+}
+
+export function createTournament(payload = {}) {
+  return postTournamentJson({
+    action: 'createTournament',
+    mode: 'tournament',
+    name: payload.name || '',
+    league: normalizeLeague(payload.league),
+    dateStart: payload.dateStart || '',
+    dateEnd: payload.dateEnd || '',
+    status: payload.status || 'ACTIVE',
+    notes: payload.notes || '',
+  });
+}
+
+export function saveTournamentTeams(payload = {}) {
+  return postTournamentJson({
+    action: 'saveTeams',
+    mode: 'tournament',
+    tournamentId: payload.tournamentId || '',
+    teams: Array.isArray(payload.teams) ? payload.teams : [],
+  });
+}
+
+export function createTournamentGames(payload = {}) {
+  return postTournamentJson({
+    action: 'createGames',
+    mode: 'tournament',
+    tournamentId: payload.tournamentId || '',
+    games: Array.isArray(payload.games) ? payload.games : [],
+  });
+}
+
+export function saveTournamentGame(payload = {}) {
+  return postTournamentJson({
+    action: 'saveGame',
+    mode: 'tournament',
+    tournamentId: payload.tournamentId || '',
+    gameId: payload.gameId || '',
+    gameMode: payload.gameMode || 'DM',
+    teamAId: payload.teamAId || '',
+    teamBId: payload.teamBId || '',
+    result: payload.result || '',
+    mvp1: payload.mvp1 || '',
+    mvp2: payload.mvp2 || '',
+    mvp3: payload.mvp3 || '',
+    notes: payload.notes || '',
+  });
+}
+
+export function getTournamentData(tournamentId) {
+  return postTournamentJson({
+    action: 'getTournamentData',
+    mode: 'tournament',
+    tournamentId: tournamentId || '',
+  });
+}
+
+export function listTournaments({ league, status } = {}) {
+  return postTournamentJson({
+    action: 'listTournaments',
+    mode: 'tournament',
+    league: league ? normalizeLeague(league) : '',
+    status: status || '',
+  });
 }

--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -14,12 +14,12 @@ import {
 import { autoBalance2, balanceIntoNTeams } from './balance.js';
 import { clearTeams, syncSelectedFromTeamsAndBench } from './manual.js';
 import { render, bindUiEvents } from './ui.js';
-import { loadPlayers, saveMatch } from './api.js';
+import { loadPlayers, saveMatch, createTournament, saveTournamentTeams, saveTournamentGame } from './api.js';
 import { saveLobby, restoreLobby, peekLobbyRestore, clearPlayersCache, saveLastSavedGame, readLastSavedGame } from './storage.js';
 import { setStatus, lockSaveButton } from './status.js';
 
 const $ = (id) => document.getElementById(id);
-const TEAM_KEYS = ['team1', 'team2', 'team3', 'team4'];
+const TEAM_KEYS = ['team1', 'team2', 'team3', 'team4', 'team5', 'team6'];
 const LEAGUE_KEY = 'balance2:league';
 let saveLocked = false;
 
@@ -108,7 +108,7 @@ function syncSeriesMirror() {
 }
 
 function setTeamCount(rawValue) {
-  state.teamsState.teamCount = Math.min(4, Math.max(2, Number(rawValue) || 2));
+  state.teamsState.teamCount = Math.min(6, Math.max(2, Number(rawValue) || 2));
   TEAM_KEYS.slice(state.teamsState.teamCount).forEach((key) => { state.teamsState.teams[key] = []; });
   state.matchState.seriesRounds = state.matchState.seriesRounds.map((value) => {
     const numeric = Number(value);
@@ -117,6 +117,10 @@ function setTeamCount(rawValue) {
     return null;
   });
   ensureActiveMatchState();
+  if (state.teamsState.teamCount === 2) {
+    state.activeTeamAId = 'team1';
+    state.activeTeamBId = 'team2';
+  }
   syncSeriesMirror();
 }
 
@@ -134,7 +138,12 @@ function runBalance() {
     });
   }
   state.app.mode = 'auto';
+  if (state.app.eventMode === 'tournament') state.tournamentState.teamsSaved = false;
   ensureActiveMatchState();
+  if (state.teamsState.teamCount === 2) {
+    state.activeTeamAId = 'team1';
+    state.activeTeamBId = 'team2';
+  }
   saveLobby();
 }
 
@@ -148,7 +157,9 @@ function toPenaltiesString() {
 function syncSaveButtonState() {
   const btn = $('saveBtn');
   if (!btn) return;
-  const [teamA, teamB] = getActiveMatchTeams();
+  const [teamA, teamB] = state.app.eventMode === 'tournament'
+    ? [state.activeTeamAId, state.activeTeamBId]
+    : getActiveMatchTeams();
   const hasTeams = state.teamsState.teams[teamA]?.length > 0 && state.teamsState.teams[teamB]?.length > 0;
   const canSave = hasTeams && computeSeriesSummary().played >= 3;
   btn.disabled = saveLocked || !canSave;
@@ -156,6 +167,12 @@ function syncSaveButtonState() {
 
 function renderAndSync() {
   ensureActiveMatchState();
+  const available = getAvailableTeamKeys();
+  const fallbackA = available[0] || 'team1';
+  const fallbackB = available.find((key) => key !== fallbackA) || 'team2';
+  if (!available.includes(state.activeTeamAId)) state.activeTeamAId = fallbackA;
+  if (!available.includes(state.activeTeamBId) || state.activeTeamBId === state.activeTeamAId) state.activeTeamBId = fallbackB;
+  cleanupTournamentMvp();
   render();
   syncSaveButtonState();
 }
@@ -181,6 +198,35 @@ function buildPayload() {
   };
 }
 
+function buildTournamentTeamsPayload() {
+  return TEAM_KEYS
+    .slice(0, state.teamsState.teamCount)
+    .filter((teamId) => (state.teamsState.teams[teamId] || []).length > 0)
+    .map((teamId) => ({
+      teamId,
+      teamName: state.teamsState.teamNames[teamId] || `Команда ${teamId.replace('team', '')}`,
+      players: [...(state.teamsState.teams[teamId] || [])],
+    }));
+}
+
+function buildTournamentGamePayload() {
+  const gameId = state.tournamentState.currentGameId || `G${String(state.tournamentState.nextGameNumber).padStart(3, '0')}`;
+  const summary = computeSeriesSummary();
+  const result = summary.winner === 'tie' ? 'DRAW' : (summary.winner === 'team1' ? 'A' : 'B');
+  return {
+    tournamentId: state.tournamentState.tournamentId,
+    gameId,
+    gameMode: state.tournamentState.gameMode,
+    teamAId: state.activeTeamAId,
+    teamBId: state.activeTeamBId,
+    result,
+    mvp1: state.matchState.match.mvp1 || '',
+    mvp2: state.matchState.match.mvp2 || '',
+    mvp3: state.matchState.match.mvp3 || '',
+    notes: toPenaltiesString(),
+  };
+}
+
 function resetMatchOnlyState() {
   state.matchState.seriesRounds = Array(7).fill(null);
   state.matchState.series = ['-', '-', '-', '-', '-', '-', '-'];
@@ -193,6 +239,22 @@ function resetMatchOnlyState() {
 }
 
 function validateSave() {
+  if (state.app.eventMode === 'tournament') {
+    if (!state.tournamentState.tournamentId) return 'Спочатку створіть турнір';
+    if (!state.tournamentState.teamsSaved) return 'Спочатку збережіть команди турніру';
+    if (!state.activeTeamAId || !state.activeTeamBId) return 'Виберіть активні команди';
+    if (state.activeTeamAId === state.activeTeamBId) return 'Команда A і Команда B мають бути різними';
+    const teamAPlayers = state.teamsState.teams[state.activeTeamAId] || [];
+    const teamBPlayers = state.teamsState.teams[state.activeTeamBId] || [];
+    if (!teamAPlayers.length || !teamBPlayers.length) return 'Обидві активні команди мають містити гравців';
+    if (!['DM', 'TR', 'KT'].includes(state.tournamentState.gameMode)) return 'Невірний режим бою';
+    if (state.tournamentState.gameMode === 'KT' && computeSeriesSummary().winner === 'tie') return 'Для KT нічия недоступна';
+    const allowed = new Set([...teamAPlayers, ...teamBPlayers]);
+    for (const id of ['mvp1', 'mvp2', 'mvp3']) {
+      const nick = state.matchState.match[id];
+      if (nick && !allowed.has(nick)) return `${id.toUpperCase()} має бути з активних команд`;
+    }
+  }
   const [teamA, teamB] = getActiveMatchTeams();
   if (!state.teamsState.teams[teamA]?.length || !state.teamsState.teams[teamB]?.length) return 'Активні команди не заповнені';
   if (computeSeriesSummary().played < 3) return 'Потрібно мінімум 3 зіграні бої';
@@ -231,7 +293,7 @@ async function doSave(retry = false) {
     return;
   }
 
-  const payload = retry ? state.meta.lastPayload : buildPayload();
+  const payload = retry ? state.meta.lastPayload : (state.app.eventMode === 'tournament' ? buildTournamentGamePayload() : buildPayload());
   state.meta.lastPayload = payload;
 
   saveLocked = true;
@@ -239,8 +301,26 @@ async function doSave(retry = false) {
   syncSaveButtonState();
   setStatus({ state: 'saving', text: 'Зберігаю…', retryVisible: false });
 
-  const res = await saveMatch(payload, 20000);
+  const res = state.app.eventMode === 'tournament'
+    ? await saveTournamentGame(payload)
+    : await saveMatch(payload, 20000);
   if (res.ok) {
+    if (state.app.eventMode === 'tournament') {
+      const snapshot = createLastSavedSnapshot();
+      state.lastSavedGame = snapshot;
+      saveLastSavedGame(snapshot);
+      state.tournamentState.nextGameNumber += 1;
+      state.tournamentState.currentGameId = '';
+      resetMatchOnlyState();
+      syncSeriesMirror();
+      saveLobby();
+      setStatus({ state: 'saved', text: '✅ Турнірний матч збережено', retryVisible: false });
+      renderAndSync();
+      saveLocked = false;
+      lockSaveButton(false);
+      syncSaveButtonState();
+      return;
+    }
     try {
       clearPlayersCache(state.app.league);
       const freshPlayers = await loadPlayers(state.app.league, { force: true, timeoutMs: 15000 });
@@ -278,6 +358,7 @@ function toggleSelectedPlayer(nick) {
     state.playersState.selected = [...state.playersState.selected, nick];
   }
   syncSelectedMap();
+  if (state.app.eventMode === 'tournament' && state.tournamentState.teamsSaved) state.tournamentState.teamsSaved = false;
   ensureActiveMatchState();
 }
 
@@ -296,8 +377,16 @@ function saveTeamName(teamKey, rawValue) {
   const value = String(rawValue || '').trim();
   state.teamsState.teamNames[teamKey] = value || `Команда ${teamKey.replace('team', '')}`;
   ensureActiveMatchState();
+  if (state.app.eventMode === 'tournament') state.tournamentState.teamsSaved = false;
   saveLobby();
   renderAndSync();
+}
+
+function cleanupTournamentMvp() {
+  const allowed = new Set([...(state.teamsState.teams[state.activeTeamAId] || []), ...(state.teamsState.teams[state.activeTeamBId] || [])]);
+  ['mvp1', 'mvp2', 'mvp3'].forEach((id) => {
+    if (state.matchState.match[id] && !allowed.has(state.matchState.match[id])) state.matchState.match[id] = '';
+  });
 }
 
 async function ensurePlayersLoaded({ force = false } = {}) {
@@ -348,6 +437,7 @@ async function init() {
     state.playersState.selected = [];
     syncSelectedMap();
     clearTeams();
+    state.tournamentState.teamsSaved = false;
     ensureActiveMatchState();
     saveLobby();
     renderAndSync();
@@ -361,8 +451,8 @@ async function init() {
 
   $('loadPlayersBtn')?.addEventListener('click', () => ensurePlayersLoaded({ force: true }));
   $('balanceBtn')?.addEventListener('click', () => { runBalance(); renderAndSync(); });
-  $('manualBtn')?.addEventListener('click', () => { state.app.mode = 'manual'; syncSelectedFromTeamsAndBench(); ensureActiveMatchState(); saveLobby(); renderAndSync(); });
-  $('clearLobbyBtn')?.addEventListener('click', () => { state.playersState.selected = []; syncSelectedMap(); clearTeams(); ensureActiveMatchState(); saveLobby(); renderAndSync(); });
+  $('manualBtn')?.addEventListener('click', () => { state.app.mode = 'manual'; syncSelectedFromTeamsAndBench(); ensureActiveMatchState(); state.tournamentState.teamsSaved = false; saveLobby(); renderAndSync(); });
+  $('clearLobbyBtn')?.addEventListener('click', () => { state.playersState.selected = []; syncSelectedMap(); clearTeams(); ensureActiveMatchState(); state.tournamentState.teamsSaved = false; saveLobby(); renderAndSync(); });
 
   const debouncedSearch = (() => {
     let timer;
@@ -375,7 +465,13 @@ async function init() {
 
   ['mvp1', 'mvp2', 'mvp3'].forEach((id) => {
     $(id)?.addEventListener('input', (e) => {
-      state.matchState.match[id] = e.target.value.trim();
+      const value = e.target.value.trim();
+      if (state.app.eventMode === 'tournament') {
+        const allowed = new Set([...(state.teamsState.teams[state.activeTeamAId] || []), ...(state.teamsState.teams[state.activeTeamBId] || [])]);
+        state.matchState.match[id] = allowed.has(value) || !value ? value : '';
+      } else {
+        state.matchState.match[id] = value;
+      }
       saveLobby();
     });
   });
@@ -436,7 +532,18 @@ async function init() {
     },
     onRenameStart(teamKey) { startRenameTeam(teamKey); },
     onRenameSave(teamKey, value) { saveTeamName(teamKey, value); },
-    onChanged() { syncSelectedFromTeamsAndBench(); ensureActiveMatchState(); saveLobby(); renderAndSync(); },
+    onChanged() {
+      syncSelectedFromTeamsAndBench();
+      ensureActiveMatchState();
+      if (state.app.eventMode === 'tournament') state.tournamentState.teamsSaved = false;
+      if (state.teamsState.teamCount === 2) {
+        state.activeTeamAId = 'team1';
+        state.activeTeamBId = 'team2';
+      }
+      cleanupTournamentMvp();
+      saveLobby();
+      renderAndSync();
+    },
     onMatchMode(mode) {
       state.activeMatch.mode = mode;
       ensureActiveMatchState();
@@ -448,6 +555,85 @@ async function init() {
       if (side === 'B') state.activeMatch.teamB = teamKey;
       ensureActiveMatchState();
       saveLobby();
+      renderAndSync();
+    },
+    onEventMode(mode) {
+      state.app.eventMode = mode === 'tournament' ? 'tournament' : 'regular';
+      syncSaveButtonState();
+      saveLobby();
+      renderAndSync();
+    },
+    onTournamentName(name) {
+      state.tournamentState.tournamentName = String(name || '').trimStart();
+      saveLobby();
+    },
+    onTournamentGameMode(mode) {
+      state.tournamentState.gameMode = ['DM', 'TR', 'KT'].includes(mode) ? mode : 'DM';
+      saveLobby();
+      renderAndSync();
+    },
+    onTournamentTeamPick(side, teamKey) {
+      if (side === 'A') state.activeTeamAId = teamKey;
+      if (side === 'B') state.activeTeamBId = teamKey;
+      if (state.activeTeamAId === state.activeTeamBId) {
+        setStatus({ state: 'error', text: '❌ Команда A і Команда B не можуть бути однаковими', retryVisible: false });
+      }
+      cleanupTournamentMvp();
+      saveLobby();
+      renderAndSync();
+    },
+    async onCreateTournament() {
+      if (state.app.eventMode !== 'tournament') return;
+      if (!state.tournamentState.tournamentName.trim()) {
+        setStatus({ state: 'error', text: '❌ Вкажіть назву турніру', retryVisible: false });
+        return;
+      }
+      if (!state.app.league) {
+        setStatus({ state: 'error', text: '❌ Оберіть лігу', retryVisible: false });
+        return;
+      }
+      setStatus({ state: 'saving', text: 'Створюю турнір…', retryVisible: false });
+      const res = await createTournament({
+        name: state.tournamentState.tournamentName,
+        league: state.app.league,
+        dateStart: new Date().toISOString().slice(0, 10),
+        dateEnd: '',
+        status: 'ACTIVE',
+        notes: '',
+      });
+      if (!res.ok) {
+        setStatus({ state: 'error', text: `❌ ${res.message}`, retryVisible: false });
+        return;
+      }
+      state.tournamentState.tournamentId = res.data?.tournamentId || res.data?.data?.tournamentId || '';
+      state.tournamentState.teamsSaved = false;
+      saveLobby();
+      setStatus({ state: 'saved', text: `✅ Турнір створено: ${state.tournamentState.tournamentId || 'ID невідомий'}`, retryVisible: false });
+      renderAndSync();
+    },
+    async onSaveTournamentTeams() {
+      if (state.app.eventMode !== 'tournament') return;
+      if (!state.tournamentState.tournamentId) {
+        setStatus({ state: 'error', text: '❌ Спочатку створіть турнір', retryVisible: false });
+        return;
+      }
+      const teams = buildTournamentTeamsPayload();
+      if (teams.length < 2 || teams.some((team) => !team.players.length)) {
+        setStatus({ state: 'error', text: '❌ Потрібно мінімум 2 непорожні команди', retryVisible: false });
+        return;
+      }
+      setStatus({ state: 'saving', text: 'Зберігаю команди турніру…', retryVisible: false });
+      const res = await saveTournamentTeams({
+        tournamentId: state.tournamentState.tournamentId,
+        teams,
+      });
+      if (!res.ok) {
+        setStatus({ state: 'error', text: `❌ ${res.message}`, retryVisible: false });
+        return;
+      }
+      state.tournamentState.teamsSaved = true;
+      saveLobby();
+      setStatus({ state: 'saved', text: '✅ Команди турніру збережено', retryVisible: false });
       renderAndSync();
     },
     onSchedulePick(matchId) {

--- a/v2/scripts/balance2/state.js
+++ b/v2/scripts/balance2/state.js
@@ -2,6 +2,7 @@ export const state = {
   app: {
     league: 'kids',
     mode: 'auto',
+    eventMode: 'regular',
     sortMode: 'points_desc',
     query: '',
   },
@@ -36,6 +37,17 @@ export const state = {
     schedule: [],
     selectedScheduleMatchId: '',
   },
+  tournamentState: {
+    tournamentId: '',
+    tournamentName: '',
+    gameMode: 'DM',
+    teamsSaved: false,
+    gamesCreated: false,
+    currentGameId: '',
+    nextGameNumber: 1,
+  },
+  activeTeamAId: 'team1',
+  activeTeamBId: 'team2',
   uiState: {
     penaltiesCollapsed: true,
   },

--- a/v2/scripts/balance2/storage.js
+++ b/v2/scripts/balance2/storage.js
@@ -19,6 +19,9 @@ export function saveLobby() {
     teamsState: state.teamsState,
     matchState: state.matchState,
     activeMatch: state.activeMatch,
+    tournamentState: state.tournamentState,
+    activeTeamAId: state.activeTeamAId,
+    activeTeamBId: state.activeTeamBId,
     uiState: state.uiState,
   };
   localStorage.setItem(KEY, JSON.stringify(data));
@@ -37,6 +40,7 @@ export function restoreLobby() {
   state.app.sortMode = ['name_asc', 'name_desc', 'points_desc', 'points_asc'].includes(data?.app?.sortMode || data?.sortMode)
     ? (data?.app?.sortMode || data?.sortMode)
     : 'points_desc';
+  state.app.eventMode = (data?.app?.eventMode === 'tournament' ? 'tournament' : 'regular');
   state.app.query = '';
 
   state.playersState.selected = Array.isArray(data?.playersState?.selected || data?.selected)
@@ -44,13 +48,15 @@ export function restoreLobby() {
     : [];
   syncSelectedMap();
 
-  state.teamsState.teamCount = Math.min(4, Math.max(2, Number(data?.teamsState?.teamCount || data?.teamCount || data?.teamsCount) || 2));
+  state.teamsState.teamCount = Math.min(6, Math.max(2, Number(data?.teamsState?.teamCount || data?.teamCount || data?.teamsCount) || 2));
   const restoredTeams = data?.teamsState?.teams || data?.teams || {};
   state.teamsState.teams = {
     team1: Array.isArray(restoredTeams.team1) ? restoredTeams.team1 : [],
     team2: Array.isArray(restoredTeams.team2) ? restoredTeams.team2 : [],
     team3: Array.isArray(restoredTeams.team3) ? restoredTeams.team3 : [],
     team4: Array.isArray(restoredTeams.team4) ? restoredTeams.team4 : [],
+    team5: Array.isArray(restoredTeams.team5) ? restoredTeams.team5 : [],
+    team6: Array.isArray(restoredTeams.team6) ? restoredTeams.team6 : [],
   };
 
   const names = data?.teamsState?.teamNames || data?.teamNames || {};
@@ -59,6 +65,8 @@ export function restoreLobby() {
     team2: String(names.team2 || 'Команда 2').trim() || 'Команда 2',
     team3: String(names.team3 || 'Команда 3').trim() || 'Команда 3',
     team4: String(names.team4 || 'Команда 4').trim() || 'Команда 4',
+    team5: String(names.team5 || 'Команда 5').trim() || 'Команда 5',
+    team6: String(names.team6 || 'Команда 6').trim() || 'Команда 6',
   };
 
   const matchState = data?.matchState || {};
@@ -85,6 +93,18 @@ export function restoreLobby() {
     schedule: Array.isArray(data?.activeMatch?.schedule) ? data.activeMatch.schedule : [],
     selectedScheduleMatchId: data?.activeMatch?.selectedScheduleMatchId || '',
   };
+  const tournamentState = data?.tournamentState || {};
+  state.tournamentState = {
+    tournamentId: tournamentState.tournamentId || '',
+    tournamentName: tournamentState.tournamentName || '',
+    gameMode: ['DM', 'TR', 'KT'].includes(tournamentState.gameMode) ? tournamentState.gameMode : 'DM',
+    teamsSaved: tournamentState.teamsSaved === true,
+    gamesCreated: tournamentState.gamesCreated === true,
+    currentGameId: tournamentState.currentGameId || '',
+    nextGameNumber: Math.max(1, Number(tournamentState.nextGameNumber) || 1),
+  };
+  state.activeTeamAId = data?.activeTeamAId || 'team1';
+  state.activeTeamBId = data?.activeTeamBId || 'team2';
 
   state.uiState.penaltiesCollapsed = data?.uiState?.penaltiesCollapsed !== false;
 

--- a/v2/scripts/balance2/ui.js
+++ b/v2/scripts/balance2/ui.js
@@ -195,13 +195,11 @@ export function renderTeams() {
 export function renderMatchConfig() {
   const root = document.getElementById('activeMatchConfig');
   if (!root) return;
+  const eventMode = state.app.eventMode === 'tournament' ? 'tournament' : 'regular';
   const keys = getAvailableTeamKeys();
-  if (keys.length <= 2) {
-    root.innerHTML = '';
-    return;
-  }
-
-  const [teamA, teamB] = getActiveMatchTeams();
+  const [teamA, teamB] = eventMode === 'tournament'
+    ? [state.activeTeamAId || 'team1', state.activeTeamBId || 'team2']
+    : getActiveMatchTeams();
   const teamOptions = (current, other, side) => keys.map((key) => `<option value="${key}" ${key === current ? 'selected' : ''} ${key === other ? 'disabled' : ''}>${escapeHtml(getTeamLabel(key))} (${side})</option>`).join('');
 
   const scheduleItems = state.activeMatch.schedule.map((match) => {
@@ -210,7 +208,7 @@ export function renderMatchConfig() {
     return `<label class="schedule-item ${selected ? 'active' : ''}"><input type="radio" name="scheduleMatch" data-schedule-pick="${escapeAttr(match.id)}" ${selected ? 'checked' : ''}/><span>${escapeHtml(match.label)}</span>${status}</label>`;
   }).join('');
 
-  root.innerHTML = `
+  const regularContent = keys.length <= 2 ? '' : `
     <div class="series-count"><span>Режим бою:</span><div class="series-count-choices">
       <button class="chip ${state.activeMatch.mode === 'manual' ? 'active' : ''}" type="button" data-match-mode="manual">Ручний вибір</button>
       <button class="chip ${state.activeMatch.mode === 'schedule' ? 'active' : ''}" type="button" data-match-mode="schedule">Розклад ігор</button>
@@ -222,12 +220,41 @@ export function renderMatchConfig() {
       </div>
     ` : `<div class="schedule-list">${scheduleItems}</div>`}
   `;
+
+  root.innerHTML = `
+    <div class="series-count"><span>Режим:</span><div class="series-count-choices">
+      <button class="chip ${eventMode === 'regular' ? 'active' : ''}" type="button" data-event-mode="regular">Звичайний матч</button>
+      <button class="chip ${eventMode === 'tournament' ? 'active' : ''}" type="button" data-event-mode="tournament">Турнір</button>
+    </div></div>
+    ${eventMode === 'regular' ? regularContent : `
+      <div class="tournament-panel">
+        <label>Назва турніру <input class="search-input" data-tournament-name type="text" value="${escapeAttr(state.tournamentState.tournamentName || '')}" placeholder="Весняний турнір"></label>
+        <label>Режим бою
+          <select class="chip" data-tournament-game-mode>
+            ${['DM', 'TR', 'KT'].map((mode) => `<option value="${mode}" ${state.tournamentState.gameMode === mode ? 'selected' : ''}>${mode}</option>`).join('')}
+          </select>
+        </label>
+        <div class="row-btns">
+          <button class="chip" type="button" data-tournament-create="1">Створити турнір</button>
+          <button class="chip" type="button" data-tournament-save-teams="1">Зберегти команди</button>
+        </div>
+        <div class="tag">Tournament ID: ${escapeHtml(state.tournamentState.tournamentId || '—')}</div>
+        <div class="tag">Teams saved: ${state.tournamentState.teamsSaved ? '✅ так' : '❗ ні'}</div>
+      </div>
+      <div class="match-pick-grid">
+        <label>Команда A <select data-tournament-team="A">${teamOptions(teamA, teamB, 'A')}</select></label>
+        <label>Команда B <select data-tournament-team="B">${teamOptions(teamB, teamA, 'B')}</select></label>
+      </div>
+    `}
+  `;
 }
 
 export function renderMatchTeams() {
   const root = document.getElementById('matchTeamsPreview');
   if (!root) return;
-  const [teamA, teamB] = getActiveMatchTeams();
+  const [teamA, teamB] = state.app.eventMode === 'tournament'
+    ? [state.activeTeamAId || 'team1', state.activeTeamBId || 'team2']
+    : getActiveMatchTeams();
   const matchTitle = document.getElementById('activeMatchLabel');
   if (matchTitle) matchTitle.textContent = `${getTeamLabel(teamA)} vs ${getTeamLabel(teamB)}`;
 
@@ -291,7 +318,9 @@ export function renderPenalties() {
 }
 
 export function renderMatchFields() {
-  const participants = [...new Set(getParticipants())];
+  const participants = state.app.eventMode === 'tournament'
+    ? [...new Set([...(state.teamsState.teams[state.activeTeamAId] || []), ...(state.teamsState.teams[state.activeTeamBId] || [])])]
+    : [...new Set(getParticipants())];
   const dl = document.getElementById('participantsDatalist');
   if (dl) dl.innerHTML = participants.map((nick) => `<option value="${escapeAttr(nick)}"></option>`).join('');
 
@@ -358,9 +387,15 @@ export function bindUiEvents(handlers) {
     const matchMode = e.target.closest('[data-match-mode]')?.dataset.matchMode;
     const teamPick = e.target.closest('select[data-match-team]');
     const schedulePick = e.target.closest('[data-schedule-pick]')?.dataset.schedulePick;
+    const eventMode = e.target.closest('[data-event-mode]')?.dataset.eventMode;
+    const tournamentTeamPick = e.target.closest('select[data-tournament-team]');
+    const gameModePick = e.target.closest('select[data-tournament-game-mode]');
     if (matchMode) handlers.onMatchMode(matchMode);
     if (teamPick) handlers.onMatchTeamPick(teamPick.dataset.matchTeam, teamPick.value);
     if (schedulePick) handlers.onSchedulePick(schedulePick);
+    if (eventMode) handlers.onEventMode(eventMode);
+    if (tournamentTeamPick) handlers.onTournamentTeamPick(tournamentTeamPick.dataset.tournamentTeam, tournamentTeamPick.value);
+    if (gameModePick) handlers.onTournamentGameMode(gameModePick.value);
   });
 
   document.addEventListener('click', (e) => {
@@ -374,6 +409,9 @@ export function bindUiEvents(handlers) {
     const renameTeam = e.target.closest('[data-rename-team]')?.dataset.renameTeam;
     const penaltiesToggle = e.target.closest('[data-toggle-penalties]');
     const matchMode = e.target.closest('[data-match-mode]')?.dataset.matchMode;
+    const eventMode = e.target.closest('[data-event-mode]')?.dataset.eventMode;
+    const createTournament = e.target.closest('[data-tournament-create]');
+    const saveTeams = e.target.closest('[data-tournament-save-teams]');
 
     if (toggle) {
       const alreadySelected = state.playersState.selectedMap.has(toggle);
@@ -417,6 +455,14 @@ export function bindUiEvents(handlers) {
     if (renameTeam) handlers.onRenameStart(renameTeam);
     if (penaltiesToggle) handlers.onTogglePenalties();
     if (matchMode) handlers.onMatchMode(matchMode);
+    if (eventMode) handlers.onEventMode(eventMode);
+    if (createTournament) handlers.onCreateTournament();
+    if (saveTeams) handlers.onSaveTournamentTeams();
+  });
+
+  document.addEventListener('input', (e) => {
+    const tournamentNameInput = e.target.closest('[data-tournament-name]');
+    if (tournamentNameInput) handlers.onTournamentName(tournamentNameInput.value);
   });
 
   document.addEventListener('keydown', (e) => {

--- a/v2/styles/balance2.css
+++ b/v2/styles/balance2.css
@@ -121,7 +121,15 @@ nav, .header, .menu, .burger, .hamburger { display: none !important; }
 
 .match-config,
 .schedule-list,
-.match-pick-grid { display: grid; gap: .45rem; }
+.match-pick-grid,
+.tournament-panel { display: grid; gap: .45rem; }
+
+.tournament-panel {
+  border: 1px solid rgba(255,255,255,.12);
+  border-radius: .65rem;
+  padding: .55rem;
+  background: rgba(255,255,255,.02);
+}
 
 .match-pick-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .match-pick-grid select { width: 100%; }


### PR DESCRIPTION
### Motivation
- Add a tournament mode to the balance2 UI that stores tournament teams/games via the provided Google Apps Script JSON endpoint while preserving the existing regular save/rating flow. 
- Support 2–6 teams, keep lobby/teams intact after tournament saves, and restrict MVP selection to the two active teams for each tournament match.

### Description
- Modified files: `v2/scripts/balance2/api.js`, `v2/scripts/balance2/state.js`, `v2/scripts/balance2/ui.js`, `v2/scripts/balance2/app.js`, `v2/scripts/balance2/storage.js`, and small CSS in `v2/styles/balance2.css` to add minimal tournament UI styling.
- API: added `postTournamentJson(payload, timeoutMs)` and helpers `createTournament`, `saveTournamentTeams`, `createTournamentGames`, `saveTournamentGame`, `getTournamentData`, and `listTournaments` that post JSON to the GAS endpoint and normalize `{ ok, data, message }` responses.
- State: added `app.eventMode` (defaults to `regular`), `tournamentState` (id, name, gameMode, teamsSaved, gamesCreated, currentGameId, nextGameNumber) and `activeTeamAId`/`activeTeamBId`, and persisted them via `storage.js`.
- UI: added a small mode switch (`Звичайний матч` / `Турнір`), tournament panel (tournament name, `DM/TR/KT` selector, `Створити турнір`, `Зберегти команди`, tournamentId and teamsSaved status), and active team selectors (A/B) showing up to `team6`; MVP datalist is limited to players from active A/B teams in tournament mode.
- Save flow: `doSave()` is split by `state.app.eventMode`: regular uses existing `saveMatch`, tournament validates (`tournamentId`, `teamsSaved`, distinct active teams, non-empty teams, valid `gameMode`, MVPs belong to active teams, KT disallows draw) and uses `saveTournamentGame` with `result` mapped to `A|B|DRAW`; on success only match-level fields are cleared and `nextGameNumber` is incremented while lobby/teams remain unchanged.
- 5/6 team support: team count limits raised to 6, selectors and `saveTournamentTeams` payload include `team5`/`team6` where present.

### Testing
- Performed static syntax/type checks with Node: `node --check` on `v2/scripts/balance2/api.js`, `state.js`, `ui.js`, `app.js`, and `storage.js`; the checks succeeded.
- Verified changes were committed locally (commit message: `balance2: add tournament mode save flow via GAS JSON API`).
- No automated browser / e2e tests were run in this patch; manual test checklist (regular save, create tournament, save teams, save tournament match, MVP/selection/KT rules, 5/6 teams) is provided for QA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edebd84dfc8321855243dca83605f1)