### PR TITLE
balance2: move event type to top and unify player source (mixed tournament support)

### DIFF
--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -40,6 +40,20 @@ function setTournamentRequestMeta({ action = '', requestStatus = '', error = '' 
   state.tournamentState.lastErrorMessage = error;
 }
 
+function normalizeEventAndSourceState(nextEventMode = state.app.eventMode, nextSourceMode = state.app.playerSourceMode) {
+  const eventMode = nextEventMode === 'tournament' ? 'tournament' : 'regular';
+  let playerSourceMode = normalizePlayerSourceMode(nextSourceMode, eventMode);
+  if (eventMode === 'regular' && playerSourceMode === 'mixed') {
+    playerSourceMode = 'sundaygames';
+  }
+  if (eventMode === 'tournament' && !['sundaygames', 'kids', 'mixed'].includes(playerSourceMode)) {
+    playerSourceMode = 'sundaygames';
+  }
+  state.app.eventMode = eventMode;
+  state.app.playerSourceMode = playerSourceMode;
+  state.app.league = normalizeLeague(playerSourceMode);
+}
+
 function setTournamentDirty(message = 'Команди змінилися — збережи їх повторно') {
   if (state.app.eventMode !== 'tournament') return;
   state.tournamentState.teamsSaved = false;
@@ -477,9 +491,8 @@ function cleanupTournamentMvp() {
 function onPlayerSourceChanged(nextMode, { warnOnLobby = false } = {}) {
   const sourceMode = normalizePlayerSourceMode(nextMode, state.app.eventMode);
   const changed = sourceMode !== state.app.playerSourceMode;
-  state.app.playerSourceMode = sourceMode;
-  state.app.league = sourceMode;
-  localStorage.setItem(LEAGUE_KEY, sourceMode);
+  normalizeEventAndSourceState(state.app.eventMode, sourceMode);
+  localStorage.setItem(LEAGUE_KEY, state.app.playerSourceMode);
   if (!changed) return;
 
   state.playersState.players = [];
@@ -494,18 +507,13 @@ function onPlayerSourceChanged(nextMode, { warnOnLobby = false } = {}) {
 async function ensurePlayersLoaded({ force = false } = {}) {
   const btn = $('loadPlayersBtn');
   const original = btn?.textContent || 'Завантажити гравців';
-  const sourceFromControl = state.app.eventMode === 'tournament'
-    ? document.querySelector('select[data-role="player-source-mode"]')?.value
-    : $('leagueSelect')?.value;
-  const sourceMode = normalizePlayerSourceMode(sourceFromControl || state.app.playerSourceMode || state.app.league, state.app.eventMode);
-
-  state.app.playerSourceMode = sourceMode;
-  state.app.league = sourceMode;
+  normalizeEventAndSourceState(state.app.eventMode, state.app.playerSourceMode);
+  const sourceMode = state.app.playerSourceMode;
+  const eventMode = state.app.eventMode;
   localStorage.setItem(LEAGUE_KEY, sourceMode);
   console.debug('[balance2] load players source', {
-    eventMode: state.app?.eventMode,
-    league: state.app.league,
-    playerSourceMode: state.app.playerSourceMode,
+    eventMode,
+    sourceMode,
   });
   if (btn) {
     btn.disabled = true;
@@ -553,22 +561,11 @@ async function init() {
 
   $('restoreBtn')?.addEventListener('click', async () => {
     if (!restoreLobby()) return;
-    $('leagueSelect').value = state.app.league;
+    normalizeEventAndSourceState(state.app.eventMode, state.app.playerSourceMode);
     $('sortMode').value = state.app.sortMode;
     await ensurePlayersLoaded();
     renderAndSync();
     $('restoreCard')?.classList.add('hidden');
-  });
-
-  $('leagueSelect')?.addEventListener('change', (e) => {
-    onPlayerSourceChanged(e.target.value);
-    state.playersState.selected = [];
-    syncSelectedMap();
-    clearTeams();
-    setTournamentDirty();
-    ensureActiveMatchState();
-    saveLobby();
-    renderAndSync();
   });
 
   $('sortMode')?.addEventListener('change', (e) => {
@@ -577,7 +574,6 @@ async function init() {
     renderAndSync();
   });
 
-  $('loadPlayersBtn')?.addEventListener('click', () => ensurePlayersLoaded({ force: true }));
   $('balanceBtn')?.addEventListener('click', () => { runBalance(); renderAndSync(); });
   $('manualBtn')?.addEventListener('click', () => { state.app.mode = 'manual'; syncSelectedFromTeamsAndBench(); ensureActiveMatchState(); setTournamentDirty(); saveLobby(); renderAndSync(); });
   $('clearLobbyBtn')?.addEventListener('click', () => { state.playersState.selected = []; syncSelectedMap(); clearTeams(); ensureActiveMatchState(); setTournamentDirty(); saveLobby(); renderAndSync(); });
@@ -689,13 +685,18 @@ async function init() {
       renderAndSync();
     },
     onEventMode(mode) {
-      state.app.eventMode = mode === 'tournament' ? 'tournament' : 'regular';
-      if (state.app.eventMode === 'regular' && state.app.playerSourceMode === 'mixed') {
-        onPlayerSourceChanged('sundaygames');
-        setStatus({ state: 'error', text: '⚠️ Змішаний режим доступний тільки для турніру.', retryVisible: false });
-      } else {
-        onPlayerSourceChanged(state.app.playerSourceMode);
-      }
+      const nextEventMode = mode === 'tournament' ? 'tournament' : 'regular';
+      const changed = nextEventMode !== state.app.eventMode;
+      normalizeEventAndSourceState(nextEventMode, state.app.playerSourceMode);
+      localStorage.setItem(LEAGUE_KEY, state.app.playerSourceMode);
+      state.playersState.players = [];
+      state.playersState.playersLoaded = false;
+      state.tournamentState.teamsSaved = false;
+      state.tournamentState.savedTournamentTeamIds = [];
+      const statusText = changed && state.playersState.selected.length > 0
+        ? '⚠️ Тип події змінено — перевір lobby перед балансуванням.'
+        : 'Обери джерело гравців і завантаж список';
+      setStatus({ state: changed && state.playersState.selected.length > 0 ? 'error' : 'idle', text: statusText, retryVisible: false });
       if (state.app.eventMode === 'regular') clearTournamentStatus();
       syncSaveButtonState();
       saveLobby();
@@ -705,6 +706,9 @@ async function init() {
       onPlayerSourceChanged(sourceMode, { warnOnLobby: true });
       saveLobby();
       renderAndSync();
+    },
+    onLoadPlayers() {
+      ensurePlayersLoaded({ force: true });
     },
     onTournamentName(name) {
       state.tournamentState.tournamentName = String(name || '').trimStart();
@@ -875,10 +879,8 @@ async function init() {
     },
   });
 
-  state.app.playerSourceMode = normalizePlayerSourceMode(localStorage.getItem(LEAGUE_KEY) || state.app.playerSourceMode, state.app.eventMode);
-  state.app.league = state.app.playerSourceMode;
+  normalizeEventAndSourceState(state.app.eventMode, localStorage.getItem(LEAGUE_KEY) || state.app.playerSourceMode);
   state.lastSavedGame = readLastSavedGame();
-  $('leagueSelect').value = state.app.league;
   $('sortMode').value = state.app.sortMode;
   syncSelectedMap();
   ensureActiveMatchState();

--- a/v2/scripts/balance2/ui.js
+++ b/v2/scripts/balance2/ui.js
@@ -104,11 +104,11 @@ function balanceIntoNTeamsLocal(players, rawTeamCount) {
 
 export function render() {
   renderLeagueControls();
+  renderLegacyControls();
   renderPlayers();
   renderLobby();
   renderTeams();
   renderMatchConfig();
-  renderTournamentSourceOptions();
   renderMatchTeams();
   renderSeriesEditor();
   renderMatchSummary();
@@ -117,10 +117,8 @@ export function render() {
   renderLastSavedGame();
 }
 
-function renderTournamentSourceOptions() {
-  const sourceSelect = document.querySelector('select[data-role="player-source-mode"]');
-  if (!sourceSelect) return;
-  const options = state.app.eventMode === 'tournament'
+function sourceOptionsForEventMode() {
+  return state.app.eventMode === 'tournament'
     ? [
       { value: 'sundaygames', label: 'Дорослі' },
       { value: 'kids', label: 'Дитяча' },
@@ -130,17 +128,45 @@ function renderTournamentSourceOptions() {
       { value: 'sundaygames', label: 'Дорослі' },
       { value: 'kids', label: 'Дитяча' },
     ];
-  sourceSelect.innerHTML = options.map((option) => `<option value="${escapeAttr(option.value)}">${escapeHtml(option.label)}</option>`).join('');
-  sourceSelect.value = options.some((option) => option.value === state.app.playerSourceMode)
+}
+
+export function renderLeagueControls() {
+  const sourceOptions = sourceOptionsForEventMode();
+  const sourceLabel = state.app.eventMode === 'tournament' ? 'Джерело гравців' : 'Ліга';
+  const controlsSection = document.getElementById('leagueSelect')?.closest('section.card');
+  if (controlsSection) {
+    controlsSection.innerHTML = `
+      <section class="balance-step balance-step--event">
+        <h3>1. Тип події</h3>
+        <div class="event-mode-switch">
+          <button type="button" class="chip event-mode-button ${state.app.eventMode === 'regular' ? 'active' : ''}" data-event-mode="regular">Рейтинговий матч</button>
+          <button type="button" class="chip event-mode-button ${state.app.eventMode === 'tournament' ? 'active' : ''}" data-event-mode="tournament">Турнір</button>
+        </div>
+      </section>
+      <section class="balance-step balance-step--source">
+        <h3>2. Джерело гравців</h3>
+        <div class="player-source-control">
+          <label class="league-label" for="leagueSelect">${escapeHtml(sourceLabel)}</label>
+          <select id="leagueSelect" class="chip" data-role="player-source-mode">
+            ${sourceOptions.map((option) => `<option value="${escapeAttr(option.value)}">${escapeHtml(option.label)}</option>`).join('')}
+          </select>
+          <button id="loadPlayersBtn" class="chip" type="button" data-load-players="1">Завантажити гравців</button>
+        </div>
+      </section>
+    `;
+  }
+
+  const sourceSelect = document.querySelector('select[data-role="player-source-mode"]');
+  if (!sourceSelect) return;
+  sourceSelect.innerHTML = sourceOptions.map((option) => `<option value="${escapeAttr(option.value)}">${escapeHtml(option.label)}</option>`).join('');
+  sourceSelect.value = sourceOptions.some((option) => option.value === state.app.playerSourceMode)
     ? state.app.playerSourceMode
     : 'sundaygames';
 }
 
-export function renderLeagueControls() {
-  const select = document.getElementById('leagueSelect');
+export function renderLegacyControls() {
   const sortSelect = document.getElementById('sortMode');
   const teamCountControl = document.getElementById('teamCountControl');
-  if (select && select.value !== state.app.league) select.value = state.app.league;
   if (sortSelect && sortSelect.value !== state.app.sortMode) sortSelect.value = state.app.sortMode;
   if (teamCountControl) {
     const existing = new Set(Array.from(teamCountControl.querySelectorAll('[data-team-count]'))
@@ -260,20 +286,9 @@ export function renderMatchConfig() {
   `;
 
   root.innerHTML = `
-    <div class="series-count"><span>Режим:</span><div class="series-count-choices">
-      <button class="chip ${eventMode === 'regular' ? 'active' : ''}" type="button" data-event-mode="regular">Звичайний матч</button>
-      <button class="chip ${eventMode === 'tournament' ? 'active' : ''}" type="button" data-event-mode="tournament">Турнір</button>
-    </div></div>
     ${eventMode === 'regular' ? regularContent : `
       <div class="tournament-panel">
         <div class="tag">Змішаний турнір завантажує гравців з дорослої та дитячої ліги.</div>
-        <label>Джерело гравців
-          <select class="chip" data-role="player-source-mode">
-            <option value="sundaygames">Дорослі</option>
-            <option value="kids">Дитяча</option>
-            <option value="mixed">Змішаний турнір</option>
-          </select>
-        </label>
         <label>Назва турніру <input class="search-input" data-tournament-name type="text" value="${escapeAttr(state.tournamentState.tournamentName || '')}" placeholder="Весняний турнір"></label>
         <label>Режим бою
           <select class="chip" data-tournament-game-mode>
@@ -475,6 +490,7 @@ export function bindUiEvents(handlers) {
     const eventMode = e.target.closest('[data-event-mode]')?.dataset.eventMode;
     const createTournament = e.target.closest('[data-tournament-create]');
     const saveTeams = e.target.closest('[data-tournament-save-teams]');
+    const loadPlayers = e.target.closest('[data-load-players]');
 
     if (toggle) {
       const alreadySelected = state.playersState.selectedMap.has(toggle);
@@ -519,6 +535,7 @@ export function bindUiEvents(handlers) {
     if (penaltiesToggle) handlers.onTogglePenalties();
     if (matchMode) handlers.onMatchMode(matchMode);
     if (eventMode) handlers.onEventMode(eventMode);
+    if (loadPlayers) handlers.onLoadPlayers();
     if (createTournament) handlers.onCreateTournament();
     if (saveTeams) handlers.onSaveTournamentTeams();
   });

--- a/v2/styles/balance2.css
+++ b/v2/styles/balance2.css
@@ -18,6 +18,7 @@
 .counts-row,
 .row-btns,
 .league-controls,
+.balance-step,
 .series-count,
 .series-count-choices,
 .team-actions,
@@ -31,6 +32,35 @@
 
 .section-head,
 .series-count { justify-content: space-between; }
+
+.balance-step {
+  border: 1px solid rgba(255, 255, 255, .12);
+  border-radius: .6rem;
+  padding: .65rem;
+  background: rgba(255, 255, 255, .02);
+}
+.balance-step h3 {
+  margin: 0 0 .45rem;
+  font-size: 1rem;
+}
+.balance-step--event { margin-bottom: .55rem; }
+.event-mode-switch {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .45rem;
+}
+.event-mode-button {
+  min-height: 40px;
+  border-radius: .4rem;
+}
+.player-source-control {
+  display: grid;
+  gap: .45rem;
+}
+.player-source-control select,
+.player-source-control button {
+  width: 100%;
+}
 
 .section-hint {
   margin: .2rem 0 .6rem;


### PR DESCRIPTION
### Motivation
- The top controls duplicated and competed for the same state: legacy league selector and in-panel tournament source caused `eventMode` / `playerSourceMode` divergence and broke the mixed tournament workflow. 
- The goal is to make the page start with event type selection so the player source options and loading behave deterministically.

### Description
- Introduced `normalizeEventAndSourceState` in `v2/scripts/balance2/app.js` and centralized normalization so `state.app.eventMode`, `state.app.playerSourceMode` and `state.app.league` are consistent for both modes. 
- Rebuilt the top controls in `v2/scripts/balance2/ui.js` to show step 1 `Тип події` (buttons `Рейтинговий матч` / `Турнір`) and step 2 dynamic `Джерело гравців` / `Ліга`, and removed the duplicate source control from the match config. 
- Updated loading flow in `v2/scripts/balance2/app.js` so `ensurePlayersLoaded` always uses normalized `state.app.playerSourceMode` (including `mixed` -> merged list with `sourceLeagueLabel`), and added an explicit `onLoadPlayers` handler wired to the new load button. 
- Added minimal styles for the new top flow in `v2/styles/balance2.css` (classes `.balance-step`, `.balance-step--event`, `.event-mode-switch`, `.event-mode-button`, `.player-source-control`). 
- Preserved compatibility: tournament/save payloads, GAS endpoints and regular rating logic remain unchanged; mixed mode still produces a merged available-player list with league markers.

### Testing
- Performed static checks: `node --check v2/scripts/balance2/state.js`, `node --check v2/scripts/balance2/ui.js`, `node --check v2/scripts/balance2/app.js`, and `node --check v2/scripts/balance2/api.js`, all succeeded. 
- Built project assets with `npm run build:summer2025-og`, which completed successfully. 
- Verified basic runtime wiring by running the app initialization path (`init`) in headless checks and confirmed no syntax/runtime errors in the modified modules.
- Manual UI checklist prepared for in-browser validation (event-first control, regular vs tournament source options, mixed load counts, merged player list with league markers, warnings on event-mode switch) — recommended to run the provided 10-step manual checklist in a browser to confirm interactive behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3b193bc083218dbbee3f002d3107)