### PR TITLE
Fix tournament save flow and GAS POST format

### DIFF
--- a/v2/scripts/balance2/api.js
+++ b/v2/scripts/balance2/api.js
@@ -66,16 +66,19 @@ export async function saveMatch(payload, timeoutMs = 20000) {
   }
 }
 
-export async function postTournamentJson(payload, timeoutMs = 20000) {
+async function postGasJson(payload, timeoutMs = 20000) {
   try {
     const res = await fetchWithTimeout(TOURNAMENT_ENDPOINT, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'text/plain;charset=utf-8' },
       body: JSON.stringify(payload || {}),
     }, timeoutMs);
     const data = await res.json();
+    if (!res.ok) {
+      return { ok: false, data: data || null, message: data?.message || data?.error || `HTTP ${res.status}` };
+    }
     const status = String(data?.status || '').toUpperCase();
-    if (status === 'OK') return { ok: true, data, message: data?.message || 'OK' };
+    if (status === 'OK') return { ok: true, data, message: data?.message || '' };
     return { ok: false, data: data || null, message: data?.message || data?.error || 'Невідома помилка' };
   } catch (e) {
     return {
@@ -87,7 +90,7 @@ export async function postTournamentJson(payload, timeoutMs = 20000) {
 }
 
 export function createTournament(payload = {}) {
-  return postTournamentJson({
+  return postGasJson({
     action: 'createTournament',
     mode: 'tournament',
     name: payload.name || '',
@@ -100,7 +103,7 @@ export function createTournament(payload = {}) {
 }
 
 export function saveTournamentTeams(payload = {}) {
-  return postTournamentJson({
+  return postGasJson({
     action: 'saveTeams',
     mode: 'tournament',
     tournamentId: payload.tournamentId || '',
@@ -109,7 +112,7 @@ export function saveTournamentTeams(payload = {}) {
 }
 
 export function createTournamentGames(payload = {}) {
-  return postTournamentJson({
+  return postGasJson({
     action: 'createGames',
     mode: 'tournament',
     tournamentId: payload.tournamentId || '',
@@ -118,7 +121,7 @@ export function createTournamentGames(payload = {}) {
 }
 
 export function saveTournamentGame(payload = {}) {
-  return postTournamentJson({
+  return postGasJson({
     action: 'saveGame',
     mode: 'tournament',
     tournamentId: payload.tournamentId || '',
@@ -135,7 +138,7 @@ export function saveTournamentGame(payload = {}) {
 }
 
 export function getTournamentData(tournamentId) {
-  return postTournamentJson({
+  return postGasJson({
     action: 'getTournamentData',
     mode: 'tournament',
     tournamentId: tournamentId || '',
@@ -143,7 +146,7 @@ export function getTournamentData(tournamentId) {
 }
 
 export function listTournaments({ league, status } = {}) {
-  return postTournamentJson({
+  return postGasJson({
     action: 'listTournaments',
     mode: 'tournament',
     league: league ? normalizeLeague(league) : '',

--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -210,7 +210,8 @@ function buildTournamentTeamsPayload() {
 }
 
 function buildTournamentGamePayload() {
-  const gameId = state.tournamentState.currentGameId || `G${String(state.tournamentState.nextGameNumber).padStart(3, '0')}`;
+  const gameNumber = Number(state.tournamentState.nextGameNumber) || 1;
+  const gameId = state.tournamentState.currentGameId || `G${String(gameNumber).padStart(3, '0')}`;
   const summary = computeSeriesSummary();
   const result = summary.winner === 'tie' ? 'DRAW' : (summary.winner === 'team1' ? 'A' : 'B');
   return {
@@ -240,22 +241,28 @@ function resetMatchOnlyState() {
 
 function validateSave() {
   if (state.app.eventMode === 'tournament') {
-    if (!state.tournamentState.tournamentId) return 'Спочатку створіть турнір';
-    if (!state.tournamentState.teamsSaved) return 'Спочатку збережіть команди турніру';
-    if (!state.activeTeamAId || !state.activeTeamBId) return 'Виберіть активні команди';
-    if (state.activeTeamAId === state.activeTeamBId) return 'Команда A і Команда B мають бути різними';
+    if (!state.tournamentState.tournamentId) return 'Спочатку створи турнір';
+    if (!state.tournamentState.teamsSaved) return 'Спочатку збережи команди турніру';
+    if (!state.activeTeamAId || !state.activeTeamBId) return 'Обери дві команди матчу';
+    if (state.activeTeamAId === state.activeTeamBId) return 'Обери дві різні команди матчу';
     const teamAPlayers = state.teamsState.teams[state.activeTeamAId] || [];
     const teamBPlayers = state.teamsState.teams[state.activeTeamBId] || [];
-    if (!teamAPlayers.length || !teamBPlayers.length) return 'Обидві активні команди мають містити гравців';
-    if (!['DM', 'TR', 'KT'].includes(state.tournamentState.gameMode)) return 'Невірний режим бою';
-    if (state.tournamentState.gameMode === 'KT' && computeSeriesSummary().winner === 'tie') return 'Для KT нічия недоступна';
+    if (!teamAPlayers.length || !teamBPlayers.length) return 'Обидві активні команди мають гравців';
+    if (!['DM', 'TR', 'KT'].includes(state.tournamentState.gameMode)) return 'Невірний режим матчу';
+    const summary = computeSeriesSummary();
+    if (summary.played < 3) return 'Вкажи результат матчу';
+    const mappedResult = summary.winner === 'tie' ? 'DRAW' : (summary.winner === 'team1' ? 'A' : 'B');
+    if (!['A', 'B', 'DRAW'].includes(mappedResult)) return 'Вкажи коректний результат матчу';
+    if (state.tournamentState.gameMode === 'KT' && mappedResult === 'DRAW') return 'Для KT нічия недоступна';
     const allowed = new Set([...teamAPlayers, ...teamBPlayers]);
     for (const id of ['mvp1', 'mvp2', 'mvp3']) {
       const nick = state.matchState.match[id];
-      if (nick && !allowed.has(nick)) return `${id.toUpperCase()} має бути з активних команд`;
+      if (nick && !allowed.has(nick)) return 'MVP має бути з активних команд';
     }
   }
-  const [teamA, teamB] = getActiveMatchTeams();
+  const [teamA, teamB] = state.app.eventMode === 'tournament'
+    ? [state.activeTeamAId, state.activeTeamBId]
+    : getActiveMatchTeams();
   if (!state.teamsState.teams[teamA]?.length || !state.teamsState.teams[teamB]?.length) return 'Активні команди не заповнені';
   if (computeSeriesSummary().played < 3) return 'Потрібно мінімум 3 зіграні бої';
   return '';
@@ -299,7 +306,7 @@ async function doSave(retry = false) {
   saveLocked = true;
   lockSaveButton(true);
   syncSaveButtonState();
-  setStatus({ state: 'saving', text: 'Зберігаю…', retryVisible: false });
+  setStatus({ state: 'saving', text: state.app.eventMode === 'tournament' ? 'Збереження турнірного матчу...' : 'Зберігаю…', retryVisible: false });
 
   const res = state.app.eventMode === 'tournament'
     ? await saveTournamentGame(payload)


### PR DESCRIPTION
### Motivation
- Tournament saves were silently failing because GAS requests used `Content-Type: application/json`, causing browser preflight/CORS issues and preventing `doPost` from receiving payloads. 
- Tournament save validation also mixed regular active-match teams with tournament-specific `activeTeamAId/activeTeamBId`, which could block legitimate saves.

### Description
- Added an Apps Script friendly POST helper `postGasJson` that sends `Content-Type: text/plain;charset=utf-8` and `body: JSON.stringify(payload)`, parses JSON response and returns unified `{ ok, data, message }` results, and replaced the old tournament fetch path to use it (`v2/scripts/balance2/api.js`).
- Routed tournament endpoints `createTournament`, `saveTournamentTeams`, `createTournamentGames`, `saveTournamentGame`, `getTournamentData`, and `listTournaments` through `postGasJson` to avoid preflight issues and standardize error handling (`v2/scripts/balance2/api.js`).
- Ensured `buildTournamentGamePayload` produces `result` mapped to `"A" | "B" | "DRAW"` and stabilized `gameId` generation to `G${padStart(3)}` using `nextGameNumber || 1` (`v2/scripts/balance2/app.js`).
- Tightened tournament save validation to explicitly check `tournamentId`, `teamsSaved`, two different active teams, both teams having players, valid `gameMode` (`DM|TR|KT`), minimum 3 played rounds, `KT`-mode draw restriction, and MVP ownership in active teams; error messages are user-facing (no silent returns) and tournament-specific checks use `activeTeamAId/activeTeamBId` (`v2/scripts/balance2/app.js`).
- Improved status text during save to show `"Збереження турнірного матчу..."` when in tournament mode and kept regular save flow unchanged (`v2/scripts/balance2/app.js`).

### Testing
- Syntax/type checks passed: ran `node --check v2/scripts/balance2/api.js && node --check v2/scripts/balance2/app.js` and the files validated with no syntax errors.
- Verified code-level changes via diffs and local file checks to ensure `saveTournamentGame` now calls `postGasJson` and `buildTournamentGamePayload`/`validateSave` were updated; manual browser/network QA is recommended per the provided checklist (Network/API, Validation, Successful flow, 5/6 teams, Regular mode).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee05a2dce4832185eb675e90aa01f7)