### PR TITLE
fix(balance2): split regular and tournament save flows

### DIFF
--- a/v2/scripts/balance2/api.js
+++ b/v2/scripts/balance2/api.js
@@ -207,7 +207,7 @@ export function createTournamentGames(payload = {}) {
 }
 
 export function saveTournamentGame(payload = {}) {
-  return postTournament({
+  const body = {
     action: 'saveGame',
     mode: 'tournament',
     tournamentId: payload.tournamentId || '',
@@ -220,7 +220,11 @@ export function saveTournamentGame(payload = {}) {
     mvp2: payload.mvp2 || '',
     mvp3: payload.mvp3 || '',
     notes: payload.notes || '',
-  });
+  };
+  if (body.mode !== 'tournament') {
+    throw new Error('Invalid tournament save mode');
+  }
+  return postTournament(body);
 }
 
 export function getTournamentData(tournamentId) {

--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -366,9 +366,11 @@ function markScheduledMatchPlayed(resultSummary) {
 }
 
 async function doSave(retry = false) {
+  const eventMode = state.app?.eventMode === 'tournament' ? 'tournament' : 'regular';
+  console.debug('[balance2:save] mode', eventMode);
   const error = validateSave();
   if (error) {
-    if (state.app.eventMode === 'tournament') {
+    if (eventMode === 'tournament') {
       console.debug(`[balance2:tournament] validation failed ${error}`);
       setTournamentStatus(error, 'error');
       setTournamentRequestMeta({ action: 'saveGame', requestStatus: 'ERR', error });
@@ -378,39 +380,72 @@ async function doSave(retry = false) {
     return;
   }
 
-  const payload = retry ? state.meta.lastPayload : (state.app.eventMode === 'tournament' ? buildTournamentGamePayload() : buildPayload());
-  state.meta.lastPayload = payload;
-
-  saveLocked = true;
-  if (state.app.eventMode === 'tournament') state.tournamentState.isSaving = true;
-  lockSaveButton(true);
-  syncSaveButtonState();
-  setStatus({ state: 'saving', text: state.app.eventMode === 'tournament' ? 'Збереження турнірного матчу...' : 'Зберігаю…', retryVisible: false });
-  if (state.app.eventMode === 'tournament') {
-    setTournamentStatus(`Зберігаю матч ${payload.gameId}...`, 'loading');
-    setTournamentRequestMeta({ action: 'saveGame', requestStatus: 'PENDING', error: '' });
-    renderAndSync();
+  if (eventMode === 'tournament') {
+    await handleSaveTournamentGame(retry);
+    return;
   }
 
-  const res = state.app.eventMode === 'tournament'
-    ? await saveTournamentGame(payload)
-    : await saveMatch(payload, 20000);
+  await handleSaveRegularGame(retry);
+}
+
+async function handleSaveTournamentGame(retry = false) {
+  const payload = retry ? state.meta.lastPayload : buildTournamentGamePayload();
+  state.meta.lastPayload = payload;
+  console.debug('[balance2:tournament] save payload', payload);
+
+  saveLocked = true;
+  state.tournamentState.isSaving = true;
+  lockSaveButton(true);
+  syncSaveButtonState();
+  setStatus({ state: 'saving', text: 'Зберігаю турнірний матч...', retryVisible: false });
+  setTournamentStatus(`Зберігаю матч ${payload.gameId}...`, 'loading');
+  setTournamentRequestMeta({ action: 'saveGame', requestStatus: 'PENDING', error: '' });
+  renderAndSync();
+
+  const res = await saveTournamentGame(payload);
   if (res.ok) {
-    if (state.app.eventMode === 'tournament') {
-      const snapshot = createLastSavedSnapshot();
-      state.lastSavedGame = snapshot;
-      saveLastSavedGame(snapshot);
-      state.tournamentState.nextGameNumber += 1;
-      state.tournamentState.currentGameId = '';
-      resetMatchOnlyState();
-      syncSeriesMirror();
-      saveLobby();
-      setStatus({ state: 'saved', text: '✅ Турнірний матч збережено', retryVisible: false });
-      setTournamentStatus(`Матч ${payload.gameId} збережено`, 'success');
-      setTournamentRequestMeta({ action: 'saveGame', requestStatus: 'OK', error: '' });
-      finishTournamentSaving();
-      return;
-    }
+    const snapshot = createLastSavedSnapshot();
+    state.lastSavedGame = snapshot;
+    saveLastSavedGame(snapshot);
+    state.tournamentState.nextGameNumber += 1;
+    state.tournamentState.currentGameId = '';
+    resetMatchOnlyState();
+    syncSeriesMirror();
+    saveLobby();
+    console.debug('[balance2:tournament] saved without regular rating update', res);
+    setStatus({ state: 'saved', text: `Турнірний матч ${payload.gameId} збережено. Основний рейтинг не змінювався.`, retryVisible: false });
+    setTournamentStatus(`Матч ${payload.gameId} збережено`, 'success');
+    setTournamentRequestMeta({ action: 'saveGame', requestStatus: 'OK', error: '' });
+    finishTournamentSaving();
+    return;
+  }
+
+  const message = res.message || 'Невідома помилка';
+  setTournamentStatus(`Не вдалося зберегти матч: ${message}`, 'error');
+  setTournamentRequestMeta({ action: 'saveGame', requestStatus: 'ERR', error: message });
+  setStatus({ state: 'error', text: `Не вдалося зберегти турнірний матч: ${message}`, retryVisible: true });
+  finishTournamentSaving();
+}
+
+async function handleSaveRegularGame(retry = false) {
+  if (state.app?.eventMode === 'tournament') {
+    const message = 'Tournament mode cannot use regular save flow';
+    console.debug(`[balance2:regular] guard blocked save: ${message}`);
+    setStatus({ state: 'error', text: `❌ ${message}`, retryVisible: false });
+    return;
+  }
+
+  const payload = retry ? state.meta.lastPayload : buildPayload();
+  state.meta.lastPayload = payload;
+  console.debug('[balance2:regular] save payload', payload);
+
+  saveLocked = true;
+  lockSaveButton(true);
+  syncSaveButtonState();
+  setStatus({ state: 'saving', text: 'Зберігаю…', retryVisible: false });
+
+  const res = await saveMatch(payload, 20000);
+  if (res.ok) {
     try {
       clearPlayersCache(normalizeLeague(state.app.league));
       const freshPlayers = await loadPlayersForSource(state.app.playerSourceMode, { force: true, timeoutMs: 15000 });
@@ -424,27 +459,18 @@ async function doSave(retry = false) {
       resetMatchOnlyState();
       syncSeriesMirror();
       saveLobby();
-      setStatus({ state: 'saved', text: `✅ Збережено (${new Date().toLocaleTimeString('uk-UA')})`, retryVisible: false });
+      setStatus({ state: 'saved', text: 'Рейтинговий матч збережено. Рейтинг оновлено.', retryVisible: false });
       renderAndSync();
     } catch (loadError) {
       setStatus({ state: 'error', text: `❌ Не вдалося отримати відповідь від сервера: ${loadError.message}`, retryVisible: true });
     }
   } else {
-    if (state.app.eventMode === 'tournament') {
-      const message = res.message || 'Невідома помилка';
-      setTournamentStatus(`Не вдалося зберегти матч: ${message}`, 'error');
-      setTournamentRequestMeta({ action: 'saveGame', requestStatus: 'ERR', error: message });
-    }
     setStatus({ state: 'error', text: `❌ ${res.message || 'Не вдалося отримати відповідь від сервера'}`, retryVisible: true });
   }
 
-  if (state.app.eventMode === 'tournament') {
-    finishTournamentSaving();
-  } else {
-    saveLocked = false;
-    lockSaveButton(false);
-    syncSaveButtonState();
-  }
+  saveLocked = false;
+  lockSaveButton(false);
+  syncSaveButtonState();
 }
 
 function toggleSelectedPlayer(nick) {


### PR DESCRIPTION
### Motivation
- A single shared `doSave` flow allowed tournament saves to fall through into the regular rating flow, causing tournament results to be recorded in the main `games`/rating pipeline.
- The goal is to strictly separate the two save flows so `eventMode === "tournament"` never triggers regular-side effects.
- This is solved on the frontend routing layer without changing rating formulas, Google Sheets schemas, or backend code.

### Description
- Refactored `doSave` in `v2/scripts/balance2/app.js` to route on a fixed `eventMode` and call `handleSaveTournamentGame()` (with early `return`) or `handleSaveRegularGame()` exclusively. 
- Implemented `handleSaveTournamentGame()` to build only the tournament payload (`buildTournamentGamePayload()`), call only `saveTournamentGame(payload)`, add debug logs `console.debug('[balance2:save] mode', ...)` and `console.debug('[balance2:tournament] save payload', ...)`, and set tournament-specific status messages on success/error.
- Implemented `handleSaveRegularGame()` and added a guard that blocks regular save execution when `state.app.eventMode === 'tournament'`, plus debug log `console.debug('[balance2:regular] save payload', ...)`.
- Hardened `saveTournamentGame` in `v2/scripts/balance2/api.js` to construct explicit `body` with `mode: 'tournament'` and throw on invalid mode before calling `postTournament(body)`.

### Testing
- Ran syntax checks with `node --check v2/scripts/balance2/app.js` and `node --check v2/scripts/balance2/api.js`, both completed successfully.
- Ran build step `npm run build:summer2025-og`, which completed successfully and generated assets (`assets/summer2025-table-preview.png`).
- No automated unit tests were present; changes limited to `v2/scripts/balance2/app.js` and `v2/scripts/balance2/api.js` and validation was performed via the checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee449b5d708321aee6cfc7351b41a5)