### PR TITLE
Switch read-only tournaments UI to GAS JSONP

### DIFF
--- a/gas/doPost.gs
+++ b/gas/doPost.gs
@@ -34,6 +34,47 @@ function normalizeLeague_(value) {
   return key;
 }
 
+function respond_(payload, callbackName) {
+  const body = JSON.stringify(payload || {});
+  const cb = String(callbackName || '').trim();
+  if (!cb) {
+    return ContentService.createTextOutput(body)
+      .setMimeType(ContentService.MimeType.JSON);
+  }
+  return ContentService.createTextOutput(`${cb}(${body})`)
+    .setMimeType(ContentService.MimeType.JAVASCRIPT);
+}
+
+function jsonTextOutputToObject_(output) {
+  if (!output || typeof output.getContent !== 'function') {
+    throw new Error('Invalid TextOutput');
+  }
+  return JSON.parse(output.getContent() || '{}');
+}
+
+function doGet(e) {
+  try {
+    const p = (e && e.parameter) || {};
+    const action = String(p.action || '').trim();
+    const cb = p.callback;
+
+    if (action === 'listTournaments' || action === 'getTournamentData') {
+      const payload = Object.assign({}, p, { mode: 'tournament', action });
+      const textOutput = handleTournamentRequest_(payload);
+      const obj = jsonTextOutputToObject_(textOutput);
+      return respond_(obj, cb);
+    }
+
+    if (action === 'ping') {
+      return respond_({ status: 'OK', pong: true, ts: new Date().toISOString() }, cb);
+    }
+
+    return respond_({ status: 'ERR', message: 'Unknown GET action' }, cb);
+  } catch (err) {
+    return respond_({ status: 'ERR', message: err && err.message ? err.message : String(err) }, e && e.parameter ? e.parameter.callback : '');
+  }
+}
+
 function doPost(e) {
   try {
     // ---------- JSON API ----------

--- a/v2/core/tournamentApi.js
+++ b/v2/core/tournamentApi.js
@@ -1,0 +1,19 @@
+import { jsonp } from './utils.js';
+
+const TOURNAMENTS_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxzIEh2-gluSxvtUqCDmpGodhFntF-t59Q9OSBEjTxqdfURS3MlYwm6vcZ-1s4XPd0kHQ/exec';
+
+async function gasTournamentJsonp(action, params = {}, timeoutMs = 15_000) {
+  const response = await jsonp(TOURNAMENTS_ENDPOINT, { action, ...params }, timeoutMs);
+  if (response?.status === 'ERR') {
+    throw new Error(response?.message || 'Tournament API error');
+  }
+  return response || {};
+}
+
+export async function listActiveTournaments(timeoutMs = 15_000) {
+  return gasTournamentJsonp('listTournaments', { mode: 'tournament', status: 'ACTIVE' }, timeoutMs);
+}
+
+export async function getTournamentData(tournamentId, timeoutMs = 20_000) {
+  return gasTournamentJsonp('getTournamentData', { mode: 'tournament', tournamentId }, timeoutMs);
+}

--- a/v2/pages/home.js
+++ b/v2/pages/home.js
@@ -1,5 +1,6 @@
 import { getCurrentLeagueLiveStats, rankFromPoints, safeErrorMessage } from '../core/dataHub.js';
 import { leagueLabelUA } from '../core/naming.js';
+import { listActiveTournaments } from '../core/tournamentApi.js';
 
 const HOME_LEAGUES = ['sundaygames', 'kids'];
 const STATS_LINKS = {
@@ -7,7 +8,6 @@ const STATS_LINKS = {
   kids: '#league-stats?league=kids'
 };
 const FALLBACK_AVATAR = 'data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2248%22 height=%2248%22 viewBox=%220 0 48 48%22%3E%3Crect width=%2248%22 height=%2248%22 fill=%22%23121a2a%22/%3E%3Ccircle cx=%2224%22 cy=%2218%22 r=%229%22 fill=%22%235b6c89%22/%3E%3Crect x=%2211%22 y=%2230%22 width=%2226%22 height=%2212%22 rx=%220%22 fill=%22%235b6c89%22/%3E%3C/svg%3E';
-const TOURNAMENTS_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxzIEh2-gluSxvtUqCDmpGodhFntF-t59Q9OSBEjTxqdfURS3MlYwm6vcZ-1s4XPd0kHQ/exec';
 
 function esc(v) {
   return String(v ?? '')
@@ -149,22 +149,8 @@ function renderHomeTournamentsCard(items = [], unavailable = false) {
 }
 
 async function fetchHomeTournaments() {
-  const controller = new AbortController();
-  const timer = window.setTimeout(() => controller.abort(), 7000);
-  try {
-    const response = await fetch(TOURNAMENTS_ENDPOINT, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'listTournaments', mode: 'tournament', status: 'ACTIVE' }),
-      signal: controller.signal
-    });
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const json = await response.json();
-    if (json?.status === 'ERR') throw new Error(json?.message || 'GAS error');
-    return Array.isArray(json?.tournaments) ? json.tournaments : [];
-  } finally {
-    window.clearTimeout(timer);
-  }
+  const json = await listActiveTournaments(7000);
+  return Array.isArray(json?.tournaments) ? json.tournaments : [];
 }
 
 function renderHomeLoadingSkeleton() {
@@ -411,8 +397,8 @@ async function safeInitHomePage(root) {
       .then((items) => {
         homeTournamentsMount.innerHTML = renderHomeTournamentsCard(items);
       })
-      .catch((error) => {
-        console.warn('[home] tournaments unavailable', error);
+      .catch(() => {
+        console.warn('[home] tournaments unavailable');
         homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], true);
       });
 

--- a/v2/pages/tournaments.js
+++ b/v2/pages/tournaments.js
@@ -1,4 +1,4 @@
-const TOURNAMENTS_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxzIEh2-gluSxvtUqCDmpGodhFntF-t59Q9OSBEjTxqdfURS3MlYwm6vcZ-1s4XPd0kHQ/exec';
+import { getTournamentData, listActiveTournaments } from '../core/tournamentApi.js';
 
 function toNumber(value) {
   const n = Number(value);
@@ -99,31 +99,6 @@ function renderRankBadge(rank) {
   return badge;
 }
 
-async function postTournamentJson(payload, timeoutMs = 20000) {
-  const controller = new AbortController();
-  const timer = window.setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetch(TOURNAMENTS_ENDPOINT, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-      signal: controller.signal
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-
-    const json = await response.json();
-    if (json?.status === 'ERR') {
-      throw new Error(json?.message || 'Помилка завантаження турнірів');
-    }
-    return json;
-  } finally {
-    window.clearTimeout(timer);
-  }
-}
-
 export async function initTournamentsPage(params = {}) {
   const root = document.getElementById('tournamentsRoot');
   if (!root) return;
@@ -148,7 +123,7 @@ export async function initTournamentsPage(params = {}) {
   root.append(hero, listWrap, dashboard);
 
   try {
-    const listData = await postTournamentJson({ action: 'listTournaments', mode: 'tournament', status: 'ACTIVE' });
+    const listData = await listActiveTournaments();
     const tournaments = Array.isArray(listData?.tournaments) ? listData.tournaments : [];
 
     listWrap.replaceChildren(listHeading);
@@ -196,8 +171,8 @@ export async function initTournamentsPage(params = {}) {
 
     listWrap.append(grid);
     if (autoOpenId) await openTournament(autoOpenId, dashboard, grid, true);
-  } catch (error) {
-    console.warn('[tournaments] list failed', error);
+  } catch {
+    console.warn('[tournaments] list failed');
     listWrap.replaceChildren(listHeading, stateCard('Турніри тимчасово недоступні', 'Спробуй оновити сторінку трохи пізніше', 'px-card'));
     dashboard.replaceChildren(createPreviewSections());
   }
@@ -216,11 +191,7 @@ async function openTournament(tournamentId, dashboardNode, listNode, silentHashU
   dashboardNode.replaceChildren(stateCard('Завантаження даних турніру...', 'Будь ласка, зачекай'));
 
   try {
-    const data = await postTournamentJson({
-      action: 'getTournamentData',
-      mode: 'tournament',
-      tournamentId
-    });
+    const data = await getTournamentData(tournamentId);
 
     if (!silentHashUpdate) {
       const nextHash = `#tournaments?selected=${encodeURIComponent(tournamentId)}`;
@@ -230,8 +201,8 @@ async function openTournament(tournamentId, dashboardNode, listNode, silentHashU
     }
 
     renderTournamentDashboard(dashboardNode, data);
-  } catch (error) {
-    console.warn('[tournaments] dashboard failed', error);
+  } catch {
+    console.warn('[tournaments] dashboard failed');
     dashboardNode.replaceChildren(stateCard('Не вдалося завантажити турнір', sanitizeErrorMessage(), 'px-card px-card--accent'));
   }
 }


### PR DESCRIPTION
### Motivation
- Public read-only tournament UI used `POST application/json` to the Apps Script endpoint which triggered CORS/preflight failures and produced `TypeError: Failed to fetch` in browser flows.
- Existing `dataHub` already uses a JSONP pattern that works with the Apps Script web app, so read-only tournament reads should follow the same scheme to avoid cross-origin issues.

### Description
- Added a small shared read-only tournament API helper `v2/core/tournamentApi.js` that wraps the existing `jsonp()` utility and exposes `listActiveTournaments()` and `getTournamentData()`.
- Replaced direct `POST` read calls with JSONP reads in `v2/pages/tournaments.js` (list load and tournament details) and `v2/pages/home.js` (home tournaments teaser), and removed the local `postTournamentJson` POST helper.
- Added `doGet(e)` JSONP support to `gas/doPost.gs` with helpers `respond_()` and `jsonTextOutputToObject_()` to return JSONP for `listTournaments` and `getTournamentData` without changing existing `doPost` save logic.
- Reduced noisy error logging for unavailable tournaments by logging concise warnings and showing friendly fallback UI states instead of stack traces.

### Testing
- Ran JS syntax checks: `node --check v2/core/tournamentApi.js`, `node --check v2/pages/home.js`, and `node --check v2/pages/tournaments.js`, all succeeded.
- Attempted to syntax-check `gas/doPost.gs` via Node which is not applicable (`.gs` not a Node extension), so GAS file was not checked by `node --check` here.
- Performed HTTP HEAD/response checks against the Apps Script endpoint URLs used for JSONP, which returned `403` from this CI/CLI environment, so endpoint behavior must be verified in a real browser after deploying the updated GAS code.
- Manual verification checklist to run after deployment: open Home and Tournaments pages in a browser, confirm no `Failed to fetch` errors, verify `listTournaments` and `getTournamentData` JSONP callback responses via the browser (or developer console), and ensure fallback UI states render when API is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfe52e8488321a5048fedfb02e555)