### PR TITLE
Normalize v2 radius tokens and enforce rectangular corners for tournament/home UI

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -10,6 +10,10 @@ body.theme-game #app :is(.topnav, .page, .container, .hero, .px-card, .section, 
   --muted: #9cb0cf;
   --accent: #31d0ff;
   --accent-2: #7cff72;
+  --v2-radius-xs: 2px;
+  --v2-radius-sm: 4px;
+  --v2-radius-md: 6px;
+  --v2-radius-lg: 8px;
   /* Canonical rank palette (synced with original/main site). */
   --rank-s: #a44dff;
   --rank-a: #ff4fa3;
@@ -8357,14 +8361,9 @@ body.theme-game .rules-v2.rules-v2--clean > .px-card::after,
 }
 
 /* v2 UI rule:
-   content cards, buttons, tabs and state blocks use sharp rectangular corners.
-   Avoid pill/oval radius in v2 content UI. */
-body.theme-game {
-  --v2-radius-xs: 2px;
-  --v2-radius-sm: 4px;
-  --v2-radius-md: 6px;
-  --v2-radius-lg: 8px;
-}
+   Content cards, CTA buttons, tabs, state blocks and tournament UI use sharp rectangular corners.
+   Avoid pill/oval radius in v2 content UI.
+*/
 
 body.theme-game .v2-rect-card {
   border-radius: var(--v2-radius-md);
@@ -8375,10 +8374,40 @@ body.theme-game .v2-rect-tab {
   border-radius: var(--v2-radius-sm);
 }
 
-body.theme-game :is(.home-tournaments-card, .tournaments-hero, .tournaments-page-hero, .tournament-list, .tournaments-page-active, .tournament-dashboard__shell, .tournament-status, .tournaments-preview__card, .tournament-dashboard-preview__card, .tournament-card, .tournament-team-card, .tournament-match-card, .tournament-table-wrap) {
+body.theme-game :is(
+  .home-tournaments-card,
+  .home-tournament-strip,
+  .home-tournaments-card__item,
+  .tournaments-page,
+  .tournaments-hero,
+  .tournaments-page-hero,
+  .tournaments-state,
+  .tournaments-empty,
+  .tournaments-preview-card,
+  .tournaments-preview__card,
+  .tournament-list,
+  .tournaments-page-active,
+  .tournament-card,
+  .tournament-dashboard,
+  .tournament-dashboard__shell,
+  .tournament-status,
+  .tournament-dashboard-preview__card,
+  .tournament-table-wrap,
+  .tournament-team-card,
+  .tournament-match-card,
+  .tournament-player-table
+) {
   border-radius: var(--v2-radius-md) !important;
 }
 
-body.theme-game :is(.home-tournaments-card__item, .home-tournaments-card__item-status, .home-tournaments-card__empty, .tournament-meta-item, .tournament-open-btn, .home-tournaments-card__cta, .tournament-tab) {
+body.theme-game :is(
+  .home-tournaments-card__cta,
+  .home-tournament-strip__action,
+  .tournament-open-btn,
+  .tournament-tab,
+  .home-tournaments-card__item-status,
+  .home-tournaments-card__empty,
+  .tournament-meta-item
+) {
   border-radius: var(--v2-radius-sm) !important;
 }


### PR DESCRIPTION
### Motivation
- The root cause was shared/generic large radius rules in `v2/assets/css/main.css` (cards/cta/chip utilities) leaking oval/pill look into new content UI components. 
- Existing v2 guardrail existed but did not cover several tournament/home selectors from the target list, so new tournament elements could inherit pill radii.

### Description
- Added canonical v2 radius tokens to `:root` (`--v2-radius-xs: 2px`, `--v2-radius-sm: 4px`, `--v2-radius-md: 6px`, `--v2-radius-lg: 8px`) and moved policy comment to the v2 section.  
- Expanded the v2 rectangular guardrail in `v2/assets/css/main.css` to explicitly target tournament/home selectors (examples: ` .home-tournaments-card`, `.home-tournament-strip`, `.tournaments-page`, `.tournaments-empty`, `.tournaments-preview-card`, `.tournament-card`, `.tournament-dashboard`, `.tournament-table-wrap`, `.tournament-team-card`, `.tournament-match-card`, `.tournament-player-table`), applying `border-radius: var(--v2-radius-md)` for cards and `var(--v2-radius-sm)` for CTAs/tabs.  
- Kept allowed exceptions (avatars, small rank badges, decorative dots) intact and did not modify markup in `v2/pages/home.js` or `v2/pages/tournaments.js`.  
- Used `!important` in the guardrail rules to neutralize legacy/high-specificity rounded selectors that otherwise keep producing pill corners, with intent to remove once legacy rules are refactored.

### Testing
- Ran a targeted grep to confirm radius-related rules: `rg -n "border-radius|rounded|pill|chip|tag|badge|btn-pill|state-pill|home-tournaments|tournament" v2/assets/css/main.css v2/pages/home.js v2/pages/tournaments.js` (inspection completed).  
- Built the repo asset task `npm run build:summer2025-og` and it completed successfully.  
- Manual verification checklist prepared for QA to validate `#main` and `#tournaments` UI (cards, CTA, empty/error states, preview cards, tabs) remain rectangular and avatars/rank badges are unaffected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee249413d883218fe998409232407f)