### PR TITLE
Refine v2 home active tournaments teaser layout

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -653,21 +653,26 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   background: linear-gradient(165deg, rgba(49,208,255,.11), rgba(124,255,114,.05));
   border: 1px solid rgba(255,255,255,.16);
   border-radius: var(--v2-radius-md);
-  padding: .62rem .72rem;
+  padding: .58rem .66rem;
   display: grid;
-  gap: .36rem;
+  gap: .3rem;
 }
 
 .home-tournaments-teaser__header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: .5rem;
+  gap: .45rem;
+}
+
+.home-tournaments-teaser__titleBlock {
+  min-width: 0;
 }
 
 .home-tournaments-teaser__header h2 {
   margin: 0;
-  font-size: 1.02rem;
+  font-size: .99rem;
+  line-height: 1.2;
 }
 
 .home-tournaments-teaser__kicker {
@@ -689,15 +694,17 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   padding: .34rem .52rem;
   font-size: .74rem;
   line-height: 1.2;
-  border-radius: var(--v2-radius-sm);
+  border-radius: min(var(--v2-radius-sm), 4px);
   min-height: auto;
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .home-tournaments-teaser__text {
   margin: 0;
   color: rgba(224, 244, 255, .82);
-  font-size: .82rem;
+  font-size: .79rem;
+  line-height: 1.38;
 }
 
 .home-tournaments-teaser__content {
@@ -709,7 +716,7 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   border: 1px solid rgba(255,255,255,.1);
   border-radius: var(--v2-radius-sm);
   background: rgba(10, 16, 28, .55);
-  padding: .48rem .56rem;
+  padding: .46rem .52rem;
 }
 
 .home-tournaments-teaser__empty strong {
@@ -726,7 +733,7 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   border: 1px solid rgba(255,255,255,.11);
   border-radius: var(--v2-radius-sm);
   background: rgba(10, 16, 28, .66);
-  padding: .42rem .52rem;
+  padding: .38rem .5rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -744,7 +751,7 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   display: block;
   color: var(--muted);
   font-size: .74rem;
-  margin-top: .14rem;
+  margin-top: .12rem;
 }
 
 .home-tournaments-teaser__arrow {

--- a/v2/pages/home.js
+++ b/v2/pages/home.js
@@ -142,9 +142,8 @@ function formatHomeTournamentMeta(item = {}) {
 function renderHomeTournamentsCard(items = [], status = 'empty') {
   const hasItems = Array.isArray(items) && items.length > 0;
   const visibleItems = hasItems ? items.slice(0, 2) : [];
-  const restCount = hasItems && items.length > 2 ? items.length - 2 : 0;
   const list = visibleItems.map((item) => (
-    `<a class="home-tournaments-teaser__row" href="#tournaments?selected=${encodeURIComponent(item?.tournamentId || '')}">
+    `<a class="home-tournaments-teaser__row" href="${item?.tournamentId ? `#tournaments?selected=${encodeURIComponent(item.tournamentId)}` : '#tournaments'}">
       <div>
         <strong>${escapeHtml(item?.name || item?.tournamentId || 'Турнір')}</strong>
         <span class="home-tournaments-teaser__meta">${formatHomeTournamentMeta(item)}</span>
@@ -159,7 +158,7 @@ function renderHomeTournamentsCard(items = [], status = 'empty') {
 
   return `<section class="home-tournaments-teaser">
     <div class="home-tournaments-teaser__header">
-      <div>
+      <div class="home-tournaments-teaser__titleBlock">
         <p class="home-tournaments-teaser__kicker">ТУРНІРНИЙ РЕЖИМ</p>
         <h2>Активні турніри</h2>
       </div>
@@ -167,7 +166,7 @@ function renderHomeTournamentsCard(items = [], status = 'empty') {
     </div>
     <p class="home-tournaments-teaser__text">Слідкуй за турнірною таблицею, матчами та статистикою команд.</p>
     <div class="home-tournaments-teaser__content">
-      ${hasItems ? `${list}${restCount > 0 ? `<span class="home-tournaments-teaser__meta">+${restCount} ще</span>` : ''}` : `<div class="home-tournaments-teaser__empty">
+      ${hasItems ? list : `<div class="home-tournaments-teaser__empty">
         <strong>Поки немає активних турнірів</strong>
         <p>Коли турнір стартує, тут з’явиться швидкий доступ до таблиці та матчів.</p>
       </div>`}
@@ -424,8 +423,8 @@ async function safeInitHomePage(root) {
       .then((items) => {
         homeTournamentsMount.innerHTML = renderHomeTournamentsCard(items, 'empty');
       })
-      .catch(() => {
-        console.warn('[home] tournaments unavailable');
+      .catch((error) => {
+        console.warn('[home] tournaments unavailable', error);
         homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], 'error');
       });
 


### PR DESCRIPTION
### Motivation
- Поточний блок «Активні турніри» виглядав як відособлений технічний модуль і ламав візуальний ритм між «Лідери сезону» та «Top 10». 
- Потрібно було зробити компактний, прямокутний teaser із інтегрованим CTA і нейтральним, продуктним fallback, не змінюючи логіку маршрутів та API.

### Description
- Оновлено `renderHomeTournamentsCard` в `v2/pages/home.js` щоб виводити секцію у рекомендованій DOM-структурі з `home-tournaments-teaser__titleBlock`, заголовком, описом та CTA у header-рядку; показується максимум 2 рядки турнірів, кожен рядок веде на `#tournaments?selected=ID` лише якщо `tournamentId` присутній, інакше на `#tournaments` без порожнього параметра.
- Зроблено neutral empty/error fallback (текст: `Поки немає активних турнірів` + опис) та уникнення raw error в UI, при помилках API тепер логуються через `console.warn` і запит лишається non-blocking (`.then/.catch`).
- Оновлено `v2/assets/css/main.css` щоб ущільнити відступи/типографіку teaser-блоку, додано `.home-tournaments-teaser__titleBlock`, зменшено paddings/gap, встановлено CTA radius як `min(var(--v2-radius-sm), 4px)` і підкручені розміри шрифтів для компактності.
- Торкнувся лише файлів: `v2/pages/home.js` та `v2/assets/css/main.css`; не змінювалася логіка маршрутів `#tournaments`, API transport, сторінка турнірів, блоки лідерів чи рейтингова логіка.

### Testing
- Запущено синтаксичну перевірку файлу: `node --check v2/pages/home.js` — пройшла успішно.
- Збірка скрипта в репозиторії: `npm run build:summer2025-og` — пройшла успішно (генеровано social preview).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee27fc2e348321a33224a5b23a7124)