### PR TITLE
Refine tournaments teaser and empty/error presentation for v2

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -261,7 +261,7 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
 
 .tournaments-page {
   display: grid;
-  gap: .65rem;
+  gap: .55rem;
 }
 
 .tournaments-hero,
@@ -272,7 +272,7 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
 }
 
 .tournaments-hero {
-  padding: .8rem .9rem;
+  padding: .72rem .82rem;
 }
 
 .tournaments-hero .px-card__title {
@@ -286,10 +286,10 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
 
 .tournament-list {
   display: grid;
-  gap: .5rem;
+  gap: .45rem;
   border: 1px solid rgba(255,255,255,.13);
   border-radius: 6px;
-  padding: .7rem;
+  padding: .62rem;
   background: rgba(8, 14, 24, .55);
 }
 
@@ -489,10 +489,47 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   border-radius: 6px;
 }
 
-.home-tournaments-card__list {
-  margin: .3rem 0 0;
+.tournaments-preview {
   display: grid;
-  gap: .45rem;
+  gap: .5rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.tournaments-preview__card {
+  border: 1px solid rgba(255,255,255,.12);
+  border-radius: 6px;
+  background: rgba(10, 16, 28, .72);
+  padding: .62rem .66rem;
+}
+
+.tournaments-preview__card .px-card__title {
+  margin-bottom: .2rem;
+}
+
+.home-tournaments-card__list {
+  margin: .2rem 0 0;
+  display: grid;
+  gap: .35rem;
+}
+
+.home-tournaments-card {
+  padding: .62rem .72rem !important;
+}
+
+.home-tournaments-card__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+  margin-bottom: .2rem;
+}
+
+.home-tournaments-card__head .px-card__title {
+  margin: 0;
+}
+
+.home-tournaments-card .px-card__text {
+  margin-bottom: .3rem;
 }
 
 .home-tournaments-card__item {
@@ -513,6 +550,14 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   gap: .4rem .6rem;
   color: var(--muted);
   font-size: .76rem;
+}
+
+.home-tournaments-card__cta {
+  padding: .34rem .5rem !important;
+  min-height: auto !important;
+  font-size: .76rem !important;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .tournament-player-table {
@@ -552,6 +597,10 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
 
   .tournament-team-grid {
     grid-template-columns: 1fr;
+  }
+
+  .home-tournaments-card__head {
+    align-items: flex-start;
   }
 
   .home-v2 .home-place {

--- a/v2/pages/home.js
+++ b/v2/pages/home.js
@@ -139,10 +139,12 @@ function renderHomeTournamentsCard(items = [], unavailable = false) {
     </li>`
   )).join('');
   return `<section class="px-card home-tournaments-card">
-    <h3 class="px-card__title">Активні турніри</h3>
-    <p class="px-card__text">${unavailable ? 'Турніри скоро з’являться' : 'Слідкуй за командними битвами, MVP і таблицею турніру'}</p>
+    <div class="home-tournaments-card__head">
+      <h3 class="px-card__title">Активні турніри</h3>
+      <a class="btn btn--secondary home-tournaments-card__cta" href="#tournaments">До турнірів</a>
+    </div>
+    <p class="px-card__text">${list ? 'Командні битви, матчі та статистика в одному розділі' : (unavailable ? 'Скоро тут з’являться активні турніри' : 'Турніри готуються')}</p>
     ${list ? `<ul class="list-clean home-tournaments-card__list">${list}</ul>` : ''}
-    <div class="px-card__actions"><a class="btn btn--secondary home-tournaments-card__cta" href="#tournaments">Перейти до турнірів</a></div>
   </section>`;
 }
 

--- a/v2/pages/tournaments.js
+++ b/v2/pages/tournaments.js
@@ -28,6 +28,35 @@ function stateCard(title, text = '', className = 'px-card') {
   return wrap;
 }
 
+function createPreviewSections() {
+  const wrap = createElement('section', 'tournaments-preview');
+  const items = [
+    {
+      title: 'Таблиця команд',
+      text: 'Тут буде турнірна таблиця з очками, перемогами та MMR'
+    },
+    {
+      title: 'Матчі',
+      text: 'Тут з’явиться список матчів, результатів і MVP'
+    },
+    {
+      title: 'Гравці',
+      text: 'Тут буде статистика учасників турніру'
+    }
+  ];
+
+  items.forEach((item) => {
+    const card = createElement('article', 'px-card tournaments-preview__card');
+    card.append(
+      createElement('h3', 'px-card__title', item.title),
+      createElement('p', 'px-card__text', item.text)
+    );
+    wrap.append(card);
+  });
+
+  return wrap;
+}
+
 function createMetaItem(label, value, className = '') {
   const item = createElement('div', `tournament-meta-item${className ? ` ${className}` : ''}`);
   item.append(
@@ -104,7 +133,7 @@ export async function initTournamentsPage(params = {}) {
   const hero = createElement('section', 'px-card tournaments-hero');
   hero.append(
     createElement('h1', 'px-card__title', 'Турніри'),
-    createElement('p', 'px-card__text', 'Командні битви, результати матчів, MVP і прогрес команд')
+    createElement('p', 'px-card__text', 'Командні битви, матчі, таблиця та статистика')
   );
 
   const listWrap = createElement('section', 'px-card tournament-list');
@@ -124,8 +153,8 @@ export async function initTournamentsPage(params = {}) {
 
     listWrap.replaceChildren(listHeading);
     if (!tournaments.length) {
-      listWrap.append(stateCard('Активних турнірів поки немає', 'Список оновиться, щойно з’явиться новий турнір'));
-      dashboard.replaceChildren(stateCard('Оберіть турнір', 'Дані таблиці та матчів з’являться тут'));
+      listWrap.append(stateCard('Активних турнірів поки немає', 'Щойно буде створено перший турнір, тут з’являться таблиця, матчі й статистика'));
+      dashboard.replaceChildren(createPreviewSections());
       return;
     }
 
@@ -169,7 +198,8 @@ export async function initTournamentsPage(params = {}) {
     if (autoOpenId) await openTournament(autoOpenId, dashboard, grid, true);
   } catch (error) {
     console.warn('[tournaments] list failed', error);
-    listWrap.replaceChildren(listHeading, stateCard('Не вдалося завантажити турніри', sanitizeErrorMessage(), 'px-card px-card--accent'));
+    listWrap.replaceChildren(listHeading, stateCard('Турніри тимчасово недоступні', 'Спробуй оновити сторінку трохи пізніше', 'px-card'));
+    dashboard.replaceChildren(createPreviewSections());
   }
 }
 


### PR DESCRIPTION
### Motivation
- Зменшити візуальну вагу блоку «Активні турніри» на головній та позбутись ефекту «чернетки» на сторінці #tournaments без зміни бізнес-логіки. 
- Надати користувацькі, дружні тексти замість сирих технічних помилок і зробити оформлення в дусі v2 (sharp / rectangular / компактно). 

### Description
- Перетворено Home «Активні турніри» на компактний teaser-card з інтегрованим header + CTA та коротким fallback/mini-list (файл `v2/pages/home.js`).
- Оновлено сторінку `#tournaments` щоб показувати продукт-орієнтований hero, м’які empty/error стани і замість порожньої сторінки додано 3 preview cards: «Таблиця команд», «Матчі», «Гравці» (файл `v2/pages/tournaments.js`).
- Підправлено стилі для ущільнення spacing, прямокутних CTA та preview-карт, а також додано адаптивну сітку для preview (файл `v2/assets/css/main.css`).
- Логіку API, маршрути та поведінку переходу до `#tournaments` не чіпано. 

### Testing
- Запущено перевірку синтаксису JavaScript через `node --check v2/pages/home.js` і `node --check v2/pages/tournaments.js`, обидві перевірки пройшли успішно. 
- Перевірено наявність очікуваних рядків і замін за допомогою `rg` (шукали помилки/нові тексти), результат відповідає змінам у файлах і без сирих технічних повідомлень у UI. 
- Локальна збірка/commit пройшли: зміни закомічено у локальному репозиторії; автоматичні перевірки коду не виявили синтаксичних помилок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf81685fc8321b504f30c3a4cc57c)