### PR TITLE
Fix v2 rectangular radius system for home/tournaments content UI

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -8269,3 +8269,30 @@ body.theme-game .rules-v2.rules-v2--clean > .px-card::after,
     justify-self: start;
   }
 }
+
+/* v2 UI rule:
+   content cards, buttons, tabs and state blocks use sharp rectangular corners.
+   Avoid pill/oval radius in v2 content UI. */
+body.theme-game {
+  --v2-radius-xs: 2px;
+  --v2-radius-sm: 4px;
+  --v2-radius-md: 6px;
+  --v2-radius-lg: 8px;
+}
+
+body.theme-game .v2-rect-card {
+  border-radius: var(--v2-radius-md);
+}
+
+body.theme-game .v2-rect-btn,
+body.theme-game .v2-rect-tab {
+  border-radius: var(--v2-radius-sm);
+}
+
+body.theme-game :is(.home-tournaments-card, .tournaments-hero, .tournament-list, .tournament-dashboard__shell, .tournament-status, .tournaments-preview__card, .tournament-card, .tournament-team-card, .tournament-match-card, .tournament-table-wrap) {
+  border-radius: var(--v2-radius-md) !important;
+}
+
+body.theme-game :is(.home-tournaments-card__item, .tournament-meta-item, .tournament-open-btn, .home-tournaments-card__cta, .tournament-tab) {
+  border-radius: var(--v2-radius-sm) !important;
+}


### PR DESCRIPTION
### Motivation
- New v2 blocks kept inheriting pill/oval corners because shared/global CSS layers and large-radius tokens were reapplying rounded shapes across reused components. 
- The goal is a small, safe root-cause fix that establishes a single rectangular radius system for content UI (home/tournaments/CTAs/tabs/state blocks) without changing JS logic or backend.

### Description
- Changed `v2/assets/css/main.css` to introduce a compact v2 radius token scale (`--v2-radius-xs`, `--v2-radius-sm`, `--v2-radius-md`, `--v2-radius-lg`) and a short guardrail comment explaining the rule. 
- Added lightweight utility hooks `.v2-rect-card`, `.v2-rect-btn`, and `.v2-rect-tab` for safe reuse of rectangular corners. 
- Enforced rectangular radii for home/tournaments surfaces and related CTA/buttons/tabs by scoping targeted `:is(...)` selectors (e.g. `.home-tournaments-card`, `.tournament-card`, `.tournament-tab`, `.tournament-meta-item`, `.tournament-open-btn`) and applying `var(--v2-radius-*)` values. 
- The change is scoped to CSS only and avoids broad structural or JS modifications and large-scale !important overrides beyond the targeted surfaces. 

### Testing
- Ran the project build with `npm run build:summer2025-og` and the build completed successfully. 
- Verified that the modified CSS file was applied and that no JS or backend automated tests were required for this CSS-only patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfb8aa0448321bc95a9a9f99412b3)