### PR TITLE
v2: add public read-only "Турніри" page and home entry (#tournaments)

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -259,6 +259,65 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   font-size: .82rem;
 }
 
+.tournaments-page {
+  display: grid;
+  gap: .75rem;
+}
+
+.tournaments-hero,
+.tournament-dashboard,
+.home-tournaments-card {
+  background: linear-gradient(165deg, rgba(49,208,255,.12), rgba(124,255,114,.06));
+  border: 1px solid rgba(255,255,255,.14);
+}
+
+.tournament-list {
+  display: grid;
+  gap: .65rem;
+}
+
+.tournament-card {
+  border: 1px solid rgba(255,255,255,.12);
+}
+
+.tournament-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .45rem;
+  margin-bottom: .6rem;
+}
+
+.tournament-tab {
+  border: 1px solid rgba(255,255,255,.16);
+  background: rgba(255,255,255,.05);
+  color: var(--text);
+  padding: .45rem .65rem;
+}
+
+.tournament-tab.is-active {
+  border-color: rgba(49,208,255,.7);
+  background: rgba(49,208,255,.16);
+}
+
+.tournament-table-wrap {
+  overflow-x: auto;
+  border: 1px solid rgba(255,255,255,.12);
+}
+
+.tournament-team-grid {
+  display: grid;
+  gap: .6rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.tournament-match-card {
+  margin-bottom: .55rem;
+}
+
+.tournament-player-table {
+  min-width: 760px;
+}
+
 .home-v2 .home-rank-badge {
   border-radius: 0 !important;
   width: 32px;

--- a/v2/core/router.js
+++ b/v2/core/router.js
@@ -2,7 +2,7 @@ import { ensureGlobalStyles } from '../pages/global-styles.js';
 import { normalizeLeague } from './naming.js';
 
 const templateCache = new Map();
-const knownRoutes = new Set(['main', 'seasons', 'season', 'league-stats', 'player', 'gameday', 'rules']);
+const knownRoutes = new Set(['main', 'seasons', 'season', 'league-stats', 'player', 'gameday', 'rules', 'tournaments']);
 
 function getView() {
   return document.getElementById('view');
@@ -48,6 +48,7 @@ function toHashFromHref(href = '') {
   if (/index\.html$|pages\/index\.html$/.test(pathOnly)) return buildHash('main');
   if (/seasons\.html$|pages\/seasons\.html$/.test(pathOnly)) return buildHash('seasons');
   if (/rules\.html$|pages\/rules\.html$/.test(pathOnly)) return buildHash('rules');
+  if (/tournaments\.html$|pages\/tournaments\.html$/.test(pathOnly)) return buildHash('tournaments');
 
   if (/season\.html$|pages\/season\.html$/.test(pathOnly)) {
     return buildHash('season', { season: qp.get('season') || '', league: qp.get('league') || '' });
@@ -238,6 +239,15 @@ async function renderRoute() {
       await mountTemplate('./pages/rules.html');
       const { initRulesPage } = await import('../pages/rules.js');
       await runPageInit(route, initRulesPage);
+      return;
+    }
+
+    if (route === 'tournaments') {
+      await mountTemplate('./pages/tournaments.html');
+      const { initTournamentsPage } = await import('../pages/tournaments.js');
+      await runPageInit(route, initTournamentsPage, {
+        selected: queryParams.selected || queryParams.id || ''
+      });
       return;
     }
 

--- a/v2/pages/home.js
+++ b/v2/pages/home.js
@@ -7,6 +7,7 @@ const STATS_LINKS = {
   kids: '#league-stats?league=kids'
 };
 const FALLBACK_AVATAR = 'data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2248%22 height=%2248%22 viewBox=%220 0 48 48%22%3E%3Crect width=%2248%22 height=%2248%22 fill=%22%23121a2a%22/%3E%3Ccircle cx=%2224%22 cy=%2218%22 r=%229%22 fill=%22%235b6c89%22/%3E%3Crect x=%2211%22 y=%2230%22 width=%2226%22 height=%2212%22 rx=%220%22 fill=%22%235b6c89%22/%3E%3C/svg%3E';
+const TOURNAMENTS_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxzIEh2-gluSxvtUqCDmpGodhFntF-t59Q9OSBEjTxqdfURS3MlYwm6vcZ-1s4XPd0kHQ/exec';
 
 function esc(v) {
   return String(v ?? '')
@@ -125,6 +126,37 @@ function renderLeagueSection({ league, players }) {
     <article class="home-panel home-section-panel">${currentRankingCard(players)}</article>
     <div class="home-cta-row"><a class="btn btn--secondary" href="${statsLink}">Детальна статистика</a></div>
   </section>`;
+}
+
+function renderHomeTournamentsCard(items = []) {
+  const list = (items || []).slice(0, 2).map((item) => (
+    `<li>${escapeHtml(item?.name || item?.tournamentId || 'Турнір')}</li>`
+  )).join('');
+  return `<section class="px-card home-tournaments-card">
+    <h3 class="px-card__title">Активні турніри</h3>
+    <p class="px-card__text">Слідкуй за командними битвами, MVP і таблицею турніру</p>
+    ${list ? `<ul class="list-clean">${list}</ul>` : ''}
+    <div class="px-card__actions"><a class="btn btn--secondary" href="#tournaments">Перейти до турнірів</a></div>
+  </section>`;
+}
+
+async function fetchHomeTournaments() {
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), 7000);
+  try {
+    const response = await fetch(TOURNAMENTS_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'listTournaments', mode: 'tournament', status: 'ACTIVE' }),
+      signal: controller.signal
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const json = await response.json();
+    if (json?.status === 'ERR') throw new Error(json?.message || 'GAS error');
+    return Array.isArray(json?.tournaments) ? json.tournaments : [];
+  } finally {
+    window.clearTimeout(timer);
+  }
 }
 
 function renderHomeLoadingSkeleton() {
@@ -315,14 +347,16 @@ async function safeInitHomePage(root) {
       <section class="hero home-hero"><span class="hero__kicker">ВАРТА КЛУБ</span><h1 class="hero__title">ЛАЗЕРТАГ РЕЙТИНГ</h1><p class="home-current-season">Весняний сезон 2026 року</p><p class="px-card__text" id="stateBox" aria-live="polite" hidden></p></section>
       <div class="px-divider"></div>
       <section class="section" id="leadersNowMount"></section>
+      <section class="section" id="homeTournamentsMount"></section>
       <section class="section" id="leagueSections"></section>
     </div>`;
 
   const lifecycle = setHomeLoadingLifecycle(root);
   const stateBox = document.getElementById('stateBox');
   const leadersNowMount = document.getElementById('leadersNowMount');
+  const homeTournamentsMount = document.getElementById('homeTournamentsMount');
   const leagueSections = document.getElementById('leagueSections');
-  if (!stateBox || !leadersNowMount || !leagueSections) {
+  if (!stateBox || !leadersNowMount || !leagueSections || !homeTournamentsMount) {
     lifecycle.destroy();
     lifecycle.revealContent();
     return;
@@ -332,6 +366,7 @@ async function safeInitHomePage(root) {
     stateBox.hidden = false;
     stateBox.textContent = 'Дані тимчасово недоступні';
     leadersNowMount.innerHTML = renderLeadersNow(null, null);
+    homeTournamentsMount.innerHTML = renderHomeTournamentsCard([]);
     leagueSections.innerHTML = '';
   };
 
@@ -363,6 +398,14 @@ async function safeInitHomePage(root) {
     const kidsPlayers = pickSeasonActive(kidsLive?.players || []);
 
     leadersNowMount.innerHTML = renderLeadersNow(adultsPlayers[0] || null, kidsPlayers[0] || null);
+    homeTournamentsMount.innerHTML = renderHomeTournamentsCard([]);
+    fetchHomeTournaments()
+      .then((items) => {
+        homeTournamentsMount.innerHTML = renderHomeTournamentsCard(items);
+      })
+      .catch((error) => {
+        console.warn('[home] tournaments unavailable', error);
+      });
 
     leagueSections.innerHTML = HOME_LEAGUES.map((league) => renderLeagueSection({
       league,

--- a/v2/pages/tournaments.html
+++ b/v2/pages/tournaments.html
@@ -1,24 +1,3 @@
-<!DOCTYPE html>
-<html lang="uk">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tournaments | v2</title>
-  <script type="module" src="./global-styles.js"></script>
-</head>
-<body>
-  <header class="topbar">
-    <div class="brand">Tournaments</div>
-    <a class="nav-link" href="#home">Menu</a>
-  </header>
-  <main>
-    <section class="card">
-      <h1 class="section-title">Tournaments</h1>
-      <div class="placeholder" id="placeholder">
-        Заглушка: структура підготовлена під майбутні турнірні сітки,
-        результати та сторінки окремих подій.
-      </div>
-    </section>
-  </main>
-  </body>
-</html>
+<main>
+  <section class="tournaments-page" id="tournamentsRoot"></section>
+</main>

--- a/v2/pages/tournaments.js
+++ b/v2/pages/tournaments.js
@@ -1,0 +1,346 @@
+const TOURNAMENTS_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxzIEh2-gluSxvtUqCDmpGodhFntF-t59Q9OSBEjTxqdfURS3MlYwm6vcZ-1s4XPd0kHQ/exec';
+
+function toNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function toText(value, fallback = '—') {
+  const text = String(value ?? '').trim();
+  return text || fallback;
+}
+
+function createElement(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function clear(node) {
+  if (node) node.replaceChildren();
+}
+
+function statusBlock(text, className = 'px-card') {
+  const wrap = createElement('article', `${className} tournament-status`);
+  const p = createElement('p', 'px-card__text', text);
+  wrap.append(p);
+  return wrap;
+}
+
+async function postTournamentJson(payload, timeoutMs = 20000) {
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(TOURNAMENTS_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const json = await response.json();
+    if (json?.status === 'ERR') {
+      throw new Error(json?.message || 'Помилка завантаження турнірів');
+    }
+    return json;
+  } finally {
+    window.clearTimeout(timer);
+  }
+}
+
+export async function initTournamentsPage(params = {}) {
+  const root = document.getElementById('tournamentsRoot');
+  if (!root) return;
+
+  clear(root);
+  const hero = createElement('section', 'px-card tournaments-hero');
+  hero.append(
+    createElement('h1', 'px-card__title', 'Турніри'),
+    createElement('p', 'px-card__text', 'Командні битви, результати матчів, MVP і прогрес команд')
+  );
+
+  const listWrap = createElement('section', 'tournament-list');
+  listWrap.append(statusBlock('Завантаження турнірів...'));
+
+  const dashboard = createElement('section', 'tournament-dashboard');
+
+  root.append(hero, listWrap, dashboard);
+
+  try {
+    const listData = await postTournamentJson({ action: 'listTournaments', mode: 'tournament', status: 'ACTIVE' });
+    const tournaments = Array.isArray(listData?.tournaments) ? listData.tournaments : [];
+
+    clear(listWrap);
+    if (!tournaments.length) {
+      listWrap.append(statusBlock('Активних турнірів поки немає'));
+      return;
+    }
+
+    const selectedId = String(params.selected || params.id || '').trim();
+    let autoOpenId = '';
+
+    tournaments.forEach((tournament, idx) => {
+      const card = createElement('article', 'px-card tournament-card');
+      const tournamentId = String(tournament?.tournamentId || tournament?.id || '').trim();
+      if (!autoOpenId && selectedId && selectedId === tournamentId) {
+        autoOpenId = tournamentId;
+      }
+
+      card.append(
+        createElement('h2', 'px-card__title', toText(tournament?.name, `Турнір ${idx + 1}`)),
+        createElement('p', 'px-card__text', `Ліга: ${toText(tournament?.league, '—')}`),
+        createElement('p', 'px-card__text', `Статус: ${toText(tournament?.status, 'ACTIVE')}`),
+        createElement('p', 'px-card__text', `Старт: ${toText(tournament?.startDate, tournament?.createdAt || '—')}`)
+      );
+
+      const actions = createElement('div', 'px-card__actions');
+      const openBtn = createElement('button', 'btn', 'Відкрити');
+      openBtn.type = 'button';
+      openBtn.addEventListener('click', () => openTournament(tournamentId, dashboard));
+      actions.append(openBtn);
+      card.append(actions);
+      listWrap.append(card);
+    });
+
+    if (autoOpenId) {
+      await openTournament(autoOpenId, dashboard, true);
+    }
+  } catch (error) {
+    clear(listWrap);
+    listWrap.append(statusBlock(error?.message || 'Помилка завантаження турнірів', 'px-card px-card--accent'));
+  }
+}
+
+async function openTournament(tournamentId, dashboardNode, silentHashUpdate = false) {
+  if (!dashboardNode || !tournamentId) return;
+  clear(dashboardNode);
+  dashboardNode.append(statusBlock('Завантаження турніру...'));
+
+  try {
+    const data = await postTournamentJson({
+      action: 'getTournamentData',
+      mode: 'tournament',
+      tournamentId
+    });
+
+    if (!silentHashUpdate) {
+      const nextHash = `#tournaments?selected=${encodeURIComponent(tournamentId)}`;
+      if (location.hash !== nextHash) {
+        history.replaceState(null, '', nextHash);
+      }
+    }
+
+    renderTournamentDashboard(dashboardNode, data);
+  } catch (error) {
+    clear(dashboardNode);
+    dashboardNode.append(statusBlock(error?.message || 'Помилка завантаження турніру', 'px-card px-card--accent'));
+  }
+}
+
+function renderTournamentDashboard(node, data) {
+  const teams = Array.isArray(data?.teams) ? [...data.teams] : [];
+  const games = Array.isArray(data?.games) ? data.games : [];
+  const players = Array.isArray(data?.players) ? [...data.players] : [];
+  const teamMap = new Map(teams.map((team) => [String(team?.teamId || ''), toText(team?.teamName, String(team?.teamId || '—'))]));
+
+  clear(node);
+
+  const tabsWrap = createElement('div', 'tournament-tabs');
+  const contentWrap = createElement('div', 'tournament-tab-content');
+
+  const tabs = [
+    { key: 'table', label: 'Таблиця' },
+    { key: 'teams', label: 'Команди' },
+    { key: 'games', label: 'Матчі' },
+    { key: 'players', label: 'Гравці' }
+  ];
+
+  const renderers = {
+    table: () => renderTeamsTable(contentWrap, teams),
+    teams: () => renderTeamsCards(contentWrap, teams),
+    games: () => renderGames(contentWrap, games, teamMap),
+    players: () => renderPlayers(contentWrap, players, teamMap)
+  };
+
+  tabs.forEach((tab, index) => {
+    const btn = createElement('button', `tournament-tab${index === 0 ? ' is-active' : ''}`, tab.label);
+    btn.type = 'button';
+    btn.addEventListener('click', () => {
+      tabsWrap.querySelectorAll('.tournament-tab').forEach((el) => el.classList.remove('is-active'));
+      btn.classList.add('is-active');
+      renderers[tab.key]();
+    });
+    tabsWrap.append(btn);
+  });
+
+  node.append(tabsWrap, contentWrap);
+  renderers.table();
+}
+
+function renderTeamsTable(node, teams) {
+  clear(node);
+  if (!teams.length) {
+    node.append(statusBlock('Команди ще не збережені'));
+    return;
+  }
+
+  const sorted = [...teams].sort((a, b) => {
+    const byPoints = toNumber(b.points) - toNumber(a.points);
+    if (byPoints) return byPoints;
+    const byWins = toNumber(b.wins) - toNumber(a.wins);
+    if (byWins) return byWins;
+    const byMmr = toNumber(b.mmrCurrent) - toNumber(a.mmrCurrent);
+    if (byMmr) return byMmr;
+    return toNumber(a.losses) - toNumber(b.losses);
+  });
+
+  const wrap = createElement('div', 'tournament-table-wrap');
+  const table = createElement('table', 'tournament-player-table');
+  const thead = createElement('thead');
+  const tbody = createElement('tbody');
+  const headRow = createElement('tr');
+  ['Місце', 'Команда', 'Ігор', 'W', 'L', 'D', 'Очки', 'MMR', 'Ранг'].forEach((title) => headRow.append(createElement('th', '', title)));
+  thead.append(headRow);
+
+  sorted.forEach((team, index) => {
+    const tr = createElement('tr');
+    const games = toNumber(team.wins) + toNumber(team.losses) + toNumber(team.draws);
+    [
+      String(index + 1),
+      toText(team.teamName, toText(team.teamId)),
+      String(games),
+      String(toNumber(team.wins)),
+      String(toNumber(team.losses)),
+      String(toNumber(team.draws)),
+      String(toNumber(team.points)),
+      String(toNumber(team.mmrCurrent)),
+      toText(team.rank)
+    ].forEach((cell) => tr.append(createElement('td', '', cell)));
+    tbody.append(tr);
+  });
+
+  table.append(thead, tbody);
+  wrap.append(table);
+  node.append(wrap);
+}
+
+function renderTeamsCards(node, teams) {
+  clear(node);
+  if (!teams.length) {
+    node.append(statusBlock('Команди ще не збережені'));
+    return;
+  }
+
+  const grid = createElement('div', 'tournament-team-grid');
+  teams.forEach((team) => {
+    const card = createElement('article', 'px-card tournament-card');
+    const players = String(team?.players || '')
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    card.append(
+      createElement('h3', 'px-card__title', toText(team.teamName, toText(team.teamId))),
+      createElement('p', 'px-card__text', `W/L/D: ${toNumber(team.wins)}/${toNumber(team.losses)}/${toNumber(team.draws)}`),
+      createElement('p', 'px-card__text', `Очки: ${toNumber(team.points)} | MMR: ${toNumber(team.mmrCurrent)} | Ранг: ${toText(team.rank)}`)
+    );
+
+    if (players.length) {
+      const ul = createElement('ul', 'list-clean');
+      players.forEach((nick) => ul.append(createElement('li', '', nick)));
+      card.append(ul);
+    }
+
+    grid.append(card);
+  });
+
+  node.append(grid);
+}
+
+function renderGames(node, games, teamMap) {
+  clear(node);
+  if (!games.length) {
+    node.append(statusBlock('Матчі ще не зіграні'));
+    return;
+  }
+
+  games.forEach((game) => {
+    const card = createElement('article', 'px-card tournament-match-card');
+    const teamA = teamMap.get(String(game?.teamAId || '')) || toText(game?.teamAId);
+    const teamB = teamMap.get(String(game?.teamBId || '')) || toText(game?.teamBId);
+    const winner = String(game?.winnerTeamId || '').trim()
+      ? (teamMap.get(String(game?.winnerTeamId || '')) || toText(game?.winnerTeamId))
+      : 'Нічия';
+
+    [
+      `Матч: ${toText(game?.gameId)}`,
+      `Режим: ${toText(game?.mode)}`,
+      `${teamA} vs ${teamB}`,
+      `Переможець: ${winner}`,
+      `MVP: ${toText(game?.mvpNick)}`,
+      `2 місце: ${toText(game?.secondNick)}`,
+      `3 місце: ${toText(game?.thirdNick)}`,
+      `ΔMMR: ${toNumber(game?.teamAMmrDelta)} / ${toNumber(game?.teamBMmrDelta)}`,
+      `Час: ${toText(game?.timestamp)}`
+    ].forEach((line) => card.append(createElement('p', 'px-card__text', line)));
+
+    node.append(card);
+  });
+}
+
+function renderPlayers(node, players, teamMap) {
+  clear(node);
+  if (!players.length) {
+    node.append(statusBlock('Статистика гравців з’явиться після першого матчу'));
+    return;
+  }
+
+  const sorted = [...players].sort((a, b) => {
+    const byImpact = toNumber(b.impactPoints) - toNumber(a.impactPoints);
+    if (byImpact) return byImpact;
+    const byMvp = toNumber(b.mvpCount) - toNumber(a.mvpCount);
+    if (byMvp) return byMvp;
+    const byWins = toNumber(b.wins) - toNumber(a.wins);
+    if (byWins) return byWins;
+    return toNumber(b.mmrChange) - toNumber(a.mmrChange);
+  });
+
+  const wrap = createElement('div', 'tournament-table-wrap');
+  const table = createElement('table', 'tournament-player-table');
+  const thead = createElement('thead');
+  const tbody = createElement('tbody');
+
+  const headRow = createElement('tr');
+  ['Гравець', 'Команда', 'Ігор', 'W', 'L', 'D', 'MVP', '2nd', '3rd', 'Impact', 'MMR Δ'].forEach((title) => {
+    headRow.append(createElement('th', '', title));
+  });
+
+  sorted.forEach((player) => {
+    const tr = createElement('tr');
+    const teamName = teamMap.get(String(player?.teamId || '')) || toText(player?.teamId);
+    [
+      toText(player.playerNick),
+      teamName,
+      String(toNumber(player.games)),
+      String(toNumber(player.wins)),
+      String(toNumber(player.losses)),
+      String(toNumber(player.draws)),
+      String(toNumber(player.mvpCount)),
+      String(toNumber(player.secondCount)),
+      String(toNumber(player.thirdCount)),
+      String(toNumber(player.impactPoints)),
+      String(toNumber(player.mmrChange))
+    ].forEach((cell) => tr.append(createElement('td', '', cell)));
+    tbody.append(tr);
+  });
+
+  thead.append(headRow);
+  table.append(thead, tbody);
+  wrap.append(table);
+  node.append(wrap);
+}


### PR DESCRIPTION
### Motivation
- Додати публічну read-only сторінку «Турніри», доступну за хешем `#tournaments`, для показу даних з GAS/Google Sheets без зміни нижньої навігації або балансера.
- Забезпечити компактний доступ з головної сторінки через невеликий блок, при цьому не блокувати існуючий рендер рейтингу при помилках API.

### Description
- Додано маршрут `tournaments` у `v2/core/router.js`, мапінг href для `tournaments.html`/`pages/tournaments.html`, і гілку рендеру яка монтує `./pages/tournaments.html` та викликає `initTournamentsPage` з параметром `selected`.
- Замінено `v2/pages/tournaments.html` на мінімальний шаблон з кореневим елементом `<section id="tournamentsRoot">` для router-mounted сторінки.
- Додано новий файл `v2/pages/tournaments.js` з експортом `initTournamentsPage(params = {})`, включаючи локальний helper `postTournamentJson(payload, timeoutMs)` (POST JSON, `Content-Type: application/json`, `AbortController` таймаут, обробка `status === 'ERR'`).
- Реалізація сторінки: завантаження `listTournaments` (ACTIVE), список карток турнірів з кнопкою «Відкрити», автоперехід при `params.selected` та завантаження деталей через `getTournamentData`; локальний dashboard з вкладками `Таблиця / Команди / Матчі / Гравці`, без змін router-а; безпечне рендерення через DOM API (`createElement`/`textContent`).
- Додано компактний блок на головну `v2/pages/home.js` (`homeTournamentsMount`) з кнопкою `href="#tournaments"` та необов’язковим неблокуючим запитом для короткого прев’ю (fetch із таймаутом і try/catch, не руйнує існуючу логіку лідерів).
- Додано мінімальні стилі в `v2/assets/css/main.css` для класів сторінки/карток/вкладок/таблиць (`.tournaments-page`, `.tournaments-hero`, `.tournament-list`, `.tournament-card`, `.tournament-dashboard`, `.tournament-tabs`, `.tournament-tab`, `.tournament-table-wrap`, `.tournament-team-grid`, `.tournament-match-card`, `.tournament-player-table`, `.home-tournaments-card`).
- Не змінювались заборонені файли і класи (нижня навігація, `dataHub`, `gameday`, `profile`, `league-stats`, `v2/scripts/balance2/*`, legacy tournament files, GAS код).

### Testing
- Запущено синтаксичні/статичні перевірки: `node --check v2/core/router.js` — пройшов, `node --check v2/pages/home.js` — пройшов, `node --check v2/pages/tournaments.js` — пройшов.
- Файли були закомічені після змін (commit message: "v2: add read-only tournaments route and home entry card").
- Ручні браузерні перевірки не запускались у цьому середовищі (dev server не піднімався); рекомендується пройти Manual Test Checklist локально (відкриття `#main`, кнопка «Перейти до турнірів», `#tournaments` та робота вкладок, перевірки empty/loading/error станів).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf05a01e083218e313cb5dfe00e67)