### PR TITLE
Stabilize v2 standalone pages — redirect to hash routes

### DIFF
--- a/v2/gameday.html
+++ b/v2/gameday.html
@@ -4,11 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ігровий день | LaserTag v2</title>
-  <script type="module" src="./pages/global-styles.js"></script>
+  <script>
+    window.location.replace('./index.html#gameday?league=sundaygames');
+  </script>
+  <noscript>
+    <meta http-equiv="refresh" content="0; url=./index.html#gameday?league=sundaygames">
+  </noscript>
 </head>
-<body class="home-v2">
-  <header class="topbar"></header>
-  <main class="page"><div class="container section" id="view"></div></main>
-  <script type="module" src="./pages/gameday.js"></script>
+<body>
+  <p>Перенаправляємо до актуальної сторінки...</p>
+  <p><a href="./index.html#gameday?league=sundaygames">Відкрити сторінку</a></p>
 </body>
 </html>

--- a/v2/kids.html
+++ b/v2/kids.html
@@ -4,11 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Дитяча ліга | LaserTag v2</title>
-  <script type="module" src="./pages/global-styles.js"></script>
+  <script>
+    window.location.replace('./index.html#league-stats?league=kids');
+  </script>
+  <noscript>
+    <meta http-equiv="refresh" content="0; url=./index.html#league-stats?league=kids">
+  </noscript>
 </head>
-<body class="home-v2 league-page" data-league="kids">
-  <header class="topbar"></header>
-  <main class="page"><div class="container section" id="view"></div></main>
-  <script type="module" src="./pages/league-stats.js"></script>
+<body>
+  <p>Перенаправляємо до актуальної сторінки...</p>
+  <p><a href="./index.html#league-stats?league=kids">Відкрити сторінку</a></p>
 </body>
 </html>

--- a/v2/sunday.html
+++ b/v2/sunday.html
@@ -4,11 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Доросла ліга | LaserTag v2</title>
-  <script type="module" src="./pages/global-styles.js"></script>
+  <script>
+    window.location.replace('./index.html#league-stats?league=sundaygames');
+  </script>
+  <noscript>
+    <meta http-equiv="refresh" content="0; url=./index.html#league-stats?league=sundaygames">
+  </noscript>
 </head>
-<body class="home-v2 league-page" data-league="sundaygames">
-  <header class="topbar"></header>
-  <main class="page"><div class="container section" id="view"></div></main>
-  <script type="module" src="./pages/league-stats.js"></script>
+<body>
+  <p>Перенаправляємо до актуальної сторінки...</p>
+  <p><a href="./index.html#league-stats?league=sundaygames">Відкрити сторінку</a></p>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Prevent v2 standalone HTML pages from opening blank when loaded directly by making the hash-router the single source of rendering logic.
- Use a fast client-side redirect so we don't duplicate init logic from `v2/index.html` and avoid diverging behavior.

### Description
- Updated `v2/kids.html` to immediately redirect to `./index.html#league-stats?league=kids` and added a `<noscript>` meta-refresh plus a minimal fallback message and link.
- Updated `v2/sunday.html` to immediately redirect to `./index.html#league-stats?league=sundaygames` and added a `<noscript>` meta-refresh plus a minimal fallback message and link.
- Updated `v2/gameday.html` to immediately redirect to `./index.html#gameday?league=sundaygames` and added a `<noscript>` meta-refresh plus a minimal fallback message and link.
- Did not modify router or page modules (for example `v2/core/router.js`, `v2/pages/league-stats.js`, `v2/pages/gameday.js`) or any CSS; changes are limited to the three standalone HTML files listed above.

### Testing
- Ran an HTML parse check with a small `python` script using `html.parser` against `v2/kids.html`, `v2/sunday.html`, and `v2/gameday.html`, and parsing succeeded for all files.
- Verified redirect snippets and fallback text with a search (`rg -n "index\.html#|Перенаправляємо"`) and found the expected `window.location.replace`, `<noscript>` meta-refresh and fallback link in each file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee301f97308321aef4fba1b798b107)