### PR TITLE
Add live data status + freshness lines (v2)

### DIFF
--- a/tests/dataStatus.test.mjs
+++ b/tests/dataStatus.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatDataUpdatedAt, makeDataStatus } from '../v2/core/dataStatus.js';
+
+test('makeDataStatus returns normalized defaults', () => {
+  const status = makeDataStatus();
+  assert.deepEqual(status, {
+    source: 'unknown',
+    ok: false,
+    updatedAt: null,
+    message: ''
+  });
+});
+
+test('formatDataUpdatedAt returns HH:MM for valid ISO date', () => {
+  const formatted = formatDataUpdatedAt('2026-04-26T14:32:00.000Z');
+  assert.match(formatted, /^\d{2}:\d{2}$/);
+});
+
+test('formatDataUpdatedAt returns empty string for invalid date', () => {
+  assert.equal(formatDataUpdatedAt('not-a-date'), '');
+  assert.equal(formatDataUpdatedAt(null), '');
+});

--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -244,6 +244,36 @@ body.rank-S { background: radial-gradient(circle at top, color-mix(in srgb, var(
   max-width: 40px !important;
 }
 
+.data-status-line {
+  display: inline-block;
+  margin: .4rem 0 0;
+  padding: .24rem .5rem;
+  border: 1px solid rgba(255,255,255,.16);
+  border-radius: var(--v2-radius-sm);
+  font-size: .78rem;
+  line-height: 1.3;
+  color: var(--muted);
+  background: rgba(255,255,255,.04);
+}
+
+.data-status-line--ok {
+  color: #a4e7ff;
+  border-color: rgba(49, 208, 255, .35);
+  background: rgba(49, 208, 255, .12);
+}
+
+.data-status-line--warning {
+  color: #ffe0a3;
+  border-color: rgba(255, 191, 60, .4);
+  background: rgba(255, 191, 60, .12);
+}
+
+.data-status-line--error {
+  color: #ffb3be;
+  border-color: rgba(255, 90, 95, .38);
+  background: rgba(255, 90, 95, .12);
+}
+
 .home-v2 .home-player-info {
   flex: 1 1 auto;
   min-width: 0;

--- a/v2/core/dataHub.js
+++ b/v2/core/dataHub.js
@@ -3,6 +3,7 @@ import seasonsConfig from './seasons.config.js';
 import { jsonp } from './utils.js';
 import { leagueLabelUA, normalizeLeague as normalizeLeagueName, normalizeLeagueKey } from './naming.js';
 import { rankFromPoints as rankFromPointsByRules } from './rankRules.js';
+import { makeDataStatus } from './dataStatus.js';
 
 const cache = new Map();
 const inFlight = new Map();
@@ -444,6 +445,16 @@ function readCache(key, ttlMs) {
     return null;
   }
   return hit.value;
+}
+
+function readCacheEntry(key, ttlMs) {
+  const hit = cache.get(key);
+  if (!hit) return null;
+  if (Date.now() - hit.ts > ttlMs) {
+    cache.delete(key);
+    return null;
+  }
+  return { value: hit.value, ts: hit.ts };
 }
 function readStorageCache(key, ttlMs) {
   if ((!key.startsWith('sheet:') && !key.startsWith('home:')) || typeof window === 'undefined') return null;
@@ -1334,8 +1345,19 @@ function buildAwards(players = [], recentGames = [], progress = {}) {
 export async function getCurrentLeagueLiveStats(leagueId = 'kids') {
   const league = normalizeLeague(leagueId) || 'kids';
   const cacheKey = `league-live-current:${league}`;
-  const cached = readCache(cacheKey, TTL.leagueSnapshot);
-  if (cached) return cached;
+  const cachedEntry = readCacheEntry(cacheKey, TTL.leagueSnapshot);
+  if (cachedEntry?.value) {
+    const cachedUpdatedAt = cachedEntry.value?.dataStatus?.updatedAt || new Date(cachedEntry.ts).toISOString();
+    return {
+      ...cachedEntry.value,
+      dataStatus: makeDataStatus({
+        source: 'cache',
+        ok: false,
+        updatedAt: cachedUpdatedAt,
+        message: 'Live data unavailable'
+      })
+    };
+  }
 
   const season = await fetchCritical('current-season', () => getCurrentSeason());
   const leagueSheet = await fetchCritical(`${league}-sheet`, () => readSheet(league, { limitRows: 4000, limitCols: 40 }));
@@ -1478,9 +1500,19 @@ export async function getCurrentLeagueLiveStats(leagueId = 'kids') {
     summary,
     progress,
     awards: buildCurrentLeagueAwards(activePlayers, progress, seasonLabel),
-    lastGameDay
+    lastGameDay,
+    dataStatus: makeDataStatus({
+      source: 'live',
+      ok: true,
+      updatedAt: new Date().toISOString()
+    })
   };
 
+  console.debug('[dataHub] dataStatus', {
+    source: result.dataStatus.source,
+    ok: result.dataStatus.ok,
+    updatedAt: result.dataStatus.updatedAt
+  });
   return writeCache(cacheKey, result);
 }
 
@@ -1494,8 +1526,19 @@ export async function getLiveLeaguePlayerByNick({ league = 'kids', nick } = {}) 
 export async function getLeagueLiveData(leagueId = 'kids') {
   const league = normalizeLeague(leagueId) || 'kids';
   const cacheKey = `league-live:${league}`;
-  const cached = readCache(cacheKey, TTL.leagueSnapshot);
-  if (cached) return cached;
+  const cachedEntry = readCacheEntry(cacheKey, TTL.leagueSnapshot);
+  if (cachedEntry?.value) {
+    const cachedUpdatedAt = cachedEntry.value?.dataStatus?.updatedAt || new Date(cachedEntry.ts).toISOString();
+    return {
+      ...cachedEntry.value,
+      dataStatus: makeDataStatus({
+        source: 'cache',
+        ok: false,
+        updatedAt: cachedUpdatedAt,
+        message: 'Live data unavailable'
+      })
+    };
+  }
 
   const leagueSheet = await fetchCritical(`${league}-sheet`, () => readSheet(league, { limitRows: 3000, limitCols: 40 }));
   const [logsSheet, gamesSheet, avatarsMap] = await Promise.all([
@@ -1544,7 +1587,7 @@ export async function getLeagueLiveData(leagueId = 'kids') {
   const mostMvp = [...enrichedPlayers].sort((a, b) => (b.mvp || 0) - (a.mvp || 0))[0] || null;
   const progress = { bestGrowth, biggestMinus, mostMvp };
 
-  return writeCache(cacheKey, {
+  const result = {
     league,
     players: enrichedPlayers,
     top10: enrichedPlayers.slice(0, 10),
@@ -1559,8 +1602,19 @@ export async function getLeagueLiveData(leagueId = 'kids') {
     progress,
     awards: buildAwards(enrichedPlayers, recentGames, progress),
     recentGames,
-    recentLogs
+    recentLogs,
+    dataStatus: makeDataStatus({
+      source: 'live',
+      ok: true,
+      updatedAt: new Date().toISOString()
+    })
+  };
+  console.debug('[dataHub] dataStatus', {
+    source: result.dataStatus.source,
+    ok: result.dataStatus.ok,
+    updatedAt: result.dataStatus.updatedAt
   });
+  return writeCache(cacheKey, result);
 }
 
 export async function getHomeLiveData() {

--- a/v2/core/dataStatus.js
+++ b/v2/core/dataStatus.js
@@ -1,0 +1,15 @@
+export function makeDataStatus({ source, ok, updatedAt, message } = {}) {
+  return {
+    source: source || 'unknown',
+    ok: Boolean(ok),
+    updatedAt: updatedAt || null,
+    message: message || ''
+  };
+}
+
+export function formatDataUpdatedAt(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+}

--- a/v2/pages/home.js
+++ b/v2/pages/home.js
@@ -1,6 +1,7 @@
 import { getCurrentLeagueLiveStats, rankFromPoints, safeErrorMessage } from '../core/dataHub.js';
 import { leagueLabelUA } from '../core/naming.js';
 import { listActiveTournaments } from '../core/tournamentApi.js';
+import { formatDataUpdatedAt, makeDataStatus } from '../core/dataStatus.js';
 
 const HOME_LEAGUES = ['sundaygames', 'kids'];
 const STATS_LINKS = {
@@ -117,6 +118,30 @@ function renderLeadersNow(adultLeader, kidsLeader) {
       </div>
     </section>
   `;
+}
+
+function pickHomeStatus(adultsStatus, kidsStatus) {
+  const statuses = [adultsStatus, kidsStatus]
+    .filter((status) => status && typeof status === 'object')
+    .map((status) => makeDataStatus(status));
+  if (!statuses.length) return makeDataStatus({ source: 'unknown', ok: false, message: 'Data unavailable' });
+  const withDate = statuses
+    .map((status) => ({ status, ts: Date.parse(status.updatedAt || '') }))
+    .filter((entry) => Number.isFinite(entry.ts))
+    .sort((a, b) => b.ts - a.ts);
+  return withDate[0]?.status || statuses[0];
+}
+
+function renderDataStatusLine(status) {
+  const safeStatus = makeDataStatus(status);
+  const timeLabel = formatDataUpdatedAt(safeStatus.updatedAt);
+  if (safeStatus.ok && timeLabel) {
+    return `<p class="data-status-line data-status-line--ok">Дані оновлено: ${esc(timeLabel)}</p>`;
+  }
+  if (safeStatus.source === 'cache' && timeLabel) {
+    return `<p class="data-status-line data-status-line--warning">Показуємо кеш · оновлено: ${esc(timeLabel)}</p>`;
+  }
+  return '<p class="data-status-line data-status-line--error">Дані тимчасово недоступні</p>';
 }
 
 function renderLeagueSection({ league, players }) {
@@ -367,6 +392,7 @@ async function safeInitHomePage(root) {
       <section class="hero home-hero"><span class="hero__kicker">ВАРТА КЛУБ</span><h1 class="hero__title">ЛАЗЕРТАГ РЕЙТИНГ</h1><p class="home-current-season">Весняний сезон 2026 року</p><p class="px-card__text" id="stateBox" aria-live="polite" hidden></p></section>
       <div class="px-divider"></div>
       <section class="section" id="leadersNowMount"></section>
+      <section class="section" id="homeDataStatusMount"></section>
       <section class="section" id="homeTournamentsMount"></section>
       <section class="section" id="leagueSections"></section>
     </div>`;
@@ -374,9 +400,10 @@ async function safeInitHomePage(root) {
   const lifecycle = setHomeLoadingLifecycle(root);
   const stateBox = document.getElementById('stateBox');
   const leadersNowMount = document.getElementById('leadersNowMount');
+  const homeDataStatusMount = document.getElementById('homeDataStatusMount');
   const homeTournamentsMount = document.getElementById('homeTournamentsMount');
   const leagueSections = document.getElementById('leagueSections');
-  if (!stateBox || !leadersNowMount || !leagueSections || !homeTournamentsMount) {
+  if (!stateBox || !leadersNowMount || !homeDataStatusMount || !leagueSections || !homeTournamentsMount) {
     lifecycle.destroy();
     lifecycle.revealContent();
     return;
@@ -386,6 +413,7 @@ async function safeInitHomePage(root) {
     stateBox.hidden = false;
     stateBox.textContent = 'Дані тимчасово недоступні';
     leadersNowMount.innerHTML = renderLeadersNow(null, null);
+    homeDataStatusMount.innerHTML = renderDataStatusLine(makeDataStatus({ source: 'unknown', ok: false, message: 'Data unavailable' }));
     homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], 'error');
     leagueSections.innerHTML = '';
   };
@@ -416,8 +444,10 @@ async function safeInitHomePage(root) {
     const pickSeasonActive = (livePlayers = []) => (livePlayers || []).filter((player) => isCurrentSeasonActive(player)).sort(byPointsDesc);
     const adultsPlayers = pickSeasonActive(adultsLive?.players || []);
     const kidsPlayers = pickSeasonActive(kidsLive?.players || []);
+    const homeStatus = pickHomeStatus(adultsLive?.dataStatus, kidsLive?.dataStatus);
 
     leadersNowMount.innerHTML = renderLeadersNow(adultsPlayers[0] || null, kidsPlayers[0] || null);
+    homeDataStatusMount.innerHTML = renderDataStatusLine(homeStatus);
     homeTournamentsMount.innerHTML = renderHomeTournamentsCard([], 'loading');
     fetchHomeTournaments()
       .then((items) => {
@@ -443,6 +473,7 @@ async function safeInitHomePage(root) {
     stateBox.hidden = false;
     stateBox.textContent = msg;
     leadersNowMount.innerHTML = renderLeadersNow(null, null);
+    homeDataStatusMount.innerHTML = renderDataStatusLine(makeDataStatus({ source: 'unknown', ok: false, message: 'Data unavailable' }));
     leagueSections.innerHTML = '';
   } finally {
     lifecycle.revealContent();

--- a/v2/pages/league-stats.js
+++ b/v2/pages/league-stats.js
@@ -1,6 +1,7 @@
 ﻿import { getCurrentLeagueLiveStats, getCurrentSeason } from '../core/dataHub.js';
 import { normalizeLeague, leagueLabelUA } from '../core/naming.js';
 import { getRouteState } from '../core/utils.js';
+import { formatDataUpdatedAt, makeDataStatus } from '../core/dataStatus.js';
 
 const RANKS = ['S', 'A', 'B', 'C', 'D', 'E', 'F'];
 const FALLBACK_AVATAR = 'data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2248%22 height=%2248%22 viewBox=%220 0 48 48%22%3E%3Crect width=%2248%22 height=%2248%22 fill=%22%23121a2a%22/%3E%3Ccircle cx=%2224%22 cy=%2218%22 r=%229%22 fill=%22%235b6c89%22/%3E%3Crect x=%2211%22 y=%2230%22 width=%2226%22 height=%2212%22 fill=%22%235b6c89%22/%3E%3C/svg%3E';
@@ -196,9 +197,16 @@ function getSmallestPositiveGrowth(players = []) {
 }
 
 function renderHero(root, league, data) {
+  const dataStatus = makeDataStatus(data?.dataStatus);
+  const updatedAt = formatDataUpdatedAt(dataStatus.updatedAt);
+  const statusText = dataStatus.ok && updatedAt
+    ? `Дані оновлено: ${updatedAt}`
+    : 'Дані тимчасово недоступні';
+  const statusClass = dataStatus.ok && updatedAt ? 'data-status-line--ok' : 'data-status-line--error';
   root.innerHTML = `<div class="league-hero__eyebrow">\u0416\u0438\u0432\u0438\u0439 \u0441\u0435\u0437\u043e\u043d</div>
   <h1 class="px-card__title league-section-title">${esc(leagueLabelUA(league))}</h1>
-  <p class="px-card__text league-season-title">\u041f\u043e\u0442\u043e\u0447\u043d\u0438\u0439 \u0441\u0435\u0437\u043e\u043d: <strong>${esc(data.seasonLabel)}</strong></p>`;
+  <p class="px-card__text league-season-title">\u041f\u043e\u0442\u043e\u0447\u043d\u0438\u0439 \u0441\u0435\u0437\u043e\u043d: <strong>${esc(data.seasonLabel)}</strong></p>
+  <p class="data-status-line ${statusClass}">${esc(statusText)}</p>`;
 }
 
 function renderGameDaySection(lastGameDay, league) {
@@ -346,7 +354,8 @@ function renderLoading(root, league) {
   if (hero) {
     hero.classList.remove('league-loading-block');
     hero.innerHTML = `<h1 class="px-card__title league-section-title">${esc(leagueLabelUA(league))}</h1>
-    <p class="px-card__text league-season-title">\u0416\u0438\u0432\u0456 \u0434\u0430\u043d\u0456: <strong>\u0417\u0430\u0432\u0430\u043d\u0442\u0430\u0436\u0435\u043d\u043d\u044f\u2026</strong></p>`;
+    <p class="px-card__text league-season-title">\u0416\u0438\u0432\u0456 \u0434\u0430\u043d\u0456: <strong>\u0417\u0430\u0432\u0430\u043d\u0442\u0430\u0436\u0435\u043d\u043d\u044f\u2026</strong></p>
+    <p class="data-status-line data-status-line--warning">Оновлюємо live-дані…</p>`;
   }
   if (tableTitle) tableTitle.textContent = '\u0422\u041e\u041f-10 \u0433\u0440\u0430\u0432\u0446\u0456\u0432';
   if (searchInput) {


### PR DESCRIPTION
### Motivation
- Surface lightweight health/freshness info for live rating data so users see when live API is working and when cached/fallback data is shown. 
- Provide a minimal, non-invasive layer in the existing `dataHub` and UI without refactoring core loading logic.

### Description
- Added a small helper module `v2/core/dataStatus.js` with `makeDataStatus()` and `formatDataUpdatedAt()` to normalize status objects and format `HH:MM` timestamps. 
- Extended `v2/core/dataHub.js` to attach `dataStatus` to live results for `getCurrentLeagueLiveStats` and `getLeagueLiveData`, and added `readCacheEntry()` to return cache timestamps so cache responses present `source: 'cache'` with an `updatedAt`. 
- Updated `v2/pages/home.js` to aggregate adults/kids statuses and render a compact status line (`Дані оновлено: HH:MM` / `Показуємо кеш · оновлено: HH:MM` / `Дані тимчасово недоступні`) in a small mount under leaders. 
- Updated `v2/pages/league-stats.js` to render a compact status line in the league hero and show a loading hint `Оновлюємо live-дані…` while loading. 
- Added minimal styles in `v2/assets/css/main.css` (`.data-status-line`, `--ok`, `--warning`, `--error`) to keep the UI compact and V2-scoped. 
- Added unit tests `tests/dataStatus.test.mjs` for the new helpers and kept debugging logs minimal (`console.debug('[dataHub] dataStatus', ...)`). 

### Testing
- Ran syntax/type checks with `node --check` for modified files: `v2/core/dataStatus.js`, `v2/core/dataHub.js`, `v2/pages/home.js`, and `v2/pages/league-stats.js`, and they passed. 
- Executed unit tests with `node --test tests/dataStatus.test.mjs` and all tests passed (`3/3` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2c847d048321b6c8c422c4037af2)