### PR TITLE
Переробка блоку «Активні турніри» на компактний teaser-модуль

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -649,6 +649,109 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   font-size: .76rem;
 }
 
+.home-tournaments-teaser {
+  background: linear-gradient(165deg, rgba(49,208,255,.11), rgba(124,255,114,.05));
+  border: 1px solid rgba(255,255,255,.16);
+  border-radius: var(--v2-radius-md);
+  padding: .62rem .72rem;
+  display: grid;
+  gap: .36rem;
+}
+
+.home-tournaments-teaser__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: .5rem;
+}
+
+.home-tournaments-teaser__header h2 {
+  margin: 0;
+  font-size: 1.02rem;
+}
+
+.home-tournaments-teaser__kicker {
+  margin: 0 0 .14rem;
+  font-size: .68rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.home-tournaments-teaser__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  border: 1px solid rgba(255,255,255,.2);
+  background: rgba(17, 28, 45, .9);
+  color: #eff8ff;
+  padding: .34rem .52rem;
+  font-size: .74rem;
+  line-height: 1.2;
+  border-radius: var(--v2-radius-sm);
+  min-height: auto;
+  white-space: nowrap;
+}
+
+.home-tournaments-teaser__text {
+  margin: 0;
+  color: rgba(224, 244, 255, .82);
+  font-size: .82rem;
+}
+
+.home-tournaments-teaser__content {
+  display: grid;
+  gap: .34rem;
+}
+
+.home-tournaments-teaser__empty {
+  border: 1px solid rgba(255,255,255,.1);
+  border-radius: var(--v2-radius-sm);
+  background: rgba(10, 16, 28, .55);
+  padding: .48rem .56rem;
+}
+
+.home-tournaments-teaser__empty strong {
+  font-size: .82rem;
+}
+
+.home-tournaments-teaser__empty p {
+  margin: .2rem 0 0;
+  color: var(--muted);
+  font-size: .76rem;
+}
+
+.home-tournaments-teaser__row {
+  border: 1px solid rgba(255,255,255,.11);
+  border-radius: var(--v2-radius-sm);
+  background: rgba(10, 16, 28, .66);
+  padding: .42rem .52rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .4rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.home-tournaments-teaser__row strong {
+  display: block;
+  font-size: .85rem;
+}
+
+.home-tournaments-teaser__meta {
+  display: block;
+  color: var(--muted);
+  font-size: .74rem;
+  margin-top: .14rem;
+}
+
+.home-tournaments-teaser__arrow {
+  color: rgba(49,208,255,.9);
+  font-size: .85rem;
+}
+
 .tournament-player-table {
   min-width: 760px;
 }
@@ -690,6 +793,7 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
 
   .home-tournaments-card__head { align-items: flex-start; }
   .home-tournaments-card__item-main { align-items: flex-start; }
+  .home-tournaments-teaser__header { flex-wrap: wrap; }
 
   .home-v2 .home-place {
     width: 42px;
@@ -8377,7 +8481,9 @@ body.theme-game .v2-rect-tab {
 body.theme-game :is(
   .home-tournaments-card,
   .home-tournament-strip,
+  .home-tournaments-teaser,
   .home-tournaments-card__item,
+  .home-tournaments-teaser__row,
   .tournaments-page,
   .tournaments-hero,
   .tournaments-page-hero,
@@ -8403,10 +8509,12 @@ body.theme-game :is(
 body.theme-game :is(
   .home-tournaments-card__cta,
   .home-tournament-strip__action,
+  .home-tournaments-teaser__cta,
   .tournament-open-btn,
   .tournament-tab,
   .home-tournaments-card__item-status,
   .home-tournaments-card__empty,
+  .home-tournaments-teaser__empty,
   .tournament-meta-item
 ) {
   border-radius: var(--v2-radius-sm) !important;

--- a/v2/pages/home.js
+++ b/v2/pages/home.js
@@ -128,37 +128,50 @@ function renderLeagueSection({ league, players }) {
   </section>`;
 }
 
+function formatHomeTournamentMeta(item = {}) {
+  const league = escapeHtml(leagueLabelUA(item?.league) || item?.league || 'Ліга');
+  const status = escapeHtml(String(item?.status || 'ACTIVE').toUpperCase());
+  const dateStart = item?.dateStart ? new Date(item.dateStart) : null;
+  if (dateStart && !Number.isNaN(dateStart.getTime())) {
+    const dateLabel = escapeHtml(dateStart.toLocaleDateString('uk-UA', { day: '2-digit', month: '2-digit' }));
+    return `${league} · ${status} · ${dateLabel}`;
+  }
+  return `${league} · ${status}`;
+}
+
 function renderHomeTournamentsCard(items = [], status = 'empty') {
   const hasItems = Array.isArray(items) && items.length > 0;
-  const list = (items || []).slice(0, 3).map((item) => (
-    `<li class="home-tournaments-card__item">
-      <div class="home-tournaments-card__item-main">
-        <div class="home-tournaments-card__item-title">${escapeHtml(item?.name || item?.tournamentId || 'Турнір')}</div>
-        <span class="home-tournaments-card__item-status">${escapeHtml(item?.status || 'ACTIVE')}</span>
+  const visibleItems = hasItems ? items.slice(0, 2) : [];
+  const restCount = hasItems && items.length > 2 ? items.length - 2 : 0;
+  const list = visibleItems.map((item) => (
+    `<a class="home-tournaments-teaser__row" href="#tournaments?selected=${encodeURIComponent(item?.tournamentId || '')}">
+      <div>
+        <strong>${escapeHtml(item?.name || item?.tournamentId || 'Турнір')}</strong>
+        <span class="home-tournaments-teaser__meta">${formatHomeTournamentMeta(item)}</span>
       </div>
-      <div class="home-tournaments-card__item-meta">
-        <span>Ліга: ${escapeHtml(item?.league || '—')}</span>
-      </div>
-    </li>`
+      <span class="home-tournaments-teaser__arrow" aria-hidden="true">→</span>
+    </a>`
   )).join('');
-  const emptyTitle = status === 'error'
-    ? 'Не вдалося завантажити турніри'
-    : (status === 'loading' ? 'Завантаження турнірів...' : 'Поки немає активних турнірів');
-  const emptyText = status === 'error'
-    ? 'Спробуй оновити сторінку пізніше'
-    : (status === 'loading'
-      ? 'Оновлюємо список активних турнірів'
-      : 'Коли турнір з’явиться, тут буде швидкий доступ до всіх результатів');
-  return `<section class="px-card home-tournaments-card">
-    <div class="home-tournaments-card__head">
-      <h3 class="px-card__title">АКТИВНІ ТУРНІРИ</h3>
-      <a class="home-tournaments-card__cta" href="#tournaments">ДО ТУРНІРІВ</a>
+
+  if (status === 'error') {
+    console.warn('[home] tournaments unavailable, using neutral fallback');
+  }
+
+  return `<section class="home-tournaments-teaser">
+    <div class="home-tournaments-teaser__header">
+      <div>
+        <p class="home-tournaments-teaser__kicker">ТУРНІРНИЙ РЕЖИМ</p>
+        <h2>Активні турніри</h2>
+      </div>
+      <a href="#tournaments" class="home-tournaments-teaser__cta">До турнірів</a>
     </div>
-    <p class="px-card__text">Слідкуй за турнірною таблицею, матчами та статистикою команд</p>
-    ${hasItems ? `<ul class="list-clean home-tournaments-card__list">${list}</ul>` : `<div class="home-tournaments-card__empty">
-      <p class="home-tournaments-card__empty-title">${emptyTitle}</p>
-      <p class="home-tournaments-card__empty-text">${emptyText}</p>
-    </div>`}
+    <p class="home-tournaments-teaser__text">Слідкуй за турнірною таблицею, матчами та статистикою команд.</p>
+    <div class="home-tournaments-teaser__content">
+      ${hasItems ? `${list}${restCount > 0 ? `<span class="home-tournaments-teaser__meta">+${restCount} ще</span>` : ''}` : `<div class="home-tournaments-teaser__empty">
+        <strong>Поки немає активних турнірів</strong>
+        <p>Коли турнір стартує, тут з’явиться швидкий доступ до таблиці та матчів.</p>
+      </div>`}
+    </div>
   </section>`;
 }
 


### PR DESCRIPTION
### Motivation
- Блок "Активні турніри" виглядав технічним і громіздким, потрібно зробити компактний продуктний teaser між "Лідери сезону" і "Топ 10". 
- Інтегрувати CTA у заголовок, прибрати технічні повідомлення про помилки у UI та показувати нейтральний fallback при відсутності або падінні API. 
- Дотриматись v2-вимог щодо прямокутних радіусів і компактної композиції без pill/oval елементів.

### Description
- Оновлено рендер у `v2/pages/home.js`: замість старого `.home-tournaments-card` повертається новий `<section class="home-tournaments-teaser">` з `kicker`, `title`, інтегрованим правим CTA та коротким описом. 
- Додано `formatHomeTournamentMeta` і логіку рендера рядків: показ до 2 турнірів як клікабельних рядків що ведуть на `#tournaments?selected=TOURNAMENT_ID`, та індикація `+N ще` якщо більше. 
- Змінено fallback: при відсутності даних або помилці показується нейтральний стан з текстами `Поки немає активних турнірів` і `Коли турнір стартує, тут з’явиться швидкий доступ до таблиці та матчів.`, при помилці API залишається лише `console.warn` без raw error в UI. 
- Додано стилі в `v2/assets/css/main.css` для `.home-tournaments-teaser` та супутніх класів, включно з мобільною адаптацією і додаванням нових класів до v2 rectangular guardrail (використовуються лише `var(--v2-radius-sm)` / `var(--v2-radius-md)`). 
- Торкнуто лише `v2/pages/home.js` і `v2/assets/css/main.css`; не змінювався маршрут `#tournaments`, `v2/pages/tournaments.js`, `v2/core/*`, backend чи інші заборонені частини.

### Testing
- Запущена перевірка синтаксису: `node --check v2/pages/home.js` — успішно. 
- Зібрано проект preview: `npm run build:summer2025-og` — успішно (генерація прев’ю пройшла). 
- Немає додаткових автоматичних юніт-тестів у репозиторії для цього патчу; рекомендація — ручна перевірка в браузері за checklist з опису (відкриття `#main`, перевірка fallback, поведінки рядків і CTA).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee25c3935c8321a2a431c6865db9b7)