### PR TITLE
balance2: додати режим «Змішаний турнір» (kids + sundaygames)

### DIFF
--- a/v2/scripts/balance2/api.js
+++ b/v2/scripts/balance2/api.js
@@ -52,6 +52,43 @@ export async function loadPlayers(league, { force = false, timeoutMs = 15000 } =
   return players;
 }
 
+export function mergeMixedLeaguePlayers(adultsPlayers = [], kidsPlayers = []) {
+  const withMeta = (players, sourceLeague, sourceLeagueLabel) => players.map((player) => {
+    const nick = String(player.nick || player.nickname || '').trim();
+    return {
+      ...player,
+      sourceLeague,
+      sourceLeagueLabel,
+      uid: `${sourceLeague}::${nick}`,
+    };
+  });
+  return [
+    ...withMeta(adultsPlayers, 'sundaygames', 'Дорослі'),
+    ...withMeta(kidsPlayers, 'kids', 'Дитяча'),
+  ];
+}
+
+export async function loadPlayersForSource(sourceMode, { force = false, timeoutMs = 15000 } = {}) {
+  if (sourceMode !== 'mixed') {
+    const players = await loadPlayers(sourceMode, { force, timeoutMs });
+    return { sourceMode, players, counts: { sundaygames: sourceMode === 'sundaygames' ? players.length : 0, kids: sourceMode === 'kids' ? players.length : 0 } };
+  }
+
+  const [adultsResult, kidsResult] = await Promise.allSettled([
+    loadPlayers('sundaygames', { force, timeoutMs }),
+    loadPlayers('kids', { force, timeoutMs }),
+  ]);
+  if (adultsResult.status === 'rejected') throw new Error(`Не вдалося завантажити дорослу лігу: ${adultsResult.reason?.message || 'невідома помилка'}`);
+  if (kidsResult.status === 'rejected') throw new Error(`Не вдалося завантажити дитячу лігу: ${kidsResult.reason?.message || 'невідома помилка'}`);
+
+  const merged = mergeMixedLeaguePlayers(adultsResult.value, kidsResult.value);
+  return {
+    sourceMode: 'mixed',
+    players: merged,
+    counts: { sundaygames: adultsResult.value.length, kids: kidsResult.value.length },
+  };
+}
+
 export async function saveMatch(payload, timeoutMs = 20000) {
   const body = toFormUrlEncoded({ ...payload, league: normalizeLeague(payload.league) });
   try {

--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -1,11 +1,13 @@
 import {
   state,
   normalizeLeague,
+  normalizePlayerSourceMode,
   getSelectedPlayers,
   computeSeriesSummary,
   syncSelectedMap,
   rankLetterForPoints,
   sortByPointsDesc,
+  getPlayerKey,
   getAvailableTeamKeys,
   getActiveMatchTeams,
   getTeamLabel,
@@ -14,7 +16,7 @@ import {
 import { autoBalance2, balanceIntoNTeams } from './balance.js';
 import { clearTeams, syncSelectedFromTeamsAndBench } from './manual.js';
 import { render, bindUiEvents, setTournamentStatus, clearTournamentStatus } from './ui.js';
-import { loadPlayers, saveMatch, createTournament, saveTournamentTeams, saveTournamentGame } from './api.js';
+import { loadPlayersForSource, saveMatch, createTournament, saveTournamentTeams, saveTournamentGame } from './api.js';
 import { saveLobby, restoreLobby, peekLobbyRestore, clearPlayersCache, saveLastSavedGame, readLastSavedGame } from './storage.js';
 import { setStatus, lockSaveButton } from './status.js';
 
@@ -59,10 +61,20 @@ function normalizeLoadedPlayers(players = []) {
       const nick = String(player.nick || player.nickname || '').trim();
       if (!nick) return null;
       const points = Number(player.points ?? player.pts) || 0;
-      return { nick, points, pts: points, rank: String(player.rank || rankLetterForPoints(points)) };
+      return {
+        ...player,
+        nick,
+        points,
+        pts: points,
+        rank: String(player.rank || rankLetterForPoints(points)),
+      };
     })
     .filter(Boolean)
     .sort(sortByPointsDesc);
+}
+
+function getPlayersByKeyMap() {
+  return new Map(state.playersState.players.map((player) => [getPlayerKey(player), player]));
 }
 
 function buildRoundRobinSchedule() {
@@ -160,12 +172,12 @@ function runBalance() {
   clearTeams();
   if (state.teamsState.teamCount === 2) {
     const teams = autoBalance2(selected);
-    state.teamsState.teams.team1 = teams.team1.map((p) => p.nick);
-    state.teamsState.teams.team2 = teams.team2.map((p) => p.nick);
+    state.teamsState.teams.team1 = teams.team1.map((p) => getPlayerKey(p));
+    state.teamsState.teams.team2 = teams.team2.map((p) => getPlayerKey(p));
   } else {
     const teams = balanceIntoNTeams(selected, state.teamsState.teamCount);
     TEAM_KEYS.forEach((key) => {
-      state.teamsState.teams[key] = (teams[key] || []).map((p) => p.nick);
+      state.teamsState.teams[key] = (teams[key] || []).map((p) => getPlayerKey(p));
     });
   }
   state.app.mode = 'auto';
@@ -214,10 +226,12 @@ function buildPayload() {
   state.matchState.match.winner = summary.winner;
   const [teamA, teamB] = getActiveMatchTeams();
 
+  const playersMap = getPlayersByKeyMap();
+  const toNick = (playerKey) => playersMap.get(playerKey)?.nick || playerKey;
   return {
-    league: state.app.league,
-    team1: state.teamsState.teams[teamA].join(', '),
-    team2: state.teamsState.teams[teamB].join(', '),
+    league: normalizeLeague(state.app.league),
+    team1: state.teamsState.teams[teamA].map(toNick).join(', '),
+    team2: state.teamsState.teams[teamB].map(toNick).join(', '),
     team3: '',
     team4: '',
     winner: summary.winner,
@@ -230,6 +244,7 @@ function buildPayload() {
 }
 
 function buildTournamentTeamsPayload() {
+  const playersMap = getPlayersByKeyMap();
   return TEAM_KEYS
     .slice(0, state.teamsState.teamCount)
     .filter((teamId) => (state.teamsState.teams[teamId] || []).length > 0)
@@ -237,7 +252,7 @@ function buildTournamentTeamsPayload() {
       teamId,
       teamName: state.teamsState.teamNames[teamId] || `Команда ${teamId.replace('team', '')}`,
       players: [...new Set((state.teamsState.teams[teamId] || [])
-        .map((nick) => String(nick || '').trim())
+        .map((playerKey) => String(playersMap.get(playerKey)?.nick || playerKey || '').trim())
         .filter(Boolean))],
     }));
 }
@@ -296,9 +311,11 @@ function validateSave() {
     if (!['A', 'B', 'DRAW'].includes(mappedResult)) return 'Вкажи коректний результат матчу';
     if (state.tournamentState.gameMode === 'KT' && mappedResult === 'DRAW') return 'Для KT нічия недоступна';
     const allowed = new Set([...teamAPlayers, ...teamBPlayers]);
+    const playersMap = getPlayersByKeyMap();
+    const allowedNicks = new Set([...allowed].map((playerKey) => playersMap.get(playerKey)?.nick || playerKey));
     for (const id of ['mvp1', 'mvp2', 'mvp3']) {
       const nick = state.matchState.match[id];
-      if (nick && !allowed.has(nick)) return 'MVP має бути гравцем активних команд';
+      if (nick && !allowedNicks.has(nick)) return 'MVP має бути гравцем активних команд';
     }
   }
   const [teamA, teamB] = state.app.eventMode === 'tournament'
@@ -381,9 +398,9 @@ async function doSave(retry = false) {
       return;
     }
     try {
-      clearPlayersCache(state.app.league);
-      const freshPlayers = await loadPlayers(state.app.league, { force: true, timeoutMs: 15000 });
-      state.playersState.players = normalizeLoadedPlayers(freshPlayers);
+      clearPlayersCache(normalizeLeague(state.app.league));
+      const freshPlayers = await loadPlayersForSource(state.app.playerSourceMode, { force: true, timeoutMs: 15000 });
+      state.playersState.players = normalizeLoadedPlayers(freshPlayers.players || []);
 
       const snapshot = createLastSavedSnapshot();
       state.lastSavedGame = snapshot;
@@ -460,20 +477,33 @@ function cleanupTournamentMvp() {
 async function ensurePlayersLoaded({ force = false } = {}) {
   const btn = $('loadPlayersBtn');
   const original = btn?.textContent || 'Завантажити гравців';
-  const league = normalizeLeague($('leagueSelect')?.value || state.app.league);
+  const sourceMode = normalizePlayerSourceMode($('leagueSelect')?.value || state.app.playerSourceMode, state.app.eventMode);
 
-  state.app.league = league;
-  localStorage.setItem(LEAGUE_KEY, league);
+  state.app.playerSourceMode = sourceMode;
+  state.app.league = sourceMode;
+  localStorage.setItem(LEAGUE_KEY, sourceMode);
   if (btn) {
     btn.disabled = true;
     btn.textContent = '⏳ Завантаження…';
   }
-  setStatus({ state: 'saving', text: 'Завантаження…', retryVisible: false });
+  setStatus({ state: 'saving', text: sourceMode === 'mixed' ? 'Завантажую дорослу та дитячу ліги...' : 'Завантаження…', retryVisible: false });
 
   try {
-    const loaded = await loadPlayers(league, { force, timeoutMs: 15000 });
-    state.playersState.players = normalizeLoadedPlayers(loaded);
-    setStatus({ state: 'saved', text: `✅ Завантажено: ${state.playersState.players.length} гравців`, retryVisible: false });
+    const loaded = await loadPlayersForSource(sourceMode, { force, timeoutMs: 15000 });
+    state.playersState.players = normalizeLoadedPlayers(loaded.players || []);
+    if (sourceMode === 'mixed') {
+      if (!state.playersState.players.length) throw new Error('Не знайдено гравців для змішаного турніру');
+      setStatus({ state: 'saved', text: `✅ Завантажено: ${loaded.counts.sundaygames} дорослих, ${loaded.counts.kids} дитячих`, retryVisible: false });
+      const nickCounts = new Map();
+      state.playersState.players.forEach((player) => {
+        nickCounts.set(player.nick, (nickCounts.get(player.nick) || 0) + 1);
+      });
+      if ([...nickCounts.values()].some((count) => count > 1)) {
+        setTournamentStatus('Є однакові нікнейми в різних лігах — перевір склад перед збереженням.', 'warning');
+      }
+    } else {
+      setStatus({ state: 'saved', text: `✅ Завантажено: ${state.playersState.players.length} гравців`, retryVisible: false });
+    }
     renderAndSync();
   } catch (error) {
     setStatus({ state: 'error', text: `❌ ${error.message || 'Не вдалося отримати відповідь від сервера'}`, retryVisible: false });
@@ -499,8 +529,9 @@ async function init() {
   });
 
   $('leagueSelect')?.addEventListener('change', (e) => {
-    state.app.league = normalizeLeague(e.target.value);
-    localStorage.setItem(LEAGUE_KEY, state.app.league);
+    state.app.playerSourceMode = normalizePlayerSourceMode(e.target.value, state.app.eventMode);
+    state.app.league = state.app.playerSourceMode;
+    localStorage.setItem(LEAGUE_KEY, state.app.playerSourceMode);
     state.playersState.players = [];
     state.playersState.selected = [];
     syncSelectedMap();
@@ -536,7 +567,9 @@ async function init() {
       const value = e.target.value.trim();
       if (state.app.eventMode === 'tournament') {
         const allowed = new Set([...(state.teamsState.teams[state.activeTeamAId] || []), ...(state.teamsState.teams[state.activeTeamBId] || [])]);
-        state.matchState.match[id] = allowed.has(value) || !value ? value : '';
+        const playersMap = getPlayersByKeyMap();
+        const allowedNicks = new Set([...allowed].map((playerKey) => playersMap.get(playerKey)?.nick || playerKey));
+        state.matchState.match[id] = allowedNicks.has(value) || !value ? value : '';
       } else {
         state.matchState.match[id] = value;
       }
@@ -628,6 +661,9 @@ async function init() {
     },
     onEventMode(mode) {
       state.app.eventMode = mode === 'tournament' ? 'tournament' : 'regular';
+      state.app.playerSourceMode = normalizePlayerSourceMode(state.app.playerSourceMode, state.app.eventMode);
+      state.app.league = state.app.playerSourceMode;
+      localStorage.setItem(LEAGUE_KEY, state.app.playerSourceMode);
       if (state.app.eventMode === 'regular') clearTournamentStatus();
       syncSaveButtonState();
       saveLobby();
@@ -668,8 +704,8 @@ async function init() {
         renderAndSync();
         return;
       }
-      if (!['kids', 'sundaygames'].includes(state.app.league)) {
-        const message = 'Обери лігу kids або sundaygames';
+      if (!['kids', 'sundaygames', 'mixed'].includes(state.app.playerSourceMode)) {
+        const message = 'Обери лігу kids, sundaygames або mixed';
         console.debug(`[balance2:tournament] validation failed ${message}`);
         setTournamentStatus(message, 'error');
         setTournamentRequestMeta({ action: 'createTournament', requestStatus: 'ERR', error: message });
@@ -685,16 +721,16 @@ async function init() {
         renderAndSync();
         return;
       }
-      const leagueLabel = state.app.league === 'kids' ? 'Kids' : 'SundayGames';
+      const leagueLabel = state.app.playerSourceMode === 'kids' ? 'Kids' : (state.app.playerSourceMode === 'mixed' ? 'Mixed' : 'SundayGames');
       const rawName = String(state.tournamentState.tournamentName || '').trim();
       const name = rawName.length >= 3 ? rawName : `Турнір ${leagueLabel} ${today}`;
       const payload = {
         name,
-        league: state.app.league,
+        league: state.app.playerSourceMode === 'mixed' ? 'sundaygames' : state.app.playerSourceMode,
         dateStart: today,
         dateEnd: '',
         status: 'ACTIVE',
-        notes: '',
+        notes: state.app.playerSourceMode === 'mixed' ? 'Mixed tournament: sundaygames + kids' : '',
       };
       state.tournamentState.isSaving = true;
       setTournamentStatus('Створюю турнір...', 'loading');
@@ -802,7 +838,8 @@ async function init() {
     },
   });
 
-  state.app.league = normalizeLeague(localStorage.getItem(LEAGUE_KEY) || state.app.league);
+  state.app.playerSourceMode = normalizePlayerSourceMode(localStorage.getItem(LEAGUE_KEY) || state.app.playerSourceMode, state.app.eventMode);
+  state.app.league = state.app.playerSourceMode;
   state.lastSavedGame = readLastSavedGame();
   $('leagueSelect').value = state.app.league;
   $('sortMode').value = state.app.sortMode;

--- a/v2/scripts/balance2/state.js
+++ b/v2/scripts/balance2/state.js
@@ -3,6 +3,7 @@ import { rankFromPoints } from '../../core/rankRules.js';
 export const state = {
   app: {
     league: 'kids',
+    playerSourceMode: 'kids',
     mode: 'auto',
     eventMode: 'regular',
     sortMode: 'points_desc',
@@ -93,17 +94,30 @@ export function normalizeLeague(league) {
   return key === 'kids' ? 'kids' : 'sundaygames';
 }
 
+export function normalizePlayerSourceMode(mode, eventMode = 'regular') {
+  const key = String(mode || '').trim().toLowerCase();
+  if (key === 'kids') return 'kids';
+  if (key === 'mixed') return eventMode === 'tournament' ? 'mixed' : 'sundaygames';
+  return 'sundaygames';
+}
+
+export function getPlayerKey(playerOrKey) {
+  if (typeof playerOrKey === 'string') return playerOrKey;
+  if (!playerOrKey || typeof playerOrKey !== 'object') return '';
+  return String(playerOrKey.uid || playerOrKey.id || playerOrKey.nick || playerOrKey.name || '').trim();
+}
+
 export function getSelectedPlayers() {
-  const map = new Map(state.playersState.players.map((p) => [p.nick, p]));
-  return state.playersState.selected.map((nick) => map.get(nick)).filter(Boolean);
+  const map = new Map(state.playersState.players.map((p) => [getPlayerKey(p), p]));
+  return state.playersState.selected.map((playerKey) => map.get(playerKey)).filter(Boolean);
 }
 
 export function syncSelectedMap() {
   state.playersState.selectedMap = new Set(state.playersState.selected);
 }
 
-export function isSelected(nick) {
-  return state.playersState.selectedMap.has(nick);
+export function isSelected(playerOrKey) {
+  return state.playersState.selectedMap.has(getPlayerKey(playerOrKey));
 }
 
 export function getTeamLabel(teamKey) {

--- a/v2/scripts/balance2/ui.js
+++ b/v2/scripts/balance2/ui.js
@@ -7,6 +7,7 @@ import {
   getAvailableTeamKeys,
   getActiveMatchTeams,
   syncSelectedMap,
+  getPlayerKey,
   TEAM_KEYS,
   TEAM_COUNT_OPTIONS,
   MAX_LOBBY_PLAYERS,
@@ -65,12 +66,14 @@ function formatPlayer(playerOrNick) {
     nick: playerOrNick.nick,
     points: Number(playerOrNick.points ?? playerOrNick.pts) || 0,
     rank: playerOrNick.rank || '—',
+    sourceLeagueLabel: playerOrNick.sourceLeagueLabel || '',
   };
 }
 
 function playerMetaHtml(player) {
   const parsed = formatPlayer(player);
-  return `<span class="player-meta"><strong>${escapeHtml(parsed.nick)}</strong> <small>${parsed.points} pts · ${escapeHtml(parsed.rank)}</small></span>`;
+  const leagueMarker = parsed.sourceLeagueLabel ? ` · <span class="league-marker">${escapeHtml(parsed.sourceLeagueLabel)}</span>` : '';
+  return `<span class="player-meta"><strong>${escapeHtml(parsed.nick)}</strong> <small>${parsed.points} pts · ${escapeHtml(parsed.rank)}${leagueMarker}</small></span>`;
 }
 
 function sanitizeTeamCount(value) {
@@ -155,18 +158,19 @@ export function renderPlayers() {
   selectedCount.textContent = `Обрано: ${state.playersState.selected.length} / ${MAX_LOBBY_PLAYERS}`;
 
   list.innerHTML = players.map((player) => {
-    const selected = isSelected(player.nick);
-    return `<div class="player-row ${selected ? 'selected' : ''}" data-toggle="${escapeAttr(player.nick)}">${playerMetaHtml(player)}<span class="tag">${selected ? '✅ у лобі' : 'Додати'}</span></div>`;
+    const key = getPlayerKey(player);
+    const selected = isSelected(key);
+    return `<div class="player-row ${selected ? 'selected' : ''}" data-toggle="${escapeAttr(key)}">${playerMetaHtml(player)}<span class="tag">${selected ? '✅ у лобі' : 'Додати'}</span></div>`;
   }).join('');
 }
 
 export function renderLobby() {
   const wrap = document.getElementById('lobbyList');
   if (!wrap) return;
-  const playersMap = new Map(state.playersState.players.map((p) => [p.nick, p]));
-  wrap.innerHTML = state.playersState.selected.map((nick) => {
-    const player = playersMap.get(nick) || { nick, points: 0, rank: '—' };
-    return `<div class="lobby-row">${playerMetaHtml(player)}<button class="chip" data-remove="${escapeAttr(nick)}">Прибрати</button></div>`;
+  const playersMap = new Map(state.playersState.players.map((p) => [getPlayerKey(p), p]));
+  wrap.innerHTML = state.playersState.selected.map((playerKey) => {
+    const player = playersMap.get(playerKey) || { nick: playerKey, points: 0, rank: '—' };
+    return `<div class="lobby-row">${playerMetaHtml(player)}<button class="chip" data-remove="${escapeAttr(playerKey)}">Прибрати</button></div>`;
   }).join('');
 }
 
@@ -174,9 +178,9 @@ function teamNameControl(key) {
   return `<div class="team-name-wrap" data-team-name-wrap="${escapeAttr(key)}"><strong class="team-name-label">${escapeHtml(getTeamLabel(key))}</strong><button class="chip" type="button" data-rename-team="${escapeAttr(key)}">✏️ Назва</button></div>`;
 }
 
-function sumByNicks(nicks) {
-  const map = new Map(state.playersState.players.map((p) => [p.nick, p]));
-  return nicks.reduce((acc, nick) => acc + (Number(map.get(nick)?.points ?? map.get(nick)?.pts) || 0), 0);
+function sumByNicks(playerKeys) {
+  const map = new Map(state.playersState.players.map((p) => [getPlayerKey(p), p]));
+  return playerKeys.reduce((acc, playerKey) => acc + (Number(map.get(playerKey)?.points ?? map.get(playerKey)?.pts) || 0), 0);
 }
 
 export function renderTeams() {
@@ -184,20 +188,23 @@ export function renderTeams() {
   if (!grid) return;
 
   const keys = TEAM_KEYS.slice(0, state.teamsState.teamCount);
-  const map = new Map(state.playersState.players.map((p) => [p.nick, p]));
+  const map = new Map(state.playersState.players.map((p) => [getPlayerKey(p), p]));
   const cards = keys.map((key) => {
-    const nicks = state.teamsState.teams[key];
-    const total = sumByNicks(nicks);
-    const members = nicks.map((nick) => {
-      const player = map.get(nick) || { nick, points: 0, rank: '—' };
-      return `<div class="team-player">${playerMetaHtml(player)}<button class="chip" data-move="${escapeAttr(nick)}:bench">Лавка</button></div>`;
+    const playerKeys = state.teamsState.teams[key];
+    const total = sumByNicks(playerKeys);
+    const members = playerKeys.map((playerKey) => {
+      const player = map.get(playerKey) || { nick: playerKey, points: 0, rank: '—' };
+      return `<div class="team-player">${playerMetaHtml(player)}<button class="chip" data-move="${escapeAttr(playerKey)}:bench">Лавка</button></div>`;
     }).join('') || '<div class="tag">порожньо</div>';
     return `<div class="team-card"><h4>${teamNameControl(key)} <span class="tag">Σ ${total}</span></h4>${members}</div>`;
   });
 
   if (state.app.mode === 'manual') {
-    const bench = state.playersState.selected.filter((nick) => !keys.some((key) => state.teamsState.teams[key].includes(nick)));
-    cards.push(`<div class="team-card"><h4>Лавка</h4>${bench.map((nick) => `<div class="team-player"><span>${escapeHtml(nick)}</span><div class="team-actions">${keys.map((k) => `<button class="chip" data-move="${escapeAttr(nick)}:${k}">→ ${escapeHtml(getTeamLabel(k))}</button>`).join('')}</div></div>`).join('') || '<div class="tag">порожньо</div>'}</div>`);
+    const bench = state.playersState.selected.filter((playerKey) => !keys.some((key) => state.teamsState.teams[key].includes(playerKey)));
+    cards.push(`<div class="team-card"><h4>Лавка</h4>${bench.map((playerKey) => {
+      const player = map.get(playerKey) || { nick: playerKey, points: 0, rank: '—' };
+      return `<div class="team-player">${playerMetaHtml(player)}<div class="team-actions">${keys.map((k) => `<button class="chip" data-move="${escapeAttr(playerKey)}:${k}">→ ${escapeHtml(getTeamLabel(k))}</button>`).join('')}</div></div>`;
+    }).join('') || '<div class="tag">порожньо</div>'}</div>`);
   }
 
   grid.innerHTML = cards.join('');
@@ -239,6 +246,7 @@ export function renderMatchConfig() {
     </div></div>
     ${eventMode === 'regular' ? regularContent : `
       <div class="tournament-panel">
+        <div class="tag">Змішаний турнір завантажує гравців з дорослої та дитячої ліги.</div>
         <label>Назва турніру <input class="search-input" data-tournament-name type="text" value="${escapeAttr(state.tournamentState.tournamentName || '')}" placeholder="Весняний турнір"></label>
         <label>Режим бою
           <select class="chip" data-tournament-game-mode>
@@ -281,8 +289,13 @@ export function renderMatchTeams() {
     return;
   }
 
+  const map = new Map(state.playersState.players.map((p) => [getPlayerKey(p), p]));
   root.innerHTML = [teamA, teamB].map((key, idx) => {
-    const items = state.teamsState.teams[key].map((nick) => `<li>${escapeHtml(nick)}</li>`).join('');
+    const items = state.teamsState.teams[key].map((playerKey) => {
+      const player = map.get(playerKey);
+      const leagueLabel = player?.sourceLeagueLabel ? ` · ${escapeHtml(player.sourceLeagueLabel)}` : '';
+      return `<li>${escapeHtml(player?.nick || playerKey)}${leagueLabel}</li>`;
+    }).join('');
     const label = idx === 0 ? 'A' : 'B';
     return `<div class="team-card"><h4>${label} · ${escapeHtml(getTeamLabel(key))}</h4><ul class="match-team-preview">${items || '<li>порожньо</li>'}</ul></div>`;
   }).join('');
@@ -328,16 +341,20 @@ export function renderPenalties() {
   section.classList.toggle('collapsed', collapsed);
   chevron.textContent = collapsed ? '▸' : '▾';
 
-  root.innerHTML = getParticipants().map((nick) => {
-    const val = Number(state.matchState.match.penalties[nick] || 0);
-    return `<div class="penalty-row"><span>${escapeHtml(nick)}</span><div class="penalty-controls"><button class="chip" data-pen="${escapeAttr(nick)}:-1">-</button><strong>${val}</strong><button class="chip" data-pen="${escapeAttr(nick)}:1">+</button></div></div>`;
+  const map = new Map(state.playersState.players.map((p) => [getPlayerKey(p), p]));
+  root.innerHTML = getParticipants().map((playerKey) => {
+    const player = map.get(playerKey);
+    const val = Number(state.matchState.match.penalties[playerKey] || 0);
+    return `<div class="penalty-row"><span>${escapeHtml(player?.nick || playerKey)}</span><div class="penalty-controls"><button class="chip" data-pen="${escapeAttr(playerKey)}:-1">-</button><strong>${val}</strong><button class="chip" data-pen="${escapeAttr(playerKey)}:1">+</button></div></div>`;
   }).join('');
 }
 
 export function renderMatchFields() {
-  const participants = state.app.eventMode === 'tournament'
+  const participantKeys = state.app.eventMode === 'tournament'
     ? [...new Set([...(state.teamsState.teams[state.activeTeamAId] || []), ...(state.teamsState.teams[state.activeTeamBId] || [])])]
     : [...new Set(getParticipants())];
+  const map = new Map(state.playersState.players.map((p) => [getPlayerKey(p), p]));
+  const participants = participantKeys.map((playerKey) => map.get(playerKey)?.nick || playerKey);
   const dl = document.getElementById('participantsDatalist');
   if (dl) dl.innerHTML = participants.map((nick) => `<option value="${escapeAttr(nick)}"></option>`).join('');
 
@@ -387,11 +404,11 @@ export function bindUiEvents(handlers) {
         window.alert(`Недостатньо гравців для ${teamCount} команд. Мінімум: ${teamCount}.`);
         return;
       }
-      const map = new Map(state.playersState.players.map((p) => [p.nick, p]));
-      const picked = state.playersState.selected.map((nick) => map.get(nick)).filter(Boolean);
+      const map = new Map(state.playersState.players.map((p) => [getPlayerKey(p), p]));
+      const picked = state.playersState.selected.map((playerKey) => map.get(playerKey)).filter(Boolean);
       const teams = balanceIntoNTeamsLocal(picked, teamCount);
       TEAM_KEYS.forEach((key) => {
-        state.teamsState.teams[key] = (teams[key] || []).map((p) => p.nick);
+        state.teamsState.teams[key] = (teams[key] || []).map((p) => getPlayerKey(p));
       });
       state.teamsState.teamCount = teamCount;
       e.preventDefault();
@@ -494,3 +511,13 @@ export function bindUiEvents(handlers) {
     }
   });
 }
+  if (select && !select.querySelector('option[value="mixed"]')) {
+    const option = document.createElement('option');
+    option.value = 'mixed';
+    option.textContent = 'Змішаний турнір';
+    select.appendChild(option);
+  }
+  if (select) {
+    const mixedOption = select.querySelector('option[value="mixed"]');
+    if (mixedOption) mixedOption.disabled = state.app.eventMode !== 'tournament';
+  }

--- a/v2/styles/balance2.css
+++ b/v2/styles/balance2.css
@@ -64,6 +64,13 @@
 .player-row.selected { border-color: rgba(124, 255, 114, .7); background: rgba(124, 255, 114, .11); }
 .player-meta { display: inline-flex; gap: .45rem; align-items: baseline; flex-wrap: wrap; }
 .player-meta small { opacity: .8; }
+.league-marker {
+  display: inline-block;
+  border: 1px solid rgba(49, 208, 255, .45);
+  background: rgba(49, 208, 255, .12);
+  border-radius: 2px;
+  padding: 0 .25rem;
+}
 
 .team-card {
   border: 1px solid rgba(255, 255, 255, .13);


### PR DESCRIPTION
### Motivation
- Потрібно дозволити турнірному режиму завантажувати та балансувати гравців одночасно з двох ліг — `sundaygames` і `kids` (режим «Змішаний турнір»). 
- Забезпечити, щоб однакові нікнейми з різних ліг не затирали один одного у frontend-стані та не ламали логіку lobby/teams.

### Description
- Додав новий source mode і ключ гравця у стані: `playerSourceMode` + `normalizePlayerSourceMode(...)` та `getPlayerKey(...)` для стабільного внутрішнього ідентифікатора; адаптовано `selected`/`selectedMap`/завантаження по ключу. (файл: `v2/scripts/balance2/state.js`)
- Додав API helper `loadPlayersForSource(...)` і `mergeMixedLeaguePlayers(...)`, що паралельно завантажує `sundaygames` + `kids`, маркує кожного гравця `sourceLeague`/`sourceLeagueLabel` і створює frontend-only `uid`. (файл: `v2/scripts/balance2/api.js`)
- Оновив логіку завантаження у `app.js` щоб використовувати `playerSourceMode` та `loadPlayersForSource(...)`, відображати статуси для mixed (loading / counts / помилки), не ламати формат payload при створенні турніру (для mixed відправляється `league: 'sundaygames'` + `notes: 'Mixed tournament: sundaygames + kids'`), та зберегти сумісність GAS. Також внутрішньо teams/selected тепер зберігають player-keys (щоб уникнути конфліктів). (файл: `v2/scripts/balance2/app.js`)
- UI: додано опцію в селектор ліги `Змішаний турнір` (доступна тільки в tournament mode), підказку у турнірному блоці, маркер ліги поруч з ніком у списках і лобі, та оновлено події/рендеринг щоб працювати з player-keys. (файл: `v2/scripts/balance2/ui.js`)
- Мінімальний CSS: прямокутний league-marker для маркування ліги у рядках гравців. (файл: `v2/styles/balance2.css`)
- Збереження/формування payload для `saveTournamentTeams` і `saveGame` залишено сумісним зі старим форматом (players масив ніків), додана лише frontend-safe підказка/notes для mixed tournaments.

### Testing
- Запущено синтаксичну перевірку JS: `node --check v2/scripts/balance2/state.js`, `node --check v2/scripts/balance2/api.js`, `node --check v2/scripts/balance2/ui.js`, `node --check v2/scripts/balance2/app.js` — всі перевірки пройшли успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3640c6708321aae1c7766c1d8129)