### PR TITLE
v2: centralize rank rules into v2/core/rankRules.js

### DIFF
--- a/v2/core/dataHub.js
+++ b/v2/core/dataHub.js
@@ -2,6 +2,7 @@
 import seasonsConfig from './seasons.config.js';
 import { jsonp } from './utils.js';
 import { leagueLabelUA, normalizeLeague as normalizeLeagueName, normalizeLeagueKey } from './naming.js';
+import { rankFromPoints as rankFromPointsByRules } from './rankRules.js';
 
 const cache = new Map();
 const inFlight = new Map();
@@ -49,7 +50,6 @@ const RANK_META = {
   E: { label: 'E', cssClass: 'rank-E', themeVars: { '--rank-color': '#666', '--rank-glow': 'rgba(102,102,102,.28)' } },
   F: { label: 'F', cssClass: 'rank-F', themeVars: { '--rank-color': '#444', '--rank-glow': 'rgba(68,68,68,.22)' } }
 };
-const RANK_THRESHOLDS = [['S', 1200], ['A', 1000], ['B', 800], ['C', 600], ['D', 400], ['E', 200], ['F', 0]];
 const RANK_PRIORITY = { S: 0, A: 1, B: 2, C: 3, D: 4, E: 5, F: 6 };
 const MAX_BATTLES_PER_GAME = 7;
 const ARCHIVE_LIMIT_ROWS = 1000;
@@ -423,8 +423,7 @@ function normalizeSeasonMasterPayload(payload, seasonId = '') {
 
 
 export function rankFromPoints(points = 0) {
-  for (const [rank, min] of RANK_THRESHOLDS) if ((points || 0) >= min) return rank;
-  return 'F';
+  return rankFromPointsByRules(points);
 }
 
 export function rankMeta(rank = 'F') { return RANK_META[rank] || RANK_META.F; }

--- a/v2/core/rankRules.js
+++ b/v2/core/rankRules.js
@@ -1,0 +1,60 @@
+export const RANK_THRESHOLDS = [
+  ['S', 1200],
+  ['A', 1000],
+  ['B', 800],
+  ['C', 600],
+  ['D', 400],
+  ['E', 200],
+  ['F', 0],
+];
+
+export function normalizePoints(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function rankFromPoints(points) {
+  const pts = normalizePoints(points);
+  const found = RANK_THRESHOLDS.find(([, min]) => pts >= min);
+  return found ? found[0] : 'F';
+}
+
+export function getNextRankProgress(points) {
+  const pts = normalizePoints(points);
+
+  const ascending = [...RANK_THRESHOLDS]
+    .sort((a, b) => a[1] - b[1]);
+
+  const currentRank = rankFromPoints(pts);
+  const currentIndex = ascending.findIndex(([rank]) => rank === currentRank);
+  const next = ascending[currentIndex + 1];
+
+  if (!next) {
+    return {
+      currentRank,
+      nextRank: null,
+      currentMin: ascending[currentIndex]?.[1] ?? 0,
+      nextMin: null,
+      points: pts,
+      pointsToNext: 0,
+      progress: 1,
+      isMaxRank: true
+    };
+  }
+
+  const currentMin = ascending[currentIndex]?.[1] ?? 0;
+  const nextMin = next[1];
+  const span = Math.max(nextMin - currentMin, 1);
+  const progress = Math.max(0, Math.min(1, (pts - currentMin) / span));
+
+  return {
+    currentRank,
+    nextRank: next[0],
+    currentMin,
+    nextMin,
+    points: pts,
+    pointsToNext: Math.max(0, nextMin - pts),
+    progress,
+    isMaxRank: false
+  };
+}

--- a/v2/pages/profile.js
+++ b/v2/pages/profile.js
@@ -7,11 +7,10 @@ import {
   safeErrorMessage
 } from '../core/dataHub.js';
 import { normalizeLeague, normalizeLeagueKey, leagueLabelUA } from '../core/naming.js';
+import { getNextRankProgress } from '../core/rankRules.js';
 import { decodeParam, getRouteState, normalizePlayerKey } from '../core/utils.js';
 
 const placeholder = '../assets/default-avatar.svg';
-const RANK_ORDER = ['F', 'E', 'D', 'C', 'B', 'A', 'S'];
-const RANK_MIN_POINTS = { F: 0, E: 200, D: 400, C: 600, B: 800, A: 1000, S: 1200 };
 
 function esc(v) {
   return String(v ?? '').replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
@@ -140,32 +139,22 @@ function seasonOrderKey(label = '') {
   return 99;
 }
 
-function getRankProgress(points, rankLetter) {
-  const rank = String(rankLetter || 'F').toUpperCase();
-  const index = RANK_ORDER.indexOf(rank);
-  const currentMin = RANK_MIN_POINTS[rank] ?? 0;
+function getRankProgress(points) {
   const pointsValue = num(points);
 
   if (pointsValue === null) {
-    return { percent: 0, currentMin, nextMin: null, remain: null, nextRank: null, isMax: rank === 'S' };
+    return { percent: 0, currentMin: 0, nextMin: null, remain: null, nextRank: null, isMax: false };
   }
 
-  if (index === -1 || rank === 'S') {
-    return { percent: 100, currentMin, nextMin: null, remain: 0, nextRank: null, isMax: true };
-  }
-
-  const nextRank = RANK_ORDER[index + 1];
-  const nextMin = RANK_MIN_POINTS[nextRank];
-  const span = Math.max(1, nextMin - currentMin);
-  const percent = Math.max(0, Math.min(100, ((pointsValue - currentMin) / span) * 100));
+  const progress = getNextRankProgress(pointsValue);
 
   return {
-    percent,
-    currentMin,
-    nextMin,
-    remain: Math.max(0, nextMin - pointsValue),
-    nextRank,
-    isMax: false
+    percent: progress.progress * 100,
+    currentMin: progress.currentMin,
+    nextMin: progress.nextMin,
+    remain: progress.pointsToNext,
+    nextRank: progress.nextRank,
+    isMax: progress.isMaxRank
   };
 }
 

--- a/v2/scripts/balance2/state.js
+++ b/v2/scripts/balance2/state.js
@@ -1,3 +1,5 @@
+import { rankFromPoints } from '../../core/rankRules.js';
+
 export const state = {
   app: {
     league: 'kids',
@@ -83,15 +85,7 @@ export function sortByPointsDesc(a, b) {
 }
 
 export function rankLetterForPoints(points) {
-  const pts = Number(points);
-  if (!Number.isFinite(pts)) return 'F';
-  if (pts >= 1000) return 'S';
-  if (pts >= 900) return 'A';
-  if (pts >= 800) return 'B';
-  if (pts >= 700) return 'C';
-  if (pts >= 600) return 'D';
-  if (pts >= 500) return 'E';
-  return 'F';
+  return rankFromPoints(points);
 }
 
 export function normalizeLeague(league) {


### PR DESCRIPTION
### Motivation
- v2 had duplicated and inconsistent rank calculators across modules which caused players to show different ranks in different places. 
- The change introduces a single source of truth for rank thresholds and helpers to ensure consistent ranking (S:1200+, A:1000+, B:800+, C:600+, D:400+, E:200+, F:0+). 
- The patch must not change scoring formulas, UI/design, GAS/backend, tournament save-flow, or perform large refactors in `dataHub.js`.

### Description
- Added `v2/core/rankRules.js` exporting `RANK_THRESHOLDS`, `normalizePoints(value)`, `rankFromPoints(points)` and `getNextRankProgress(points)` as the shared rank rules module. 
- Replaced local thresholds in `v2/core/dataHub.js` by importing the shared `rankFromPoints` and left a thin wrapper `rankFromPoints` in `dataHub` to preserve its API. 
- Replaced profile-local rank progression in `v2/pages/profile.js` to use `getNextRankProgress` from the shared module and removed the duplicated `RANK_ORDER`/`RANK_MIN_POINTS`. 
- Replaced balance2 local scale in `v2/scripts/balance2/state.js` with `rankFromPoints` from the shared module, removing the outdated `S:1000/A:900/.../E:500` logic.

### Testing
- Ran syntax checks with `node --check` for modified files: `v2/core/rankRules.js`, `v2/core/dataHub.js`, `v2/pages/profile.js`, and `v2/scripts/balance2/state.js`, and they all passed. 
- Executed an automated boundary test for `rankFromPoints` via Node (checking the specified boundary cases 0/199/200/399/.../1200) and it passed. 
- All automated checks completed successfully (Node emitted a harmless module-type warning about `package.json` not specifying `type`, which does not affect the results).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee29deb70883219430ac4633152359)