### PR TITLE
Remove capsule/meta tournament UI from v2 tournaments page

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -8762,12 +8762,8 @@ body.theme-game :is(
 
 .tournaments-page-v2 .tournament-panel,
 .tournaments-page-v2 .tournament-selected,
-.tournaments-page-v2 .tournament-count-card,
 .tournaments-page-v2 .tournament-card,
-.tournaments-page-v2 .tournament-standing-card,
 .tournaments-page-v2 .tournament-match-log,
-.tournaments-page-v2 .tournament-team-box,
-.tournaments-page-v2 .tournament-mvp-item,
 .tournaments-page-v2 .tournament-player-rank-card,
 .tournaments-page-v2 .tournament-insight-card,
 .tournaments-page-v2 .tournament-empty-state {
@@ -8777,25 +8773,17 @@ body.theme-game :is(
   box-sizing: border-box;
 }
 
-.tournaments-page-v2 .tournament-meta-item,
-.tournaments-page-v2 .t-rank-badge,
-.tournaments-page-v2 .px-card {
-  border-radius: 4px !important;
+.tournaments-page-v2 .tournament-meta-item {
+  display: none !important;
 }
 
 .tournament-selected__kicker { margin: 0 0 4px; font-size: 11px; letter-spacing: .08em; color: var(--muted); }
 .tournament-selected__title { margin: 0; }
 .tournament-selected__sub { margin: 6px 0 0; color: #c8d7ee; font-size: 13px; }
-
-.tournament-summary-row { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin-top: 10px; }
-.tournament-count-card { border: 1px solid rgba(255,255,255,.14); background: rgba(10,17,29,.74); padding: 9px; display: grid; gap: 4px; }
-.tournament-count-card span { font-size: 11px; color: var(--muted); }
-.tournament-count-card strong { font-size: 18px; }
+.tournament-selected__summary { margin: 10px 0 0; color: #dce8f9; font-size: 14px; }
 
 .tournament-statline-group { display: grid; gap: 6px; }
 .tournament-simple-line { margin: 0; color: #dce8f9; font-size: 13px; }
-.tournament-statcell { border: 1px solid rgba(255,255,255,.12); padding: 8px; display: grid; gap: 2px; margin-bottom: 6px; }
-.tournament-statcell span { font-size: 11px; color: var(--muted); }
 
 .tournament-standing-list,
 .tournament-games-list,
@@ -8803,84 +8791,35 @@ body.theme-game :is(
 
 .tournament-result-view { display: grid; gap: 10px; width: 100%; max-width: 100%; }
 .tournament-section-title { margin: 2px 0 0; font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: #9eb4d3; }
-
-.tournament-leader-card {
-  border: 1px solid rgba(124,255,114,.36);
-  border-left: 4px solid rgba(124,255,114,.8);
-  border-radius: var(--v2-radius-md);
-  background: linear-gradient(160deg, rgba(18,39,24,.92), rgba(10,17,29,.92));
-  box-shadow: 0 0 0 1px rgba(124,255,114,.08), 0 12px 22px rgba(0,0,0,.2);
-  padding: 12px;
-  display: grid;
-  gap: 6px;
-}
-.tournament-leader-card__head { display: flex; justify-content: space-between; gap: 10px; align-items: baseline; }
-.tournament-leader-card__label {
-  font-size: 11px;
-  letter-spacing: .08em;
-  color: #b7f1bc;
-  text-transform: uppercase;
-  font-weight: 700;
-}
-.tournament-leader-card__place { color: #d6ffd8; font-size: 22px; line-height: 1; }
-.tournament-leader-card__team { margin: 0; font-size: 20px; line-height: 1.2; }
-.tournament-leader-card__score { margin: 0; font-size: 26px; line-height: 1.05; font-weight: 800; color: #effff2; }
-
-.tournament-podium-list,
-.tournament-standings-compact { display: grid; gap: 10px; }
-
-.tournament-podium-card {
-  border: 1px solid rgba(255,255,255,.14);
-  border-left: 3px solid rgba(49,208,255,.65);
-  border-radius: var(--v2-radius-sm);
-  background: rgba(10,17,29,.84);
-  padding: 12px;
-  display: grid;
-  gap: 4px;
-}
-.tournament-podium-card.is-top-3 { border-left-color: rgba(255,191,60,.78); }
-.tournament-podium-card__rank,
-.tournament-podium-card__score { margin: 0; }
-.tournament-podium-card__rank { font-weight: 700; color: #e8f3ff; }
-.tournament-podium-card__score { font-size: 17px; font-weight: 700; color: #d6ebff; }
-
-.tournament-standing-row {
+.tournament-standings-list { display: grid; gap: 10px; }
+.tournament-result-card {
   border: 1px solid rgba(255,255,255,.12);
-  border-radius: var(--v2-radius-sm);
+  border-radius: 6px;
   background: rgba(8,14,24,.66);
   padding: 12px;
   display: grid;
   gap: 4px;
 }
-.tournament-standing-row.is-leader { border-left: 3px solid rgba(124,255,114,.62); }
-.tournament-standing-row__title,
-.tournament-standing-row__score { margin: 0; }
-.tournament-standing-row__title { font-weight: 700; color: #e3efff; }
-.tournament-standing-row__score { color: #c8e0ff; font-size: 15px; font-weight: 700; }
-.tournament-statline { margin: 0; color: #d8e6f9; font-size: 13px; line-height: 1.3; }
-.tournament-statline--muted { color: #a7bfdc; font-size: 12px; }
+.tournament-result-card.is-leader { border-color: rgba(124,255,114,.5); }
+.tournament-result-card__title,
+.tournament-result-card__points,
+.tournament-result-card__line { margin: 0; }
+.tournament-result-card__title { font-weight: 700; color: #e3efff; }
+.tournament-result-card__points { color: #c8e0ff; font-size: 15px; font-weight: 700; }
+.tournament-result-card__line { color: #d8e6f9; font-size: 13px; line-height: 1.3; }
 
 .tournament-match-log { border: 1px solid rgba(255,255,255,.14); background: rgba(9,15,27,.8); overflow: hidden; }
-.tournament-match-log__head { width: 100%; border: 0; background: transparent; color: inherit; text-align: left; padding: 10px; display: flex; justify-content: space-between; gap: 10px; }
-.tournament-match-log__main { display: grid; gap: 3px; }
+.tournament-match-log__head { padding: 10px; display: flex; justify-content: space-between; gap: 10px; align-items: center; }
+.tournament-match-log__meta { display: grid; gap: 3px; }
 .tournament-match-log__kicker { font-size: 11px; color: var(--muted); letter-spacing: .06em; }
-.tournament-match-log__main small { color: var(--muted); font-size: 12px; }
-.tournament-match-log__score { color: #9ddfff; font-weight: 700; align-self: center; white-space: nowrap; }
-.tournament-match-log__body { border-top: 1px solid rgba(255,255,255,.1); padding: 10px; display: grid; gap: 8px; }
-.tournament-match-log__teams { display: grid; gap: 8px; }
-.tournament-team-box { border: 1px solid rgba(255,255,255,.12); padding: 8px; display: grid; gap: 2px; background: rgba(5,10,18,.5); }
-.tournament-team-box.is-winner { border-color: rgba(124,255,114,.36); background: rgba(124,255,114,.08); }
-.tournament-team-box span { color: var(--muted); font-size: 12px; }
-.tournament-mvp-list { display: grid; gap: 6px; }
-.tournament-mvp-item { border: 1px solid rgba(255,255,255,.12); padding: 7px 8px; display: flex; justify-content: space-between; gap: 8px; }
-.tournament-mvp-item span { color: var(--muted); font-size: 12px; }
-.tournament-delta-line { margin: 0; color: #d9e7fa; font-size: 13px; }
+.tournament-match-log small { color: var(--muted); font-size: 12px; }
+.tournament-match-log__score { color: #9ddfff; font-weight: 700; white-space: nowrap; }
+.tournament-match-log__line { margin: 0; padding: 0 10px 10px; color: #d9e7fa; font-size: 13px; }
 
 .tournament-player-rank-card { border: 1px solid rgba(255,255,255,.12); background: rgba(9,15,27,.76); padding: 10px; display: grid; gap: 7px; }
-.tournament-player-rank-card__head { display: flex; align-items: center; gap: 8px; }
+.tournament-player-rank-card__title { margin: 0; font-weight: 700; color: #edf5ff; }
 .tournament-player-rank-card__team { margin: 0; color: #b7c8e2; font-size: 13px; }
-.tournament-player-rank-card__stats { display: flex; flex-wrap: wrap; gap: 10px; color: #dce8f9; font-size: 13px; }
-.tournament-player-rank-card__impact { display: flex; justify-content: space-between; gap: 8px; font-size: 13px; }
+.tournament-player-rank-card__line { margin: 0; color: #dce8f9; font-size: 13px; }
 
 .tournament-insight-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 10px; }
 .tournament-insight-card { border: 1px solid rgba(255,255,255,.12); background: rgba(9,15,27,.76); padding: 10px; }
@@ -8894,13 +8833,4 @@ body.theme-game :is(
   .tournament-tabs { display: flex; overflow-x: auto; gap: 6px; }
   .tournament-tab-content { width: 100%; max-width: 100%; }
   .tournament-result-view { gap: 10px; }
-  .tournament-leader-card,
-  .tournament-podium-card,
-  .tournament-standing-row { padding: 12px; }
-  .tournament-podium-list,
-  .tournament-standings-compact { gap: 10px; }
-}
-
-@media (max-width: 380px) {
-  .tournament-summary-row { grid-template-columns: 1fr; }
 }

--- a/v2/pages/tournaments.js
+++ b/v2/pages/tournaments.js
@@ -300,26 +300,8 @@ function createPreviewSections() {
   return wrap;
 }
 
-function createStatInline(label, value) {
-  const item = createElement('p', 'tournament-statline');
-  item.append(createElement('span', '', label), createElement('strong', '', String(value)));
-  return item;
-}
-
-function createStatCell(label, value) {
-  const item = createElement('div', 'tournament-statcell');
-  item.append(createElement('span', '', label), createElement('strong', '', String(value)));
-  return item;
-}
-
 function createSimpleLine(text) {
   return createElement('p', 'tournament-simple-line', text);
-}
-
-function createCountCard(label, value) {
-  const item = createElement('div', 'tournament-count-card');
-  item.append(createElement('span', '', label), createElement('strong', '', String(value)));
-  return item;
 }
 
 function sanitizeErrorMessage() {
@@ -584,12 +566,8 @@ function renderTournamentDashboard(node, data) {
   top.append(topInfo);
   head.append(top);
 
-  const summaryStrip = createElement('div', 'tournament-summary-row');
-  summaryStrip.append(
-    createCountCard('Команд', teams.length),
-    createCountCard('Матчів', games.length),
-    createCountCard('Гравців', players.length)
-  );
+  const summaryStrip = createElement('p', 'tournament-selected__summary');
+  summaryStrip.textContent = `Команд: ${teams.length} · Матчів: ${games.length} · Гравців: ${players.length}`;
   head.append(summaryStrip);
 
   const tabsWrap = createElement('div', 'tournament-tabs');
@@ -669,52 +647,16 @@ function renderTeamsTable(node, teams) {
   });
 
   const wrap = createElement('section', 'tournament-result-view');
-  const leader = sorted[0];
-  const podiumTeams = sorted.slice(1, 3);
-
-  if (leader) {
-    const leaderCard = createElement('article', 'tournament-leader-card');
-    const leaderTop = createElement('div', 'tournament-leader-card__head');
-    leaderTop.append(
-      createElement('span', 'tournament-leader-card__label', 'ЛІДЕР ТУРНІРУ'),
-      createElement('strong', 'tournament-leader-card__place', '#1')
-    );
-    leaderCard.append(
-      leaderTop,
-      createElement('h3', 'tournament-leader-card__team', toText(leader.teamName, toText(leader.teamId))),
-      createElement('p', 'tournament-leader-card__score', formatPointsLabel(leader.points)),
-      createElement('p', 'tournament-statline', formatRecordLabel(leader)),
-      createElement('p', 'tournament-statline tournament-statline--muted', `MMR ${toNumber(leader.mmrCurrent) || '—'}`)
-    );
-    wrap.append(leaderCard);
-  }
-
-  if (podiumTeams.length) {
-    wrap.append(createElement('h3', 'tournament-section-title', 'ТОП-3'));
-    const podiumList = createElement('div', 'tournament-podium-list');
-    podiumTeams.forEach((team, idx) => {
-      const place = idx + 2;
-      const card = createElement('article', `tournament-podium-card tournament-podium-row is-top-${place}`);
-      card.append(
-        createElement('p', 'tournament-podium-card__rank', `#${place} ${toText(team.teamName, toText(team.teamId))}`),
-        createElement('p', 'tournament-podium-card__score', formatPointsLabel(team.points)),
-        createElement('p', 'tournament-statline', formatRecordLabel(team))
-      );
-      podiumList.append(card);
-    });
-    wrap.append(podiumList);
-  }
-
-  wrap.append(createElement('h3', 'tournament-section-title', 'Вся таблиця'));
-  const standings = createElement('div', 'tournament-standings-compact');
+  const standings = createElement('div', 'tournament-standings-list');
   sorted.forEach((team, index) => {
-    const row = createElement('article', `tournament-standing-row${index === 0 ? ' is-leader' : ''}`);
-    row.append(
-      createElement('p', 'tournament-standing-row__title', `#${index + 1} ${toText(team.teamName, toText(team.teamId))}`),
-      createElement('p', 'tournament-standing-row__score', formatPointsLabel(team.points)),
-      createElement('p', 'tournament-statline tournament-statline--muted', `${formatRecordLabel(team, true)} · MMR ${toNumber(team.mmrCurrent) || '—'}`)
+    const card = createElement('article', `tournament-result-card${index === 0 ? ' is-leader' : ''}`);
+    card.append(
+      createElement('p', 'tournament-result-card__title', `#${index + 1} ${toText(team.teamName, toText(team.teamId))}`),
+      createElement('p', 'tournament-result-card__points', formatPointsLabel(team.points)),
+      createElement('p', 'tournament-result-card__line', formatRecordLabel(team)),
+      createElement('p', 'tournament-result-card__line', `MMR ${toNumber(team.mmrCurrent) || '—'}`)
     );
-    standings.append(row);
+    standings.append(card);
   });
   wrap.append(standings);
   node.append(wrap);
@@ -731,67 +673,22 @@ function renderGames(node, games, teamMap) {
   games.forEach((game, index) => {
     const teamA = getTeamName(game?.teamAId, teamMap);
     const teamB = getTeamName(game?.teamBId, teamMap);
-    const winnerLabel = getWinnerLabel(game, teamMap);
-    const scoreLabel = getMatchScoreLabel(game);
-    const mvpLabel = getMvpLabel(game);
+    const scoreLabel = getMatchScoreLabel(game) || getWinnerLabel(game, teamMap);
+    const mvpLabel = getMvpLabel(game) || '—';
     const card = createElement('article', 'tournament-match-log');
-    const triggerId = `tournamentMatch${index + 1}`;
-    const head = createElement('button', 'tournament-match-log__head');
-    head.type = 'button';
-    head.setAttribute('aria-expanded', 'false');
-    head.setAttribute('aria-controls', `${triggerId}Details`);
-
-    const info = createElement('div', 'tournament-match-log__main');
-    info.append(
+    const head = createElement('div', 'tournament-match-log__head');
+    const meta = createElement('div', 'tournament-match-log__meta');
+    meta.append(
       createElement('span', 'tournament-match-log__kicker', `МАТЧ ${toText(game?.gameId, `G${index + 1}`)}`),
-      createElement('strong', '', `${teamA} vs ${teamB}`),
       createElement('small', '', `${toText(game?.mode, 'Режим')} · ${formatTournamentDate(game?.timestamp)}`)
     );
-
-    const result = createElement('span', 'tournament-match-log__score', scoreLabel || winnerLabel);
-    head.append(info, result);
-
-    const details = createElement('div', 'tournament-match-log__body');
-    details.id = `${triggerId}Details`;
-    details.hidden = true;
-    const teamGrid = createElement('div', 'tournament-match-log__teams');
-    const winnerTeamId = String(game?.winnerTeamId || '').trim();
-    [game?.teamAId, game?.teamBId].forEach((teamId) => {
-      const box = createElement('section', `tournament-team-box${winnerTeamId && String(teamId) === winnerTeamId ? ' is-winner' : ''}`);
-      box.append(
-        createElement('strong', '', getTeamName(teamId, teamMap)),
-        createElement('span', '', winnerTeamId && String(teamId) === winnerTeamId ? 'Переможець матчу' : 'Учасник матчу')
-      );
-      teamGrid.append(box);
-    });
-    details.append(teamGrid);
-    if (mvpLabel) {
-      const mvpList = createElement('div', 'tournament-mvp-list');
-      [game?.mvpNick, game?.secondNick, game?.thirdNick]
-        .map((nick) => String(nick || '').trim())
-        .filter(Boolean)
-        .forEach((nick, mvpIndex) => {
-          const mvpItem = createElement('div', `tournament-mvp-item is-mvp${mvpIndex + 1}`);
-          mvpItem.append(createElement('span', '', `MVP ${mvpIndex + 1}`), createElement('strong', '', nick));
-          mvpList.append(mvpItem);
-        });
-      details.append(mvpList);
-    }
-    if (toNumber(game?.teamAMmrDelta) || toNumber(game?.teamBMmrDelta)) {
-      details.append(createElement('p', 'tournament-delta-line', `ΔMMR: ${teamA} ${formatDelta(game?.teamAMmrDelta)} · ${teamB} ${formatDelta(game?.teamBMmrDelta)}`));
-    }
-    head.addEventListener('click', () => {
-      const expanded = head.getAttribute('aria-expanded') === 'true';
-      head.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-      details.hidden = expanded;
-      card.classList.toggle('is-open', !expanded);
-    });
-    card.append(head, details);
-    if (index < 2) {
-      head.setAttribute('aria-expanded', 'true');
-      details.hidden = false;
-      card.classList.add('is-open');
-    }
+    head.append(meta, createElement('strong', 'tournament-match-log__score', scoreLabel));
+    card.append(
+      head,
+      createElement('p', 'tournament-match-log__line', `${teamA} vs ${teamB}`),
+      createElement('p', 'tournament-match-log__line', `MVP: ${mvpLabel}`),
+      createElement('p', 'tournament-match-log__line', `ΔMMR: ${teamA} ${formatDelta(game?.teamAMmrDelta)} · ${teamB} ${formatDelta(game?.teamBMmrDelta)}`)
+    );
     list.append(card);
   });
 
@@ -821,20 +718,12 @@ function renderPlayers(node, players, teamMap) {
   sorted.forEach((player, index) => {
     const row = createElement('article', `tournament-player-rank-card${index < 3 ? ` is-top-${index + 1}` : ''}`);
     const teamName = teamMap.get(String(player?.teamId || '')) || toText(player?.teamId);
-    const head = createElement('div', 'tournament-player-rank-card__head');
-    head.append(createElement('span', '', `#${index + 1}`), createElement('strong', '', toText(player.playerNick, 'Гравець')));
-    const stats = createElement('div', 'tournament-player-rank-card__stats');
-    stats.append(
-      createElement('span', '', `${toNumber(player.games)} гри`),
-      createElement('span', '', `${toNumber(player.wins)} перемоги`),
-      createElement('span', '', `${toNumber(player.mvpCount)} MVP`)
+    row.append(
+      createElement('p', 'tournament-player-rank-card__title', `#${index + 1} ${toText(player.playerNick, 'Гравець')}`),
+      createElement('p', 'tournament-player-rank-card__team', teamName),
+      createElement('p', 'tournament-player-rank-card__line', `${toNumber(player.games)} гри · ${toNumber(player.wins)} перемоги · MVP ${toNumber(player.mvpCount)}`),
+      createElement('p', 'tournament-player-rank-card__line', `Impact ${formatDelta(player.impactPoints)} · MMR ${formatDelta(player.mmrChange)}`)
     );
-    const impact = createElement('div', 'tournament-player-rank-card__impact');
-    impact.append(
-      createElement('strong', '', `Impact ${formatDelta(player.impactPoints)}`),
-      createElement('span', '', `MMR ${formatDelta(player.mmrChange)}`)
-    );
-    row.append(head, createElement('p', 'tournament-player-rank-card__team', teamName), stats, impact);
     list.append(row);
   });
   node.append(list);
@@ -867,11 +756,7 @@ function renderOverview(node, teams, games, players, teamMap) {
 
   const statsCard = createElement('article', 'tournament-insight-card');
   statsCard.append(createElement('h4', '', 'Турнір у цифрах'));
-  statsCard.append(
-    createStatCell('Команд', teams.length),
-    createStatCell('Матчів', games.length),
-    createStatCell('Гравців', players.length)
-  );
+  statsCard.append(createSimpleLine(`Команд: ${teams.length} · Матчів: ${games.length} · Гравців: ${players.length}`));
   if (latestGame) {
     const teamA = teamMap.get(String(latestGame?.teamAId || '')) || toText(latestGame?.teamAId);
     const teamB = teamMap.get(String(latestGame?.teamBId || '')) || toText(latestGame?.teamBId);


### PR DESCRIPTION
### Motivation
- Remove capsule/oval meta UI from the public tournaments v2 UI and replace it with plain text layout to match gameday-style rectangular cards and mobile constraints.
- Ensure tournament DOM contains no capsule elements (`tournament-meta-item`, `px-card` internal capsules, rank/pill/chip badges) and avoid internal bordered rows inside result cards.

### Description
- Updated `v2/pages/tournaments.js` to stop generating capsule/meta items and removed helper functions that created capsule cells (`createStatCell`, `createCountCard`, related meta inline builders); summary now renders as a single text line (`Команд: X · Матчів: Y · Гравців: Z`).
- Rebuilt result rendering to output one outer card per team with only text/flex lines and a single outer border (`tournament-result-card`), removing internal bordered rows/podium/leader capsule structures.
- Rebuilt matches rendering into gameday-like match cards (header/meta, score, teams line, MVP, ΔMMR) with no expandable capsule bodies or team capsule boxes.
- Rebuilt players rendering into individual rating cards with compact text lines (place + nick, team, games/wins/MVP, Impact + MMR) and no per-line border wrappers.
- Updated `v2/assets/css/main.css` to neutralize legacy capsule styles inside tournaments scope by adding a hard rule: `.tournaments-page-v2 .tournament-meta-item { display: none !important; }` and removed/neutralized capsule-structure styles while keeping outer card border/radius rules and text styling.
- No changes were made to GAS, balance2, save-flow, dataHub, router, or rating formula; all changes are UI-only in the two files above.

### Testing
- Syntax check: `node --check v2/pages/tournaments.js` — succeeded.
- Syntax check: `node --check v2/pages/home.js` — succeeded.
- Forbidden-token grep check: `rg -n "createMetaItem|tournament-meta-item|t-rank-badge|pill|chip|px-card" v2/pages/tournaments.js || true` — no matches found.
- Commit recorded with message `hard delete tournament meta capsules in v2 UI` and files changed: `v2/pages/tournaments.js`, `v2/assets/css/main.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee6a25208883219cf5e82f458e6d3e)