### PR TITLE
balance2: add manual team assignment from lobby

### DIFF
--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -12,16 +12,21 @@ import {
   getActiveMatchTeams,
   getTeamLabel,
   MAX_LOBBY_PLAYERS,
+  TEAM_KEYS,
+  ensureTeamsForManualAssignment,
+  assignPlayerToTeam,
+  removePlayerFromTeam,
+  removePlayerFromAllTeams,
+  resolvePlayerByKey,
 } from './state.js';
 import { autoBalance2, balanceIntoNTeams } from './balance.js';
-import { clearTeams, syncSelectedFromTeamsAndBench } from './manual.js';
+import { syncSelectedFromTeamsAndBench } from './manual.js';
 import { render, bindUiEvents, setTournamentStatus, clearTournamentStatus } from './ui.js';
 import { loadPlayersForSource, saveMatch, createTournament, saveTournamentTeams, saveTournamentGame } from './api.js';
 import { saveLobby, restoreLobby, peekLobbyRestore, clearPlayersCache, saveLastSavedGame, readLastSavedGame } from './storage.js';
 import { setStatus, lockSaveButton } from './status.js';
 
 const $ = (id) => document.getElementById(id);
-const TEAM_KEYS = ['team1', 'team2', 'team3', 'team4', 'team5', 'team6'];
 const LEAGUE_KEY = 'balance2:league';
 let saveLocked = false;
 
@@ -164,8 +169,7 @@ function syncSeriesMirror() {
 }
 
 function setTeamCount(rawValue) {
-  state.teamsState.teamCount = Math.min(6, Math.max(2, Number(rawValue) || 2));
-  TEAM_KEYS.slice(state.teamsState.teamCount).forEach((key) => { state.teamsState.teams[key] = []; });
+  ensureTeamsForManualAssignment(rawValue);
   state.matchState.seriesRounds = state.matchState.seriesRounds.map((value) => {
     const numeric = Number(value);
     if (value === null) return null;
@@ -181,9 +185,13 @@ function setTeamCount(rawValue) {
   setTournamentDirty();
 }
 
+function clearAllTeams() {
+  TEAM_KEYS.forEach((key) => { state.teamsState.teams[key] = []; });
+}
+
 function runBalance() {
   const selected = getSelectedPlayers();
-  clearTeams();
+  clearAllTeams();
   if (state.teamsState.teamCount === 2) {
     const teams = autoBalance2(selected);
     state.teamsState.teams.team1 = teams.team1.map((p) => getPlayerKey(p));
@@ -476,9 +484,7 @@ async function handleSaveRegularGame(retry = false) {
 function toggleSelectedPlayer(nick) {
   if (state.playersState.selectedMap.has(nick)) {
     state.playersState.selected = state.playersState.selected.filter((n) => n !== nick);
-    Object.keys(state.teamsState.teams).forEach((key) => {
-      state.teamsState.teams[key] = state.teamsState.teams[key].filter((n) => n !== nick);
-    });
+    removePlayerFromAllTeams(nick);
   } else if (state.playersState.selected.length < MAX_LOBBY_PLAYERS) {
     state.playersState.selected = [...state.playersState.selected, nick];
   }
@@ -601,8 +607,8 @@ async function init() {
   });
 
   $('balanceBtn')?.addEventListener('click', () => { runBalance(); renderAndSync(); });
-  $('manualBtn')?.addEventListener('click', () => { state.app.mode = 'manual'; syncSelectedFromTeamsAndBench(); ensureActiveMatchState(); setTournamentDirty(); saveLobby(); renderAndSync(); });
-  $('clearLobbyBtn')?.addEventListener('click', () => { state.playersState.selected = []; syncSelectedMap(); clearTeams(); ensureActiveMatchState(); setTournamentDirty(); saveLobby(); renderAndSync(); });
+  $('manualBtn')?.addEventListener('click', () => { state.app.mode = 'manual'; ensureTeamsForManualAssignment(); syncSelectedFromTeamsAndBench(); ensureActiveMatchState(); setTournamentDirty(); saveLobby(); renderAndSync(); });
+  $('clearLobbyBtn')?.addEventListener('click', () => { state.playersState.selected = []; syncSelectedMap(); clearAllTeams(); ensureActiveMatchState(); setTournamentDirty(); saveLobby(); renderAndSync(); });
 
   const debouncedSearch = (() => {
     let timer;
@@ -640,9 +646,7 @@ async function init() {
     onRemove(nick) {
       state.playersState.selected = state.playersState.selected.filter((n) => n !== nick);
       syncSelectedMap();
-      Object.keys(state.teamsState.teams).forEach((key) => {
-        state.teamsState.teams[key] = state.teamsState.teams[key].filter((n) => n !== nick);
-      });
+      removePlayerFromAllTeams(nick);
       ensureActiveMatchState();
       setTournamentDirty();
       saveLobby();
@@ -686,6 +690,7 @@ async function init() {
     onRenameStart(teamKey) { startRenameTeam(teamKey); },
     onRenameSave(teamKey, value) { saveTeamName(teamKey, value); },
     onChanged() {
+      ensureTeamsForManualAssignment();
       syncSelectedFromTeamsAndBench();
       ensureActiveMatchState();
       setTournamentDirty();
@@ -754,6 +759,31 @@ async function init() {
         setStatus({ state: 'error', text: '❌ Команда A і Команда B не можуть бути однаковими', retryVisible: false });
       }
       cleanupTournamentMvp();
+      saveLobby();
+      renderAndSync();
+    },
+    onAssignPlayerTeam(playerKey, teamId) {
+      ensureTeamsForManualAssignment();
+      if (!playerKey) return;
+      if (!teamId) {
+        const removed = removePlayerFromAllTeams(playerKey);
+        if (!removed) return;
+        setTournamentDirty('Команди змінено — збережи їх перед матчем');
+        saveLobby();
+        renderAndSync();
+        return;
+      }
+      if (!resolvePlayerByKey(playerKey) && !state.playersState.selected.includes(playerKey)) return;
+      if (!assignPlayerToTeam(playerKey, teamId)) return;
+      setTournamentDirty(`Гравця додано в ${getTeamLabel(teamId)}`);
+      saveLobby();
+      renderAndSync();
+    },
+    onRemovePlayerFromTeam(playerKey, teamId) {
+      if (!playerKey || !teamId) return;
+      const removed = removePlayerFromTeam(playerKey, teamId);
+      if (!removed) return;
+      setTournamentDirty('Команди змінено — збережи їх перед матчем');
       saveLobby();
       renderAndSync();
     },
@@ -860,8 +890,10 @@ async function init() {
         renderAndSync();
         return;
       }
-      if (teams.some((team) => !team.players.length)) {
-        const message = 'Кожна команда має містити хоча б 1 гравця';
+      const activeTeamIds = TEAM_KEYS.slice(0, state.teamsState.teamCount);
+      const firstEmptyTeamId = activeTeamIds.find((teamId) => !(state.teamsState.teams[teamId] || []).length);
+      if (firstEmptyTeamId) {
+        const message = `${getTeamLabel(firstEmptyTeamId)} порожня`;
         console.debug(`[balance2:tournament] validation failed ${message}`);
         setTournamentStatus(message, 'error');
         setTournamentRequestMeta({ action: 'saveTeams', requestStatus: 'ERR', error: message });

--- a/v2/scripts/balance2/state.js
+++ b/v2/scripts/balance2/state.js
@@ -113,6 +113,12 @@ export function getSelectedPlayers() {
   return state.playersState.selected.map((playerKey) => map.get(playerKey)).filter(Boolean);
 }
 
+export function resolvePlayerByKey(playerKey) {
+  const key = getPlayerKey(playerKey);
+  if (!key) return null;
+  return state.playersState.players.find((player) => getPlayerKey(player) === key) || null;
+}
+
 export function syncSelectedMap() {
   state.playersState.selectedMap = new Set(state.playersState.selected);
 }
@@ -132,6 +138,51 @@ export function getParticipants() {
 
 export function getAvailableTeamKeys() {
   return TEAM_KEYS.slice(0, normalizeTeamCount(state.teamsState.teamCount));
+}
+
+export function ensureTeamsForManualAssignment(rawTeamCount = state.teamsState.teamCount) {
+  const teamCount = normalizeTeamCount(rawTeamCount);
+  state.teamsState.teamCount = teamCount;
+  TEAM_KEYS.forEach((teamKey, idx) => {
+    if (!Array.isArray(state.teamsState.teams[teamKey])) state.teamsState.teams[teamKey] = [];
+    if (idx >= teamCount) state.teamsState.teams[teamKey] = [];
+  });
+  return TEAM_KEYS.slice(0, teamCount);
+}
+
+export function getAssignedTeamId(playerKey) {
+  const key = getPlayerKey(playerKey);
+  if (!key) return '';
+  return TEAM_KEYS.find((teamKey) => (state.teamsState.teams[teamKey] || []).includes(key)) || '';
+}
+
+export function removePlayerFromTeam(playerKey, teamId) {
+  const key = getPlayerKey(playerKey);
+  if (!key || !TEAM_KEYS.includes(teamId) || !Array.isArray(state.teamsState.teams[teamId])) return false;
+  const before = state.teamsState.teams[teamId].length;
+  state.teamsState.teams[teamId] = state.teamsState.teams[teamId].filter((id) => id !== key);
+  return state.teamsState.teams[teamId].length !== before;
+}
+
+export function removePlayerFromAllTeams(playerKey) {
+  const key = getPlayerKey(playerKey);
+  if (!key) return false;
+  let changed = false;
+  TEAM_KEYS.forEach((teamKey) => {
+    changed = removePlayerFromTeam(key, teamKey) || changed;
+  });
+  return changed;
+}
+
+export function assignPlayerToTeam(playerKey, teamId) {
+  const key = getPlayerKey(playerKey);
+  if (!key || !TEAM_KEYS.includes(teamId) || !Array.isArray(state.teamsState.teams[teamId])) return false;
+  const inLobby = state.playersState.selected.includes(key);
+  const exists = !!resolvePlayerByKey(key);
+  if (!inLobby && !exists) return false;
+  removePlayerFromAllTeams(key);
+  if (!state.teamsState.teams[teamId].includes(key)) state.teamsState.teams[teamId].push(key);
+  return true;
 }
 
 export function getActiveMatchTeams() {

--- a/v2/scripts/balance2/ui.js
+++ b/v2/scripts/balance2/ui.js
@@ -12,6 +12,7 @@ import {
   TEAM_COUNT_OPTIONS,
   MAX_LOBBY_PLAYERS,
   normalizeTeamCount,
+  getAssignedTeamId,
 } from './state.js';
 import { movePlayerToTeam } from './manual.js';
 
@@ -213,10 +214,13 @@ export function renderPlayers() {
 export function renderLobby() {
   const wrap = document.getElementById('lobbyList');
   if (!wrap) return;
+  const availableTeamKeys = getAvailableTeamKeys();
   const playersMap = new Map(state.playersState.players.map((p) => [getPlayerKey(p), p]));
   wrap.innerHTML = state.playersState.selected.map((playerKey) => {
     const player = playersMap.get(playerKey) || { nick: playerKey, points: 0, rank: '—' };
-    return `<div class="lobby-row">${playerMetaHtml(player)}<button class="chip" data-remove="${escapeAttr(playerKey)}">Прибрати</button></div>`;
+    const assignedTeamId = getAssignedTeamId(playerKey);
+    const status = assignedTeamId ? `У команді: ${getTeamLabel(assignedTeamId)}` : 'Не в команді';
+    return `<div class="lobby-row"><div>${playerMetaHtml(player)}<div class="player-assignment-status">${escapeHtml(status)}</div></div><div class="manual-assign-control"><select class="team-assignment-select" data-role="assign-player-team" data-player-key="${escapeAttr(playerKey)}"><option value="">У команду...</option>${availableTeamKeys.map((teamKey) => `<option value="${escapeAttr(teamKey)}" ${assignedTeamId === teamKey ? 'selected' : ''}>${escapeHtml(getTeamLabel(teamKey))}</option>`).join('')}</select><button class="chip" data-remove="${escapeAttr(playerKey)}">Прибрати</button></div></div>`;
   }).join('');
 }
 
@@ -236,22 +240,14 @@ export function renderTeams() {
   const keys = TEAM_KEYS.slice(0, state.teamsState.teamCount);
   const map = new Map(state.playersState.players.map((p) => [getPlayerKey(p), p]));
   const cards = keys.map((key) => {
-    const playerKeys = state.teamsState.teams[key];
+    const playerKeys = state.teamsState.teams[key] || [];
     const total = sumByNicks(playerKeys);
     const members = playerKeys.map((playerKey) => {
       const player = map.get(playerKey) || { nick: playerKey, points: 0, rank: '—' };
-      return `<div class="team-player">${playerMetaHtml(player)}<button class="chip" data-move-player-key="${escapeAttr(playerKey)}" data-move-team="bench">Лавка</button></div>`;
-    }).join('') || '<div class="tag">порожньо</div>';
+      return `<div class="team-player">${playerMetaHtml(player)}<button class="team-player-remove" type="button" data-role="remove-player-from-team" data-player-key="${escapeAttr(playerKey)}" data-team-id="${escapeAttr(key)}">Прибрати</button></div>`;
+    }).join('') || '<div class="team-empty-state">Додай гравців із lobby</div>';
     return `<div class="team-card"><h4>${teamNameControl(key)} <span class="tag">Σ ${total}</span></h4>${members}</div>`;
   });
-
-  if (state.app.mode === 'manual') {
-    const bench = state.playersState.selected.filter((playerKey) => !keys.some((key) => state.teamsState.teams[key].includes(playerKey)));
-    cards.push(`<div class="team-card"><h4>Лавка</h4>${bench.map((playerKey) => {
-      const player = map.get(playerKey) || { nick: playerKey, points: 0, rank: '—' };
-      return `<div class="team-player">${playerMetaHtml(player)}<div class="team-actions">${keys.map((k) => `<button class="chip" data-move-player-key="${escapeAttr(playerKey)}" data-move-team="${escapeAttr(k)}">→ ${escapeHtml(getTeamLabel(k))}</button>`).join('')}</div></div>`;
-    }).join('') || '<div class="tag">порожньо</div>'}</div>`);
-  }
 
   grid.innerHTML = cards.join('');
 }
@@ -467,6 +463,7 @@ export function bindUiEvents(handlers) {
     const tournamentTeamPick = e.target.closest('select[data-tournament-team]');
     const gameModePick = e.target.closest('select[data-tournament-game-mode]');
     const playerSourceModePick = e.target.closest('select[data-role="player-source-mode"]');
+    const assignPlayerTeam = e.target.closest('select[data-role="assign-player-team"]');
     if (matchMode) handlers.onMatchMode(matchMode);
     if (teamPick) handlers.onMatchTeamPick(teamPick.dataset.matchTeam, teamPick.value);
     if (schedulePick) handlers.onSchedulePick(schedulePick);
@@ -474,6 +471,7 @@ export function bindUiEvents(handlers) {
     if (tournamentTeamPick) handlers.onTournamentTeamPick(tournamentTeamPick.dataset.tournamentTeam, tournamentTeamPick.value);
     if (gameModePick) handlers.onTournamentGameMode(gameModePick.value);
     if (playerSourceModePick) handlers.onPlayerSourceMode(playerSourceModePick.value);
+    if (assignPlayerTeam) handlers.onAssignPlayerTeam(assignPlayerTeam.dataset.playerKey, assignPlayerTeam.value);
   });
 
   document.addEventListener('click', (e) => {
@@ -491,6 +489,7 @@ export function bindUiEvents(handlers) {
     const createTournament = e.target.closest('[data-tournament-create]');
     const saveTeams = e.target.closest('[data-tournament-save-teams]');
     const loadPlayers = e.target.closest('[data-load-players]');
+    const removeFromTeam = e.target.closest('[data-role="remove-player-from-team"]');
 
     if (toggle) {
       const alreadySelected = state.playersState.selectedMap.has(toggle);
@@ -540,6 +539,7 @@ export function bindUiEvents(handlers) {
     if (loadPlayers) handlers.onLoadPlayers();
     if (createTournament) handlers.onCreateTournament();
     if (saveTeams) handlers.onSaveTournamentTeams();
+    if (removeFromTeam) handlers.onRemovePlayerFromTeam(removeFromTeam.dataset.playerKey, removeFromTeam.dataset.teamId);
   });
 
   document.addEventListener('input', (e) => {

--- a/v2/styles/balance2.css
+++ b/v2/styles/balance2.css
@@ -101,6 +101,22 @@
   border-radius: 2px;
   padding: 0 .25rem;
 }
+.manual-assign-control {
+  display: grid;
+  gap: .35rem;
+  min-width: 140px;
+}
+.team-assignment-select {
+  min-height: 34px;
+  border-radius: .35rem;
+  padding: .3rem .4rem;
+  width: 100%;
+}
+.player-assignment-status {
+  margin-top: .2rem;
+  font-size: .78rem;
+  opacity: .9;
+}
 
 .team-card {
   border: 1px solid rgba(255, 255, 255, .13);
@@ -111,6 +127,16 @@
 .team-card h4 { margin: .1rem 0 .5rem; display: flex; justify-content: space-between; flex-wrap: wrap; gap: .5rem; }
 .team-name-wrap { display: inline-flex; gap: .4rem; align-items: center; flex-wrap: wrap; }
 .match-team-preview { margin: 0; padding-left: 1.2rem; display: grid; gap: .25rem; }
+.team-empty-state {
+  border: 1px dashed rgba(255,255,255,.2);
+  border-radius: .5rem;
+  padding: .5rem;
+  opacity: .85;
+}
+.team-player-remove {
+  border-radius: .35rem;
+  min-height: 32px;
+}
 
 .round-card {
   padding: .6rem;


### PR DESCRIPTION
### Motivation
- Додати простий робочий ручний розподіл гравців із lobby у команди для режимів `tournament`, `mixed` та звичайного lobby.  
- Root cause: UI і логіка раніше не мали контролів для призначення з lobby (лише «лавка»/manual flow), а контейнери команд створювались переважно після автобалансу, тому неможливо було зручно зробити початкове ручне заповнення команд.  
- Мета патчу: після вибору `teamsCount` створювати порожні team-контейнери і дозволити адміну клацнути гравця в lobby і вибрати команду (без drag&drop).  

### Description
- Додано state-helpers у `v2/scripts/balance2/state.js`: `ensureTeamsForManualAssignment`, `assignPlayerToTeam`, `removePlayerFromTeam`, `removePlayerFromAllTeams`, `getAssignedTeamId`, `resolvePlayerByKey` і пов’язане використання `getPlayerKey`.  
- Оновлено UI в `v2/scripts/balance2/ui.js`: у `renderLobby()` для кожного lobby-item додано `<select data-role="assign-player-team" data-player-key="...">` з опціями тільки для доступних команд і показом статусу `Не в команді` / `У команді: ...`; оновлено `renderTeams()` щоб показувати порожні карти команд і кнопку «Прибрати» у списку гравців команди.  
- Пов’язано логіку в `v2/scripts/balance2/app.js`: гарантування команд при зміні `teamsCount` через `ensureTeamsForManualAssignment`, нові handlers `onAssignPlayerTeam` та `onRemovePlayerFromTeam`, скидання assignment при видаленні з lobby та валідація збереження турніру (блокує `saveTeams` якщо серед активних команд є порожня).  
- Мінімальні стилі додано в `v2/styles/balance2.css` для `manual-assign-control`, `team-assignment-select`, `team-empty-state`, `player-assignment-status`, `team-player-remove`.  

### Testing
- Запущена синтаксична перевірка файлів: `node --check v2/scripts/balance2/state.js`, `node --check v2/scripts/balance2/ui.js`, `node --check v2/scripts/balance2/app.js` — всі перевірки пройшли успішно.  
- Запущена збірка-програма: `npm run build:summer2025-og` — виконано успішно.  
- Немає змін у зовнішніх API/schema-файлах або backend-логіці; ручні тест-кейси згідно чекліста готові для локального інтерактивного тестування (описані у коментарях до патчу).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee48340c5c8321b6f520d4bca0f7bb)