### PR TITLE
Restyle tournaments home block and #tournaments dashboard to v2 sharp style

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -261,57 +261,258 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
 
 .tournaments-page {
   display: grid;
-  gap: .75rem;
+  gap: .65rem;
 }
 
 .tournaments-hero,
-.tournament-dashboard,
 .home-tournaments-card {
-  background: linear-gradient(165deg, rgba(49,208,255,.12), rgba(124,255,114,.06));
-  border: 1px solid rgba(255,255,255,.14);
+  background: linear-gradient(165deg, rgba(49,208,255,.11), rgba(124,255,114,.05));
+  border: 1px solid rgba(255,255,255,.16);
+  border-radius: 6px;
+}
+
+.tournaments-hero {
+  padding: .8rem .9rem;
+}
+
+.tournaments-hero .px-card__title {
+  margin-bottom: .35rem;
+  letter-spacing: .04em;
+}
+
+.tournaments-hero .px-card__text {
+  color: rgba(224, 244, 255, .82);
 }
 
 .tournament-list {
   display: grid;
-  gap: .65rem;
+  gap: .5rem;
+  border: 1px solid rgba(255,255,255,.13);
+  border-radius: 6px;
+  padding: .7rem;
+  background: rgba(8, 14, 24, .55);
+}
+
+.tournament-list__heading .px-card__title {
+  margin-bottom: .2rem;
+}
+
+.tournament-list__grid {
+  display: grid;
+  gap: .5rem;
 }
 
 .tournament-card {
+  background: rgba(12, 20, 33, .86);
   border: 1px solid rgba(255,255,255,.12);
+  border-radius: 6px;
+  padding: .7rem;
+  cursor: pointer;
+  transition: border-color .18s ease, box-shadow .18s ease, transform .18s ease;
+}
+
+.tournament-card:hover {
+  border-color: rgba(49,208,255,.45);
+  transform: translateY(-1px);
+}
+
+.tournament-card.is-selected {
+  border-color: rgba(49,208,255,.86);
+  box-shadow: 0 0 0 1px rgba(49,208,255,.46), inset 0 0 0 1px rgba(49,208,255,.16);
+}
+
+.tournament-card__title {
+  margin: 0 0 .45rem;
+}
+
+.tournament-card__meta,
+.tournament-dashboard__meta,
+.tournament-team-card__stats,
+.tournament-match-card__bottom {
+  display: grid;
+  gap: .4rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.tournament-card__actions {
+  margin-top: .55rem;
+}
+
+.tournament-open-btn,
+.home-tournaments-card__cta,
+.tournament-tab {
+  border-radius: 4px !important;
+}
+
+.tournament-dashboard__shell {
+  border: 1px solid rgba(255,255,255,.13);
+  border-radius: 6px;
+  background: rgba(7, 12, 22, .64);
+  padding: .75rem;
+}
+
+.tournament-dashboard__head {
+  margin-bottom: .55rem;
+}
+
+.tournament-meta-item {
+  border: 1px solid rgba(255,255,255,.12);
+  border-radius: 4px;
+  background: rgba(12, 20, 32, .72);
+  padding: .45rem .55rem;
+}
+
+.tournament-meta-item__label {
+  display: block;
+  font-size: .67rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  margin-bottom: .18rem;
+}
+
+.tournament-meta-item.status-is-active {
+  border-color: rgba(124,255,114,.45);
+}
+
+.tournament-meta-item.status-is-finished {
+  border-color: rgba(255,198,87,.45);
+}
+
+.tournament-meta-item__value {
+  font-size: .86rem;
+  color: #eff8ff;
 }
 
 .tournament-tabs {
   display: flex;
-  flex-wrap: wrap;
-  gap: .45rem;
-  margin-bottom: .6rem;
+  gap: .4rem;
+  margin: .65rem 0;
+  overflow-x: auto;
+  padding-bottom: .15rem;
 }
 
 .tournament-tab {
   border: 1px solid rgba(255,255,255,.16);
-  background: rgba(255,255,255,.05);
+  background: rgba(255,255,255,.03);
   color: var(--text);
-  padding: .45rem .65rem;
+  padding: .42rem .58rem;
+  white-space: nowrap;
+  font-size: .84rem;
 }
 
 .tournament-tab.is-active {
-  border-color: rgba(49,208,255,.7);
-  background: rgba(49,208,255,.16);
+  border-color: rgba(49,208,255,.78);
+  background: rgba(49,208,255,.22);
+}
+
+.tournament-tab-content {
+  min-height: 140px;
 }
 
 .tournament-table-wrap {
   overflow-x: auto;
   border: 1px solid rgba(255,255,255,.12);
+  border-radius: 6px;
+  background: rgba(10, 17, 29, .75);
 }
 
 .tournament-team-grid {
   display: grid;
-  gap: .6rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: .55rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.tournament-team-card {
+  border: 1px solid rgba(255,255,255,.12);
+  border-radius: 6px;
+  background: rgba(12, 20, 33, .78);
+  padding: .7rem;
+}
+
+.tournament-team-card__title {
+  margin: 0 0 .45rem;
+}
+
+.tournament-team-card__players {
+  margin: .55rem 0 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: .25rem;
+}
+
+.tournament-games-list {
+  display: grid;
+  gap: .5rem;
 }
 
 .tournament-match-card {
-  margin-bottom: .55rem;
+  border: 1px solid rgba(255,255,255,.13);
+  border-radius: 6px;
+  background: rgba(11, 18, 29, .78);
+  padding: .65rem;
+}
+
+.tournament-match-card__top {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: .35rem;
+  font-size: .74rem;
+  color: var(--muted);
+  margin-bottom: .45rem;
+}
+
+.tournament-match-card__middle {
+  font-weight: 700;
+  margin-bottom: .45rem;
+}
+
+.tournament-player-table th,
+.tournament-player-table td {
+  padding: .4rem .48rem;
+  font-size: .83rem;
+}
+
+.t-rank-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(49,208,255,.5);
+  min-width: 28px;
+  min-height: 22px;
+  padding: 0 .32rem;
+  border-radius: 4px;
+  font-weight: 700;
+}
+
+.tournament-status {
+  border-radius: 6px;
+}
+
+.home-tournaments-card__list {
+  margin: .3rem 0 0;
+  display: grid;
+  gap: .45rem;
+}
+
+.home-tournaments-card__item {
+  border: 1px solid rgba(255,255,255,.11);
+  border-radius: 4px;
+  background: rgba(10, 16, 28, .66);
+  padding: .45rem .55rem;
+}
+
+.home-tournaments-card__item-title {
+  font-weight: 700;
+  margin-bottom: .2rem;
+}
+
+.home-tournaments-card__item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .4rem .6rem;
+  color: var(--muted);
+  font-size: .76rem;
 }
 
 .tournament-player-table {
@@ -338,6 +539,21 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
 }
 
 @media (max-width: 640px) {
+  .tournament-match-card__top {
+    grid-template-columns: 1fr;
+  }
+
+  .tournament-card__meta,
+  .tournament-dashboard__meta,
+  .tournament-team-card__stats,
+  .tournament-match-card__bottom {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .tournament-team-grid {
+    grid-template-columns: 1fr;
+  }
+
   .home-v2 .home-place {
     width: 42px;
     min-width: 42px;

--- a/v2/pages/home.js
+++ b/v2/pages/home.js
@@ -128,15 +128,21 @@ function renderLeagueSection({ league, players }) {
   </section>`;
 }
 
-function renderHomeTournamentsCard(items = []) {
+function renderHomeTournamentsCard(items = [], unavailable = false) {
   const list = (items || []).slice(0, 2).map((item) => (
-    `<li>${escapeHtml(item?.name || item?.tournamentId || 'Турнір')}</li>`
+    `<li class="home-tournaments-card__item">
+      <div class="home-tournaments-card__item-title">${escapeHtml(item?.name || item?.tournamentId || 'Турнір')}</div>
+      <div class="home-tournaments-card__item-meta">
+        <span>Ліга: ${escapeHtml(item?.league || '—')}</span>
+        <span>Статус: ${escapeHtml(item?.status || 'ACTIVE')}</span>
+      </div>
+    </li>`
   )).join('');
   return `<section class="px-card home-tournaments-card">
     <h3 class="px-card__title">Активні турніри</h3>
-    <p class="px-card__text">Слідкуй за командними битвами, MVP і таблицею турніру</p>
-    ${list ? `<ul class="list-clean">${list}</ul>` : ''}
-    <div class="px-card__actions"><a class="btn btn--secondary" href="#tournaments">Перейти до турнірів</a></div>
+    <p class="px-card__text">${unavailable ? 'Турніри скоро з’являться' : 'Слідкуй за командними битвами, MVP і таблицею турніру'}</p>
+    ${list ? `<ul class="list-clean home-tournaments-card__list">${list}</ul>` : ''}
+    <div class="px-card__actions"><a class="btn btn--secondary home-tournaments-card__cta" href="#tournaments">Перейти до турнірів</a></div>
   </section>`;
 }
 
@@ -366,7 +372,7 @@ async function safeInitHomePage(root) {
     stateBox.hidden = false;
     stateBox.textContent = 'Дані тимчасово недоступні';
     leadersNowMount.innerHTML = renderLeadersNow(null, null);
-    homeTournamentsMount.innerHTML = renderHomeTournamentsCard([]);
+    homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], true);
     leagueSections.innerHTML = '';
   };
 
@@ -398,13 +404,14 @@ async function safeInitHomePage(root) {
     const kidsPlayers = pickSeasonActive(kidsLive?.players || []);
 
     leadersNowMount.innerHTML = renderLeadersNow(adultsPlayers[0] || null, kidsPlayers[0] || null);
-    homeTournamentsMount.innerHTML = renderHomeTournamentsCard([]);
+    homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], true);
     fetchHomeTournaments()
       .then((items) => {
         homeTournamentsMount.innerHTML = renderHomeTournamentsCard(items);
       })
       .catch((error) => {
         console.warn('[home] tournaments unavailable', error);
+        homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], true);
       });
 
     leagueSections.innerHTML = HOME_LEAGUES.map((league) => renderLeagueSection({

--- a/v2/pages/tournaments.js
+++ b/v2/pages/tournaments.js
@@ -21,11 +21,53 @@ function clear(node) {
   if (node) node.replaceChildren();
 }
 
-function statusBlock(text, className = 'px-card') {
+function stateCard(title, text = '', className = 'px-card') {
   const wrap = createElement('article', `${className} tournament-status`);
-  const p = createElement('p', 'px-card__text', text);
-  wrap.append(p);
+  wrap.append(createElement('h3', 'px-card__title', title));
+  if (text) wrap.append(createElement('p', 'px-card__text', text));
   return wrap;
+}
+
+function createMetaItem(label, value, className = '') {
+  const item = createElement('div', `tournament-meta-item${className ? ` ${className}` : ''}`);
+  item.append(
+    createElement('span', 'tournament-meta-item__label', label),
+    createElement('strong', 'tournament-meta-item__value', value)
+  );
+  return item;
+}
+
+function sanitizeErrorMessage() {
+  return 'Спробуй оновити сторінку або перевірити підключення до API';
+}
+
+function statusClass(status = '') {
+  const normalized = String(status || '').toLowerCase();
+  if (normalized.includes('active')) return 'is-active';
+  if (normalized.includes('finished')) return 'is-finished';
+  return 'is-neutral';
+}
+
+function statusLabel(status = '') {
+  const normalized = String(status || '').toLowerCase();
+  if (normalized.includes('active')) return 'Активний';
+  if (normalized.includes('finished')) return 'Завершений';
+  return toText(status);
+}
+
+function actionLabel(status = '') {
+  return statusClass(status) === 'is-active' ? 'Відкрити' : 'Переглянути';
+}
+
+function shortTimestamp(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '—';
+  return raw.replace('T', ' ').replace('Z', '');
+}
+
+function renderRankBadge(rank) {
+  const badge = createElement('span', 't-rank-badge', toText(rank, '—'));
+  return badge;
 }
 
 async function postTournamentJson(payload, timeoutMs = 20000) {
@@ -58,68 +100,90 @@ export async function initTournamentsPage(params = {}) {
   if (!root) return;
 
   clear(root);
+
   const hero = createElement('section', 'px-card tournaments-hero');
   hero.append(
     createElement('h1', 'px-card__title', 'Турніри'),
     createElement('p', 'px-card__text', 'Командні битви, результати матчів, MVP і прогрес команд')
   );
 
-  const listWrap = createElement('section', 'tournament-list');
-  listWrap.append(statusBlock('Завантаження турнірів...'));
+  const listWrap = createElement('section', 'px-card tournament-list');
+  const listHeading = createElement('div', 'tournament-list__heading');
+  listHeading.append(
+    createElement('h2', 'px-card__title', 'Активні турніри'),
+    createElement('p', 'px-card__text', 'Оберіть турнір, щоб переглянути таблицю, матчі та статистику')
+  );
 
   const dashboard = createElement('section', 'tournament-dashboard');
-
+  listWrap.append(listHeading, stateCard('Завантаження турнірів...', 'Отримуємо список активних ігор'));
   root.append(hero, listWrap, dashboard);
 
   try {
     const listData = await postTournamentJson({ action: 'listTournaments', mode: 'tournament', status: 'ACTIVE' });
     const tournaments = Array.isArray(listData?.tournaments) ? listData.tournaments : [];
 
-    clear(listWrap);
+    listWrap.replaceChildren(listHeading);
     if (!tournaments.length) {
-      listWrap.append(statusBlock('Активних турнірів поки немає'));
+      listWrap.append(stateCard('Активних турнірів поки немає', 'Список оновиться, щойно з’явиться новий турнір'));
+      dashboard.replaceChildren(stateCard('Оберіть турнір', 'Дані таблиці та матчів з’являться тут'));
       return;
     }
 
     const selectedId = String(params.selected || params.id || '').trim();
+    const grid = createElement('div', 'tournament-list__grid');
     let autoOpenId = '';
 
     tournaments.forEach((tournament, idx) => {
-      const card = createElement('article', 'px-card tournament-card');
+      const card = createElement('article', 'tournament-card');
       const tournamentId = String(tournament?.tournamentId || tournament?.id || '').trim();
-      if (!autoOpenId && selectedId && selectedId === tournamentId) {
-        autoOpenId = tournamentId;
-      }
+      if (!autoOpenId && selectedId && selectedId === tournamentId) autoOpenId = tournamentId;
+      if (!autoOpenId && idx === 0) autoOpenId = tournamentId;
 
-      card.append(
-        createElement('h2', 'px-card__title', toText(tournament?.name, `Турнір ${idx + 1}`)),
-        createElement('p', 'px-card__text', `Ліга: ${toText(tournament?.league, '—')}`),
-        createElement('p', 'px-card__text', `Статус: ${toText(tournament?.status, 'ACTIVE')}`),
-        createElement('p', 'px-card__text', `Старт: ${toText(tournament?.startDate, tournament?.createdAt || '—')}`)
+      card.setAttribute('data-tournament-id', tournamentId);
+      card.append(createElement('h3', 'tournament-card__title', toText(tournament?.name, `Турнір ${idx + 1}`)));
+
+      const meta = createElement('div', 'tournament-card__meta');
+      meta.append(
+        createMetaItem('Ліга', toText(tournament?.league)),
+        createMetaItem('Статус', statusLabel(tournament?.status || 'ACTIVE'), `status-${statusClass(tournament?.status)}`),
+        createMetaItem('Старт', toText(tournament?.startDate, tournament?.createdAt || '—'))
       );
+      card.append(meta);
 
-      const actions = createElement('div', 'px-card__actions');
-      const openBtn = createElement('button', 'btn', 'Відкрити');
+      const actions = createElement('div', 'tournament-card__actions');
+      const openBtn = createElement('button', 'btn tournament-open-btn', actionLabel(tournament?.status));
       openBtn.type = 'button';
-      openBtn.addEventListener('click', () => openTournament(tournamentId, dashboard));
+      openBtn.addEventListener('click', () => openTournament(tournamentId, dashboard, grid));
       actions.append(openBtn);
       card.append(actions);
-      listWrap.append(card);
+
+      card.addEventListener('click', (event) => {
+        if (event.target instanceof HTMLElement && event.target.closest('button')) return;
+        openTournament(tournamentId, dashboard, grid);
+      });
+
+      grid.append(card);
     });
 
-    if (autoOpenId) {
-      await openTournament(autoOpenId, dashboard, true);
-    }
+    listWrap.append(grid);
+    if (autoOpenId) await openTournament(autoOpenId, dashboard, grid, true);
   } catch (error) {
-    clear(listWrap);
-    listWrap.append(statusBlock(error?.message || 'Помилка завантаження турнірів', 'px-card px-card--accent'));
+    console.warn('[tournaments] list failed', error);
+    listWrap.replaceChildren(listHeading, stateCard('Не вдалося завантажити турніри', sanitizeErrorMessage(), 'px-card px-card--accent'));
   }
 }
 
-async function openTournament(tournamentId, dashboardNode, silentHashUpdate = false) {
+function activateTournamentCard(listNode, nextId) {
+  listNode?.querySelectorAll('.tournament-card').forEach((card) => {
+    const selected = card.getAttribute('data-tournament-id') === nextId;
+    card.classList.toggle('is-selected', selected);
+  });
+}
+
+async function openTournament(tournamentId, dashboardNode, listNode, silentHashUpdate = false) {
   if (!dashboardNode || !tournamentId) return;
-  clear(dashboardNode);
-  dashboardNode.append(statusBlock('Завантаження турніру...'));
+  activateTournamentCard(listNode, tournamentId);
+  dashboardNode.replaceChildren(stateCard('Завантаження даних турніру...', 'Будь ласка, зачекай'));
 
   try {
     const data = await postTournamentJson({
@@ -137,8 +201,8 @@ async function openTournament(tournamentId, dashboardNode, silentHashUpdate = fa
 
     renderTournamentDashboard(dashboardNode, data);
   } catch (error) {
-    clear(dashboardNode);
-    dashboardNode.append(statusBlock(error?.message || 'Помилка завантаження турніру', 'px-card px-card--accent'));
+    console.warn('[tournaments] dashboard failed', error);
+    dashboardNode.replaceChildren(stateCard('Не вдалося завантажити турнір', sanitizeErrorMessage(), 'px-card px-card--accent'));
   }
 }
 
@@ -146,9 +210,21 @@ function renderTournamentDashboard(node, data) {
   const teams = Array.isArray(data?.teams) ? [...data.teams] : [];
   const games = Array.isArray(data?.games) ? data.games : [];
   const players = Array.isArray(data?.players) ? [...data.players] : [];
+  const tournament = data?.tournament || data || {};
+  const title = toText(tournament?.name, toText(tournament?.tournamentId, 'Турнір'));
   const teamMap = new Map(teams.map((team) => [String(team?.teamId || ''), toText(team?.teamName, String(team?.teamId || '—'))]));
 
   clear(node);
+
+  const dashboardCard = createElement('section', 'px-card tournament-dashboard__shell');
+  const head = createElement('div', 'tournament-dashboard__head');
+  head.append(createElement('h3', 'px-card__title', title));
+  const meta = createElement('div', 'tournament-dashboard__meta');
+  meta.append(
+    createMetaItem('Ліга', toText(tournament?.league)),
+    createMetaItem('Статус', statusLabel(tournament?.status || 'ACTIVE'), `status-${statusClass(tournament?.status)}`),
+    createMetaItem('Старт', toText(tournament?.startDate, tournament?.createdAt || '—'))
+  );
 
   const tabsWrap = createElement('div', 'tournament-tabs');
   const contentWrap = createElement('div', 'tournament-tab-content');
@@ -178,14 +254,15 @@ function renderTournamentDashboard(node, data) {
     tabsWrap.append(btn);
   });
 
-  node.append(tabsWrap, contentWrap);
+  dashboardCard.append(head, meta, tabsWrap, contentWrap);
+  node.append(dashboardCard);
   renderers.table();
 }
 
 function renderTeamsTable(node, teams) {
   clear(node);
   if (!teams.length) {
-    node.append(statusBlock('Команди ще не збережені'));
+    node.append(stateCard('Команди ще не збережені', 'Таблиця зʼявиться після формування складів'));
     return;
   }
 
@@ -204,7 +281,7 @@ function renderTeamsTable(node, teams) {
   const thead = createElement('thead');
   const tbody = createElement('tbody');
   const headRow = createElement('tr');
-  ['Місце', 'Команда', 'Ігор', 'W', 'L', 'D', 'Очки', 'MMR', 'Ранг'].forEach((title) => headRow.append(createElement('th', '', title)));
+  ['#', 'Команда', 'І', 'В', 'П', 'Н', 'Очки', 'MMR', 'Ранг'].forEach((title) => headRow.append(createElement('th', '', title)));
   thead.append(headRow);
 
   sorted.forEach((team, index) => {
@@ -218,9 +295,11 @@ function renderTeamsTable(node, teams) {
       String(toNumber(team.losses)),
       String(toNumber(team.draws)),
       String(toNumber(team.points)),
-      String(toNumber(team.mmrCurrent)),
-      toText(team.rank)
+      String(toNumber(team.mmrCurrent))
     ].forEach((cell) => tr.append(createElement('td', '', cell)));
+    const rankTd = createElement('td');
+    rankTd.append(renderRankBadge(team.rank));
+    tr.append(rankTd);
     tbody.append(tr);
   });
 
@@ -232,26 +311,31 @@ function renderTeamsTable(node, teams) {
 function renderTeamsCards(node, teams) {
   clear(node);
   if (!teams.length) {
-    node.append(statusBlock('Команди ще не збережені'));
+    node.append(stateCard('Команди ще не збережені', 'Склади команд будуть показані після додавання учасників'));
     return;
   }
 
   const grid = createElement('div', 'tournament-team-grid');
   teams.forEach((team) => {
-    const card = createElement('article', 'px-card tournament-card');
+    const card = createElement('article', 'tournament-team-card');
     const players = String(team?.players || '')
       .split(',')
       .map((item) => item.trim())
       .filter(Boolean);
 
-    card.append(
-      createElement('h3', 'px-card__title', toText(team.teamName, toText(team.teamId))),
-      createElement('p', 'px-card__text', `W/L/D: ${toNumber(team.wins)}/${toNumber(team.losses)}/${toNumber(team.draws)}`),
-      createElement('p', 'px-card__text', `Очки: ${toNumber(team.points)} | MMR: ${toNumber(team.mmrCurrent)} | Ранг: ${toText(team.rank)}`)
+    card.append(createElement('h3', 'tournament-team-card__title', toText(team.teamName, toText(team.teamId))));
+
+    const stats = createElement('div', 'tournament-team-card__stats');
+    stats.append(
+      createMetaItem('W/L/D', `${toNumber(team.wins)}/${toNumber(team.losses)}/${toNumber(team.draws)}`),
+      createMetaItem('Очки', String(toNumber(team.points))),
+      createMetaItem('MMR', String(toNumber(team.mmrCurrent))),
+      createMetaItem('Ранг', toText(team.rank))
     );
+    card.append(stats);
 
     if (players.length) {
-      const ul = createElement('ul', 'list-clean');
+      const ul = createElement('ul', 'tournament-team-card__players');
       players.forEach((nick) => ul.append(createElement('li', '', nick)));
       card.append(ul);
     }
@@ -265,38 +349,46 @@ function renderTeamsCards(node, teams) {
 function renderGames(node, games, teamMap) {
   clear(node);
   if (!games.length) {
-    node.append(statusBlock('Матчі ще не зіграні'));
+    node.append(stateCard('Матчі ще не зіграні', 'Лог матчів з’явиться після першої гри'));
     return;
   }
 
+  const list = createElement('div', 'tournament-games-list');
   games.forEach((game) => {
-    const card = createElement('article', 'px-card tournament-match-card');
+    const card = createElement('article', 'tournament-match-card');
     const teamA = teamMap.get(String(game?.teamAId || '')) || toText(game?.teamAId);
     const teamB = teamMap.get(String(game?.teamBId || '')) || toText(game?.teamBId);
     const winner = String(game?.winnerTeamId || '').trim()
       ? (teamMap.get(String(game?.winnerTeamId || '')) || toText(game?.winnerTeamId))
       : 'Нічия';
 
-    [
-      `Матч: ${toText(game?.gameId)}`,
-      `Режим: ${toText(game?.mode)}`,
-      `${teamA} vs ${teamB}`,
-      `Переможець: ${winner}`,
-      `MVP: ${toText(game?.mvpNick)}`,
-      `2 місце: ${toText(game?.secondNick)}`,
-      `3 місце: ${toText(game?.thirdNick)}`,
-      `ΔMMR: ${toNumber(game?.teamAMmrDelta)} / ${toNumber(game?.teamBMmrDelta)}`,
-      `Час: ${toText(game?.timestamp)}`
-    ].forEach((line) => card.append(createElement('p', 'px-card__text', line)));
+    const top = createElement('div', 'tournament-match-card__top');
+    top.append(
+      createElement('span', 'tournament-match-card__id', `ID: ${toText(game?.gameId)}`),
+      createElement('span', 'tournament-match-card__mode', toText(game?.mode)),
+      createElement('span', 'tournament-match-card__time', shortTimestamp(game?.timestamp))
+    );
 
-    node.append(card);
+    const middle = createElement('div', 'tournament-match-card__middle', `${teamA} vs ${teamB}`);
+
+    const bottom = createElement('div', 'tournament-match-card__bottom');
+    bottom.append(
+      createMetaItem('Результат', String(game?.winnerTeamId || '').trim() ? winner : 'Нічия'),
+      createMetaItem('MVP', `${toText(game?.mvpNick)} / ${toText(game?.secondNick)} / ${toText(game?.thirdNick)}`),
+      createMetaItem('ΔMMR', `${toNumber(game?.teamAMmrDelta)} / ${toNumber(game?.teamBMmrDelta)}`)
+    );
+
+    card.append(top, middle, bottom);
+    list.append(card);
   });
+
+  node.append(list);
 }
 
 function renderPlayers(node, players, teamMap) {
   clear(node);
   if (!players.length) {
-    node.append(statusBlock('Статистика гравців з’явиться після першого матчу'));
+    node.append(stateCard('Статистика гравців з’явиться після першого матчу', 'Після матчу тут буде рейтинг гравців'));
     return;
   }
 
@@ -316,7 +408,7 @@ function renderPlayers(node, players, teamMap) {
   const tbody = createElement('tbody');
 
   const headRow = createElement('tr');
-  ['Гравець', 'Команда', 'Ігор', 'W', 'L', 'D', 'MVP', '2nd', '3rd', 'Impact', 'MMR Δ'].forEach((title) => {
+  ['Гравець', 'Команда', 'І', 'В', 'П', 'Н', 'MVP', '2', '3', 'Impact', 'MMR +/-'].forEach((title) => {
     headRow.append(createElement('th', '', title));
   });
 


### PR DESCRIPTION
### Motivation
- Привести блок «Активні турніри» на головній і сторінку `#tournaments` до візуальної мови v2: прямокутні форми, компактна композиція, кібер/неон-настрій і без овальних/pill елементів.
- Поліпшити пусті/завантажувальні/помилкові стани щоб не показувати сирий текст або JSON і не ламати головну сторінку при відсутності API.

### Description
- Оновлено рендеринг і структуру сторінки турнірів у `v2/pages/tournaments.js`: компактний hero, selectable list карток турнірів з hover/selected станами, єдиний dashboard shell з meta → tabs → content, перероблені таби, таблиці, командні/матч/гравець-рендерери та сприятливі state-карти (loading/error/empty). 
- Перероблено блок «Активні турніри» на головній у `v2/pages/home.js` для компактної подачі items (name/league/status), прямокутної CTA і стриманого fallback-контенту при недоступності API. 
- Додано/посилио стилі в `v2/assets/css/main.css` для sharp/rectangular вигляду: обмежені `border-radius` (4–6px), переважно прямокутні кнопки/вкладки, selected-підсвітка, ущільнені відступи та мобільні правки; перевизначено старі округлені елементи локально для tournaments UI. 
- Збережено існуючу fetch-логіку та контроли без великого рефакторингу; зміни сфокусовані на markup/CSS і безпечному обгортанні помилок (user-friendly повідомлення). 

### Testing
- Пройшли синтаксичні перевірки JS через `node --check v2/pages/home.js && node --check v2/pages/tournaments.js` (успіх). 
- Прогнали unit tests командою `node --test tests/*.mjs` і всі тести пройшли (`4 passed, 0 failed`). 
- Зроблено локальний commit з повідомленням `Restyle tournaments UI to match v2 dashboard style` після перевірок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf4525620832197a5fc97e8d0b33c)