### PR TITLE
Rebuild mobile Result tab: leader hero, podium and compact standings

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -8801,14 +8801,64 @@ body.theme-game :is(
 .tournament-games-list,
 .tournament-players-list { display: grid; grid-template-columns: 1fr; gap: 10px; }
 
-.tournament-standing-card { border: 1px solid rgba(255,255,255,.12); background: rgba(9,15,27,.76); padding: 10px; display: grid; gap: 8px; }
-.tournament-standing-card__head { display: flex; align-items: center; gap: 8px; }
-.tournament-standing-card__place { color: #9ddfff; font-weight: 700; }
-.tournament-standing-card__record,
-.tournament-standing-card__score { display: flex; flex-wrap: wrap; gap: 10px; font-size: 13px; color: #d9e7fa; }
-.tournament-standing-card.is-top-1 { box-shadow: inset 3px 0 0 rgba(124,255,114,.7); }
-.tournament-standing-card.is-top-2 { box-shadow: inset 3px 0 0 rgba(49,208,255,.7); }
-.tournament-standing-card.is-top-3 { box-shadow: inset 3px 0 0 rgba(255,191,60,.7); }
+.tournament-result-view { display: grid; gap: 10px; width: 100%; max-width: 100%; }
+.tournament-section-title { margin: 2px 0 0; font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: #9eb4d3; }
+
+.tournament-leader-card {
+  border: 1px solid rgba(124,255,114,.36);
+  border-left: 4px solid rgba(124,255,114,.8);
+  border-radius: var(--v2-radius-md);
+  background: linear-gradient(160deg, rgba(18,39,24,.92), rgba(10,17,29,.92));
+  box-shadow: 0 0 0 1px rgba(124,255,114,.08), 0 12px 22px rgba(0,0,0,.2);
+  padding: 12px;
+  display: grid;
+  gap: 6px;
+}
+.tournament-leader-card__head { display: flex; justify-content: space-between; gap: 10px; align-items: baseline; }
+.tournament-leader-card__label {
+  font-size: 11px;
+  letter-spacing: .08em;
+  color: #b7f1bc;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.tournament-leader-card__place { color: #d6ffd8; font-size: 22px; line-height: 1; }
+.tournament-leader-card__team { margin: 0; font-size: 20px; line-height: 1.2; }
+.tournament-leader-card__score { margin: 0; font-size: 26px; line-height: 1.05; font-weight: 800; color: #effff2; }
+
+.tournament-podium-list,
+.tournament-standings-compact { display: grid; gap: 10px; }
+
+.tournament-podium-card {
+  border: 1px solid rgba(255,255,255,.14);
+  border-left: 3px solid rgba(49,208,255,.65);
+  border-radius: var(--v2-radius-sm);
+  background: rgba(10,17,29,.84);
+  padding: 12px;
+  display: grid;
+  gap: 4px;
+}
+.tournament-podium-card.is-top-3 { border-left-color: rgba(255,191,60,.78); }
+.tournament-podium-card__rank,
+.tournament-podium-card__score { margin: 0; }
+.tournament-podium-card__rank { font-weight: 700; color: #e8f3ff; }
+.tournament-podium-card__score { font-size: 17px; font-weight: 700; color: #d6ebff; }
+
+.tournament-standing-row {
+  border: 1px solid rgba(255,255,255,.12);
+  border-radius: var(--v2-radius-sm);
+  background: rgba(8,14,24,.66);
+  padding: 12px;
+  display: grid;
+  gap: 4px;
+}
+.tournament-standing-row.is-leader { border-left: 3px solid rgba(124,255,114,.62); }
+.tournament-standing-row__title,
+.tournament-standing-row__score { margin: 0; }
+.tournament-standing-row__title { font-weight: 700; color: #e3efff; }
+.tournament-standing-row__score { color: #c8e0ff; font-size: 15px; font-weight: 700; }
+.tournament-statline { margin: 0; color: #d8e6f9; font-size: 13px; line-height: 1.3; }
+.tournament-statline--muted { color: #a7bfdc; font-size: 12px; }
 
 .tournament-match-log { border: 1px solid rgba(255,255,255,.14); background: rgba(9,15,27,.8); overflow: hidden; }
 .tournament-match-log__head { width: 100%; border: 0; background: transparent; color: inherit; text-align: left; padding: 10px; display: flex; justify-content: space-between; gap: 10px; }
@@ -8842,6 +8892,13 @@ body.theme-game :is(
 
 @media (max-width: 640px) {
   .tournament-tabs { display: flex; overflow-x: auto; gap: 6px; }
+  .tournament-tab-content { width: 100%; max-width: 100%; }
+  .tournament-result-view { gap: 10px; }
+  .tournament-leader-card,
+  .tournament-podium-card,
+  .tournament-standing-row { padding: 12px; }
+  .tournament-podium-list,
+  .tournament-standings-compact { gap: 10px; }
 }
 
 @media (max-width: 380px) {

--- a/v2/pages/tournaments.js
+++ b/v2/pages/tournaments.js
@@ -625,10 +625,36 @@ function renderTournamentDashboard(node, data) {
   renderers.result();
 }
 
+function pluralizeUa(value, one, few, many) {
+  const n = Math.abs(toNumber(value));
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return one;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return few;
+  return many;
+}
+
+function formatPointsLabel(value) {
+  const points = toNumber(value);
+  return `${points} ${pluralizeUa(points, 'очко', 'очки', 'очок')}`;
+}
+
+function formatRecordLabel(record = {}, compact = false) {
+  const wins = toNumber(record?.wins);
+  const losses = toNumber(record?.losses);
+  const draws = toNumber(record?.draws);
+  if (compact) return `${wins}В · ${losses}П · ${draws}Н`;
+  return [
+    `${wins} ${pluralizeUa(wins, 'перемога', 'перемоги', 'перемог')}`,
+    `${losses} ${pluralizeUa(losses, 'поразка', 'поразки', 'поразок')}`,
+    `${draws} ${pluralizeUa(draws, 'нічия', 'нічиї', 'нічиїх')}`
+  ].join(' · ');
+}
+
 function renderTeamsTable(node, teams) {
   clear(node);
   if (!teams.length) {
-    node.append(stateCard('Команди ще формуються', 'Команди ще формуються'));
+    node.append(stateCard('Команди ще формуються', 'Після збереження команд тут з’явиться результат турніру.'));
     return;
   }
 
@@ -642,34 +668,56 @@ function renderTeamsTable(node, teams) {
     return toNumber(a.losses) - toNumber(b.losses);
   });
 
-  const cards = createElement('div', 'tournament-standing-list');
+  const wrap = createElement('section', 'tournament-result-view');
+  const leader = sorted[0];
+  const podiumTeams = sorted.slice(1, 3);
 
+  if (leader) {
+    const leaderCard = createElement('article', 'tournament-leader-card');
+    const leaderTop = createElement('div', 'tournament-leader-card__head');
+    leaderTop.append(
+      createElement('span', 'tournament-leader-card__label', 'ЛІДЕР ТУРНІРУ'),
+      createElement('strong', 'tournament-leader-card__place', '#1')
+    );
+    leaderCard.append(
+      leaderTop,
+      createElement('h3', 'tournament-leader-card__team', toText(leader.teamName, toText(leader.teamId))),
+      createElement('p', 'tournament-leader-card__score', formatPointsLabel(leader.points)),
+      createElement('p', 'tournament-statline', formatRecordLabel(leader)),
+      createElement('p', 'tournament-statline tournament-statline--muted', `MMR ${toNumber(leader.mmrCurrent) || '—'}`)
+    );
+    wrap.append(leaderCard);
+  }
+
+  if (podiumTeams.length) {
+    wrap.append(createElement('h3', 'tournament-section-title', 'ТОП-3'));
+    const podiumList = createElement('div', 'tournament-podium-list');
+    podiumTeams.forEach((team, idx) => {
+      const place = idx + 2;
+      const card = createElement('article', `tournament-podium-card tournament-podium-row is-top-${place}`);
+      card.append(
+        createElement('p', 'tournament-podium-card__rank', `#${place} ${toText(team.teamName, toText(team.teamId))}`),
+        createElement('p', 'tournament-podium-card__score', formatPointsLabel(team.points)),
+        createElement('p', 'tournament-statline', formatRecordLabel(team))
+      );
+      podiumList.append(card);
+    });
+    wrap.append(podiumList);
+  }
+
+  wrap.append(createElement('h3', 'tournament-section-title', 'Вся таблиця'));
+  const standings = createElement('div', 'tournament-standings-compact');
   sorted.forEach((team, index) => {
-    const card = createElement('article', `tournament-standing-card${index < 3 ? ` is-top-${index + 1}` : ''}`);
-    const header = createElement('div', 'tournament-standing-card__head');
-    header.append(
-      createElement('span', 'tournament-standing-card__place', `#${index + 1}`),
-      createElement('strong', '', toText(team.teamName, toText(team.teamId)))
+    const row = createElement('article', `tournament-standing-row${index === 0 ? ' is-leader' : ''}`);
+    row.append(
+      createElement('p', 'tournament-standing-row__title', `#${index + 1} ${toText(team.teamName, toText(team.teamId))}`),
+      createElement('p', 'tournament-standing-row__score', formatPointsLabel(team.points)),
+      createElement('p', 'tournament-statline tournament-statline--muted', `${formatRecordLabel(team, true)} · MMR ${toNumber(team.mmrCurrent) || '—'}`)
     );
-    const record = createElement('div', 'tournament-standing-card__record');
-    record.append(
-      createElement('span', '', `${toNumber(team.wins)} В`),
-      createElement('span', '', `${toNumber(team.losses)} П`),
-      createElement('span', '', `${toNumber(team.draws)} Н`)
-    );
-    const score = createElement('div', 'tournament-standing-card__score');
-    score.append(
-      createElement('span', '', `Очки: ${toNumber(team.points)}`),
-      createElement('span', '', `MMR: ${toNumber(team.mmrCurrent) || '—'}`)
-    );
-    card.append(
-      header,
-      record,
-      score
-    );
-    cards.append(card);
+    standings.append(row);
   });
-  node.append(cards);
+  wrap.append(standings);
+  node.append(wrap);
 }
 
 function renderGames(node, games, teamMap) {


### PR DESCRIPTION
### Motivation
- Поточна вкладка «Результат» рендерила всі команди однаково і не створювала візуальної ієрархії для лідера/топ‑3/аутсайдерів, що робило сторінку незрозумілою на mobile.;
- Потрібно було зменшити «шум» дрібних капсульних метрик і показати ключові дані (хто лідирує, очки, перемоги, хто внизу) за 3 секунди; 
- Мета — мобільно‑перший, більш гейміфікований вигляд з чітким hero для #1, компактними #2/#3 і компактною повною таблицею.

### Description
- Перероблено рендер вкладки `result` у `v2/pages/tournaments.js`, замінивши однакові standing‑card на нову структуру: leader hero (`.tournament-leader-card`), podium list (`.tournament-podium-list` / `.tournament-podium-card`) та compact standings (`.tournament-standings-compact` / `.tournament-standing-row`).
- Додано хелпери для читабельних підписів: `pluralizeUa`, `formatPointsLabel` і `formatRecordLabel` (підтримка повного та компактного формату рекорду). 
- Оновлено пустий стан для результатів та приберено капсульні/oval елементи у вигляді statline (відмова від pill‑метрик у Result view). 
- Додано mobile‑first стилі в `v2/assets/css/main.css` для нових класів (`.tournament-result-view`, `.tournament-leader-card`, `.tournament-podium-card`, `.tournament-standing-row`, `.tournament-section-title` тощо) з візуальними акцентами для #1/#2/#3 і контрольованими відступами/розмірами.

### Testing
- Автоматична перевірка синтаксису JavaScript виконана командою `node --check v2/pages/tournaments.js` і пройдена успішно.
- Автоматична перевірка синтаксису сторінки домашньої панелі виконана командою `node --check v2/pages/home.js` і пройдена успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee6791c34c8321818c425bf64ddc1f)