### PR TITLE
Refine v2 tournaments UI to sharp hub-style layout

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -259,32 +259,39 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   font-size: .82rem;
 }
 
-.tournaments-page {
+/* ===== Tournament UI V2 (home + tournaments hub) ===== */
+.tournaments-page,
+.tournaments-page-v2 {
   display: grid;
   gap: .55rem;
 }
 
 .tournaments-hero,
+.tournaments-page-hero,
 .home-tournaments-card {
   background: linear-gradient(165deg, rgba(49,208,255,.11), rgba(124,255,114,.05));
   border: 1px solid rgba(255,255,255,.16);
   border-radius: 6px;
 }
 
-.tournaments-hero {
+.tournaments-hero,
+.tournaments-page-hero {
   padding: .72rem .82rem;
 }
 
-.tournaments-hero .px-card__title {
+.tournaments-hero .px-card__title,
+.tournaments-page-hero .px-card__title {
   margin-bottom: .35rem;
   letter-spacing: .04em;
 }
 
-.tournaments-hero .px-card__text {
+.tournaments-hero .px-card__text,
+.tournaments-page-hero .px-card__text {
   color: rgba(224, 244, 255, .82);
 }
 
-.tournament-list {
+.tournament-list,
+.tournaments-page-active {
   display: grid;
   gap: .45rem;
   border: 1px solid rgba(255,255,255,.13);
@@ -293,11 +300,13 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   background: rgba(8, 14, 24, .55);
 }
 
-.tournament-list__heading .px-card__title {
+.tournament-list__heading .px-card__title,
+.tournaments-page-active__heading .px-card__title {
   margin-bottom: .2rem;
 }
 
-.tournament-list__grid {
+.tournament-list__grid,
+.tournaments-page-active__list {
   display: grid;
   gap: .5rem;
 }
@@ -342,6 +351,26 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
 .home-tournaments-card__cta,
 .tournament-tab {
   border-radius: 4px !important;
+}
+
+.home-tournaments-card__cta,
+.tournament-open-btn,
+.tournament-tab {
+  border: 1px solid rgba(255,255,255,.2);
+  background: rgba(17, 28, 45, .9);
+  color: #eff8ff;
+  font-size: .77rem;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.home-tournaments-card__cta,
+.tournament-open-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  padding: .36rem .56rem;
 }
 
 .tournament-dashboard__shell {
@@ -487,14 +516,33 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
 
 .tournament-status {
   border-radius: 6px;
+  border: 1px solid rgba(255,255,255,.12);
+  background: rgba(11, 18, 31, .72);
+  padding: .62rem .66rem;
 }
 
+.tournament-status--loading {
+  border-color: rgba(121, 152, 201, .36);
+}
+
+.tournament-status--error {
+  border-color: rgba(255, 111, 111, .44);
+}
+
+.tournament-dashboard-preview,
+.tournaments-preview {
+  display: grid;
+  gap: .5rem;
+}
+
+.tournament-dashboard-preview__grid,
 .tournaments-preview {
   display: grid;
   gap: .5rem;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.tournament-dashboard-preview__card,
 .tournaments-preview__card {
   border: 1px solid rgba(255,255,255,.12);
   border-radius: 6px;
@@ -539,9 +587,26 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   padding: .45rem .55rem;
 }
 
+.home-tournaments-card__item-main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .45rem;
+}
+
 .home-tournaments-card__item-title {
   font-weight: 700;
   margin-bottom: .2rem;
+}
+
+.home-tournaments-card__item-status {
+  border: 1px solid rgba(49,208,255,.4);
+  border-radius: 4px;
+  padding: .08rem .35rem;
+  font-size: .68rem;
+  color: #9ddfff;
+  background: rgba(20, 38, 63, .7);
+  text-transform: uppercase;
 }
 
 .home-tournaments-card__item-meta {
@@ -558,6 +623,26 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   font-size: .76rem !important;
   line-height: 1.2;
   white-space: nowrap;
+}
+
+.home-tournaments-card__empty {
+  border: 1px solid rgba(255,255,255,.1);
+  border-radius: 4px;
+  padding: .52rem .56rem;
+  background: rgba(10, 16, 28, .55);
+}
+
+.home-tournaments-card__empty-title {
+  margin: 0 0 .2rem;
+  font-size: .8rem;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+}
+
+.home-tournaments-card__empty-text {
+  margin: 0;
+  color: var(--muted);
+  font-size: .76rem;
 }
 
 .tournament-player-table {
@@ -599,9 +684,8 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
     grid-template-columns: 1fr;
   }
 
-  .home-tournaments-card__head {
-    align-items: flex-start;
-  }
+  .home-tournaments-card__head { align-items: flex-start; }
+  .home-tournaments-card__item-main { align-items: flex-start; }
 
   .home-v2 .home-place {
     width: 42px;
@@ -8291,10 +8375,10 @@ body.theme-game .v2-rect-tab {
   border-radius: var(--v2-radius-sm);
 }
 
-body.theme-game :is(.home-tournaments-card, .tournaments-hero, .tournament-list, .tournament-dashboard__shell, .tournament-status, .tournaments-preview__card, .tournament-card, .tournament-team-card, .tournament-match-card, .tournament-table-wrap) {
+body.theme-game :is(.home-tournaments-card, .tournaments-hero, .tournaments-page-hero, .tournament-list, .tournaments-page-active, .tournament-dashboard__shell, .tournament-status, .tournaments-preview__card, .tournament-dashboard-preview__card, .tournament-card, .tournament-team-card, .tournament-match-card, .tournament-table-wrap) {
   border-radius: var(--v2-radius-md) !important;
 }
 
-body.theme-game :is(.home-tournaments-card__item, .tournament-meta-item, .tournament-open-btn, .home-tournaments-card__cta, .tournament-tab) {
+body.theme-game :is(.home-tournaments-card__item, .home-tournaments-card__item-status, .home-tournaments-card__empty, .tournament-meta-item, .tournament-open-btn, .home-tournaments-card__cta, .tournament-tab) {
   border-radius: var(--v2-radius-sm) !important;
 }

--- a/v2/pages/home.js
+++ b/v2/pages/home.js
@@ -128,23 +128,37 @@ function renderLeagueSection({ league, players }) {
   </section>`;
 }
 
-function renderHomeTournamentsCard(items = [], unavailable = false) {
-  const list = (items || []).slice(0, 2).map((item) => (
+function renderHomeTournamentsCard(items = [], status = 'empty') {
+  const hasItems = Array.isArray(items) && items.length > 0;
+  const list = (items || []).slice(0, 3).map((item) => (
     `<li class="home-tournaments-card__item">
-      <div class="home-tournaments-card__item-title">${escapeHtml(item?.name || item?.tournamentId || 'Турнір')}</div>
+      <div class="home-tournaments-card__item-main">
+        <div class="home-tournaments-card__item-title">${escapeHtml(item?.name || item?.tournamentId || 'Турнір')}</div>
+        <span class="home-tournaments-card__item-status">${escapeHtml(item?.status || 'ACTIVE')}</span>
+      </div>
       <div class="home-tournaments-card__item-meta">
         <span>Ліга: ${escapeHtml(item?.league || '—')}</span>
-        <span>Статус: ${escapeHtml(item?.status || 'ACTIVE')}</span>
       </div>
     </li>`
   )).join('');
+  const emptyTitle = status === 'error'
+    ? 'Не вдалося завантажити турніри'
+    : (status === 'loading' ? 'Завантаження турнірів...' : 'Поки немає активних турнірів');
+  const emptyText = status === 'error'
+    ? 'Спробуй оновити сторінку пізніше'
+    : (status === 'loading'
+      ? 'Оновлюємо список активних турнірів'
+      : 'Коли турнір з’явиться, тут буде швидкий доступ до всіх результатів');
   return `<section class="px-card home-tournaments-card">
     <div class="home-tournaments-card__head">
-      <h3 class="px-card__title">Активні турніри</h3>
-      <a class="btn btn--secondary home-tournaments-card__cta" href="#tournaments">До турнірів</a>
+      <h3 class="px-card__title">АКТИВНІ ТУРНІРИ</h3>
+      <a class="home-tournaments-card__cta" href="#tournaments">ДО ТУРНІРІВ</a>
     </div>
-    <p class="px-card__text">${list ? 'Командні битви, матчі та статистика в одному розділі' : (unavailable ? 'Скоро тут з’являться активні турніри' : 'Турніри готуються')}</p>
-    ${list ? `<ul class="list-clean home-tournaments-card__list">${list}</ul>` : ''}
+    <p class="px-card__text">Слідкуй за турнірною таблицею, матчами та статистикою команд</p>
+    ${hasItems ? `<ul class="list-clean home-tournaments-card__list">${list}</ul>` : `<div class="home-tournaments-card__empty">
+      <p class="home-tournaments-card__empty-title">${emptyTitle}</p>
+      <p class="home-tournaments-card__empty-text">${emptyText}</p>
+    </div>`}
   </section>`;
 }
 
@@ -360,7 +374,7 @@ async function safeInitHomePage(root) {
     stateBox.hidden = false;
     stateBox.textContent = 'Дані тимчасово недоступні';
     leadersNowMount.innerHTML = renderLeadersNow(null, null);
-    homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], true);
+    homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], 'error');
     leagueSections.innerHTML = '';
   };
 
@@ -392,14 +406,14 @@ async function safeInitHomePage(root) {
     const kidsPlayers = pickSeasonActive(kidsLive?.players || []);
 
     leadersNowMount.innerHTML = renderLeadersNow(adultsPlayers[0] || null, kidsPlayers[0] || null);
-    homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], true);
+    homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], 'loading');
     fetchHomeTournaments()
       .then((items) => {
-        homeTournamentsMount.innerHTML = renderHomeTournamentsCard(items);
+        homeTournamentsMount.innerHTML = renderHomeTournamentsCard(items, 'empty');
       })
       .catch(() => {
         console.warn('[home] tournaments unavailable');
-        homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], true);
+        homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], 'error');
       });
 
     leagueSections.innerHTML = HOME_LEAGUES.map((league) => renderLeagueSection({

--- a/v2/pages/tournaments.js
+++ b/v2/pages/tournaments.js
@@ -21,15 +21,16 @@ function clear(node) {
   if (node) node.replaceChildren();
 }
 
-function stateCard(title, text = '', className = 'px-card') {
-  const wrap = createElement('article', `${className} tournament-status`);
-  wrap.append(createElement('h3', 'px-card__title', title));
+function stateCard(title, text = '', tone = 'empty') {
+  const wrap = createElement('article', `px-card tournament-status tournament-status--${tone}`);
+  wrap.append(createElement('h3', 'px-card__title tournament-status__title', title));
   if (text) wrap.append(createElement('p', 'px-card__text', text));
   return wrap;
 }
 
 function createPreviewSections() {
-  const wrap = createElement('section', 'tournaments-preview');
+  const wrap = createElement('section', 'tournament-dashboard-preview');
+  const shell = createElement('div', 'tournament-dashboard-preview__grid');
   const items = [
     {
       title: 'Таблиця команд',
@@ -46,14 +47,15 @@ function createPreviewSections() {
   ];
 
   items.forEach((item) => {
-    const card = createElement('article', 'px-card tournaments-preview__card');
+    const card = createElement('article', 'px-card tournament-dashboard-preview__card');
     card.append(
       createElement('h3', 'px-card__title', item.title),
       createElement('p', 'px-card__text', item.text)
     );
-    wrap.append(card);
+    shell.append(card);
   });
 
+  wrap.append(shell);
   return wrap;
 }
 
@@ -67,7 +69,7 @@ function createMetaItem(label, value, className = '') {
 }
 
 function sanitizeErrorMessage() {
-  return 'Спробуй оновити сторінку або перевірити підключення до API';
+  return 'Спробуй оновити сторінку пізніше';
 }
 
 function statusClass(status = '') {
@@ -105,21 +107,23 @@ export async function initTournamentsPage(params = {}) {
 
   clear(root);
 
-  const hero = createElement('section', 'px-card tournaments-hero');
+  root.classList.add('tournaments-page-v2');
+
+  const hero = createElement('section', 'px-card tournaments-page-hero');
   hero.append(
-    createElement('h1', 'px-card__title', 'Турніри'),
+    createElement('h1', 'px-card__title', 'ТУРНІРИ'),
     createElement('p', 'px-card__text', 'Командні битви, матчі, таблиця та статистика')
   );
 
-  const listWrap = createElement('section', 'px-card tournament-list');
-  const listHeading = createElement('div', 'tournament-list__heading');
+  const listWrap = createElement('section', 'px-card tournaments-page-active');
+  const listHeading = createElement('div', 'tournaments-page-active__heading');
   listHeading.append(
-    createElement('h2', 'px-card__title', 'Активні турніри'),
-    createElement('p', 'px-card__text', 'Оберіть турнір, щоб переглянути таблицю, матчі та статистику')
+    createElement('h2', 'px-card__title', 'АКТИВНІ ТУРНІРИ'),
+    createElement('p', 'px-card__text', 'Обери турнір, щоб переглянути таблицю, матчі та статистику')
   );
 
-  const dashboard = createElement('section', 'tournament-dashboard');
-  listWrap.append(listHeading, stateCard('Завантаження турнірів...', 'Отримуємо список активних ігор'));
+  const dashboard = createElement('section', 'tournament-dashboard-shell');
+  listWrap.append(listHeading, stateCard('Завантаження турнірів...', 'Отримуємо список активних ігор', 'loading'));
   root.append(hero, listWrap, dashboard);
 
   try {
@@ -128,13 +132,13 @@ export async function initTournamentsPage(params = {}) {
 
     listWrap.replaceChildren(listHeading);
     if (!tournaments.length) {
-      listWrap.append(stateCard('Активних турнірів поки немає', 'Щойно буде створено перший турнір, тут з’являться таблиця, матчі й статистика'));
+      listWrap.append(stateCard('АКТИВНИХ ТУРНІРІВ ПОКИ НЕМАЄ', 'Коли турнір з’явиться, тут буде доступ до таблиці команд, матчів і статистики', 'empty'));
       dashboard.replaceChildren(createPreviewSections());
       return;
     }
 
     const selectedId = String(params.selected || params.id || '').trim();
-    const grid = createElement('div', 'tournament-list__grid');
+    const grid = createElement('div', 'tournaments-page-active__list');
     let autoOpenId = '';
 
     tournaments.forEach((tournament, idx) => {
@@ -155,7 +159,7 @@ export async function initTournamentsPage(params = {}) {
       card.append(meta);
 
       const actions = createElement('div', 'tournament-card__actions');
-      const openBtn = createElement('button', 'btn tournament-open-btn', actionLabel(tournament?.status));
+      const openBtn = createElement('button', 'tournament-open-btn', actionLabel(tournament?.status));
       openBtn.type = 'button';
       openBtn.addEventListener('click', () => openTournament(tournamentId, dashboard, grid));
       actions.append(openBtn);
@@ -173,7 +177,7 @@ export async function initTournamentsPage(params = {}) {
     if (autoOpenId) await openTournament(autoOpenId, dashboard, grid, true);
   } catch {
     console.warn('[tournaments] list failed');
-    listWrap.replaceChildren(listHeading, stateCard('Турніри тимчасово недоступні', 'Спробуй оновити сторінку трохи пізніше', 'px-card'));
+    listWrap.replaceChildren(listHeading, stateCard('Не вдалося завантажити дані турнірів', 'Спробуй оновити сторінку пізніше', 'error'));
     dashboard.replaceChildren(createPreviewSections());
   }
 }
@@ -188,7 +192,7 @@ function activateTournamentCard(listNode, nextId) {
 async function openTournament(tournamentId, dashboardNode, listNode, silentHashUpdate = false) {
   if (!dashboardNode || !tournamentId) return;
   activateTournamentCard(listNode, tournamentId);
-  dashboardNode.replaceChildren(stateCard('Завантаження даних турніру...', 'Будь ласка, зачекай'));
+  dashboardNode.replaceChildren(stateCard('Завантаження даних турніру...', 'Будь ласка, зачекай', 'loading'));
 
   try {
     const data = await getTournamentData(tournamentId);
@@ -203,7 +207,7 @@ async function openTournament(tournamentId, dashboardNode, listNode, silentHashU
     renderTournamentDashboard(dashboardNode, data);
   } catch {
     console.warn('[tournaments] dashboard failed');
-    dashboardNode.replaceChildren(stateCard('Не вдалося завантажити турнір', sanitizeErrorMessage(), 'px-card px-card--accent'));
+    dashboardNode.replaceChildren(stateCard('Не вдалося завантажити турнір', sanitizeErrorMessage(), 'error'));
   }
 }
 


### PR DESCRIPTION
### Motivation
- Tournament UI still showed oval/pill visuals due to inheritance from global card/button rules, so tournament blocks needed a v2-aligned rectangular, dense, mobile-first hub treatment.
- The change aims to make the home "Active tournaments" module and the `#tournaments` page feel like a single tournament hub (sharp corners, clear hierarchy, product copy, compact rows) without touching routing or API logic.

### Description
- Isolated tournament markup and states in `v2/pages/home.js` by replacing generic CTA classes with `home-tournaments-card__cta`, introducing `status` modes (`loading`/`empty`/`error`), and restructuring list rows and empty state content for a compact rectangular panel look.
- Reworked tournament hub in `v2/pages/tournaments.js` by adding `tournaments-page-v2` namespace, sharper hero `tournaments-page-hero`, namespaced active list `tournaments-page-active*`, unified preview shell (`tournament-dashboard-preview*`) and a `stateCard` tone parameter to separate loading/empty/error presentation.
- Added targeted tournament-specific CSS in `v2/assets/css/main.css`: new namespaces, compact spacing, normalized radii (`--v2-radius-sm`/`--v2-radius-md`), explicit rectangular button/card styles for tournament elements, and final `body.theme-game :is(...)` overrides to prevent global `.btn` pill radius from affecting tournament UI.
- Files changed: `v2/pages/home.js`, `v2/pages/tournaments.js`, `v2/assets/css/main.css` and changes were intentionally limited to these files only.

### Testing
- Ran syntax checks with `node --check v2/pages/home.js` and `node --check v2/pages/tournaments.js`, both completed without errors.
- Verified CSS edits are scoped to tournament namespaces and added v2 radius overrides to prevent regression from global `.btn` rules (manual cascade inspection of `v2/assets/css/main.css`).
- No other automated test suites were modified or required; commit applied and local commit recorded successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1c41dd9083218e3a382ad1a60d4f)