### PR TITLE
HARD UI REBUILD: simplify tournaments to scoreboard-first gameday layout

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -8754,83 +8754,108 @@ body.theme-game :is(
   .home-tournaments-teaser__row { align-items:flex-start; }
 }
 
-/* Tournament page uses gameday-style rectangular cards. No pill/meta capsules. */
+/* Tournament UI: no capsules, no inner bordered stat pills */
+
+.tournaments-page-v2 .tournament-meta-item,
+.tournaments-page-v2 .t-rank-badge,
+.tournaments-page-v2 .chip,
+.tournaments-page-v2 .pill {
+  display: none !important;
+}
+
 .tournaments-page-v2 {
   overflow-x: hidden;
   padding-bottom: calc(104px + env(safe-area-inset-bottom));
 }
 
-.tournaments-page-v2 .tournament-panel,
-.tournaments-page-v2 .tournament-selected,
-.tournaments-page-v2 .tournament-card,
-.tournaments-page-v2 .tournament-match-log,
-.tournaments-page-v2 .tournament-player-rank-card,
-.tournaments-page-v2 .tournament-insight-card,
-.tournaments-page-v2 .tournament-empty-state {
+.tournaments-page-v2 .tournament-event *,
+.tournaments-page-v2 .tournament-scoreboard *,
+.tournaments-page-v2 .tournament-table-row *,
+.tournaments-page-v2 .tournament-match-log *,
+.tournaments-page-v2 .tournament-player-row * {
+  border-radius: 0 !important;
+}
+
+.tournament-event,
+.tournament-scoreboard,
+.tournament-scoreboard__leader,
+.tournament-scoreboard__latest,
+.tournament-table-row,
+.tournament-match-log,
+.tournament-player-row {
+  border-radius: var(--v2-radius-md) !important;
+}
+
+.tournament-event,
+.tournament-scoreboard,
+.tournament-table-row,
+.tournament-match-log,
+.tournament-player-row,
+.tournament-overview-card,
+.tournament-empty-state,
+.tournament-card {
+  border: 1px solid rgba(255,255,255,.14);
+  background: rgba(9,15,27,.78);
+}
+
+.tournament-event,
+.tournament-scoreboard,
+.tournament-overview-card,
+.tournament-empty-state { padding: 12px; }
+
+.tournament-event__kicker { margin: 0; font-size: 11px; letter-spacing: .08em; color: var(--muted); }
+.tournament-event__title { margin: 4px 0 0; font-size: clamp(1.15rem, 4.8vw, 1.6rem); }
+.tournament-event__meta,
+.tournament-event__summary { margin: 8px 0 0; color: #cfe0f8; font-size: 13px; }
+
+.tournament-scoreboard { display: grid; gap: 10px; }
+.tournament-scoreboard__leader,
+.tournament-scoreboard__latest { display: grid; gap: 4px; padding: 10px; border: 1px solid rgba(255,255,255,.12); background: rgba(14,25,43,.66); }
+.tournament-scoreboard__top { display: grid; gap: 4px; color: #d5e4f8; font-size: 14px; }
+.tournament-scoreboard span { color: var(--muted); font-size: 12px; }
+.tournament-scoreboard strong { color: #edf5ff; }
+.tournament-scoreboard b { color: #9fe0ff; font-size: 15px; }
+.tournament-scoreboard small { color: #c8d9f0; font-size: 12px; }
+
+.tournament-tabs { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; }
+.tournament-tab {
+  border: 1px solid rgba(255,255,255,.18);
+  background: rgba(255,255,255,.05);
+  color: #e8f2ff;
   border-radius: var(--v2-radius-sm) !important;
-  max-width: 100%;
-  min-width: 0;
-  box-sizing: border-box;
 }
+.tournament-tab.is-active { background: rgba(49,208,255,.2); border-color: rgba(49,208,255,.5); }
 
-.tournaments-page-v2 .tournament-meta-item {
-  display: none !important;
-}
+.tournament-table-list,
+.tournament-match-list,
+.tournament-player-list { display: grid; grid-template-columns: 1fr; gap: 10px; }
 
-.tournament-selected__kicker { margin: 0 0 4px; font-size: 11px; letter-spacing: .08em; color: var(--muted); }
-.tournament-selected__title { margin: 0; }
-.tournament-selected__sub { margin: 6px 0 0; color: #c8d7ee; font-size: 13px; }
-.tournament-selected__summary { margin: 10px 0 0; color: #dce8f9; font-size: 14px; }
+.tournament-table-row,
+.tournament-match-log,
+.tournament-player-row { padding: 10px; }
+.tournament-table-row__top,
+.tournament-match-log__top,
+.tournament-player-row__top { display: flex; align-items: center; gap: 8px; justify-content: space-between; border: 0; background: transparent; }
+.tournament-table-row__top strong { flex: 1; min-width: 0; }
+.tournament-table-row .points { font-weight: 700; color: #9fe0ff; }
+.tournament-table-row__meta,
+.tournament-player-row__meta,
+.tournament-match-log__line { margin: 6px 0 0; color: #d4e4f8; font-size: 13px; border: 0; background: transparent; }
+.tournament-table-row.is-leader { border-color: rgba(124,255,114,.44); }
 
-.tournament-statline-group { display: grid; gap: 6px; }
-.tournament-simple-line { margin: 0; color: #dce8f9; font-size: 13px; }
-
-.tournament-standing-list,
-.tournament-games-list,
-.tournament-players-list { display: grid; grid-template-columns: 1fr; gap: 10px; }
-
-.tournament-result-view { display: grid; gap: 10px; width: 100%; max-width: 100%; }
-.tournament-section-title { margin: 2px 0 0; font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: #9eb4d3; }
-.tournament-standings-list { display: grid; gap: 10px; }
-.tournament-result-card {
-  border: 1px solid rgba(255,255,255,.12);
-  border-radius: 6px;
-  background: rgba(8,14,24,.66);
-  padding: 12px;
-  display: grid;
-  gap: 4px;
-}
-.tournament-result-card.is-leader { border-color: rgba(124,255,114,.5); }
-.tournament-result-card__title,
-.tournament-result-card__points,
-.tournament-result-card__line { margin: 0; }
-.tournament-result-card__title { font-weight: 700; color: #e3efff; }
-.tournament-result-card__points { color: #c8e0ff; font-size: 15px; font-weight: 700; }
-.tournament-result-card__line { color: #d8e6f9; font-size: 13px; line-height: 1.3; }
-
-.tournament-match-log { border: 1px solid rgba(255,255,255,.14); background: rgba(9,15,27,.8); overflow: hidden; }
-.tournament-match-log__head { padding: 10px; display: flex; justify-content: space-between; gap: 10px; align-items: center; }
-.tournament-match-log__meta { display: grid; gap: 3px; }
-.tournament-match-log__kicker { font-size: 11px; color: var(--muted); letter-spacing: .06em; }
-.tournament-match-log small { color: var(--muted); font-size: 12px; }
-.tournament-match-log__score { color: #9ddfff; font-weight: 700; white-space: nowrap; }
-.tournament-match-log__line { margin: 0; padding: 0 10px 10px; color: #d9e7fa; font-size: 13px; }
-
-.tournament-player-rank-card { border: 1px solid rgba(255,255,255,.12); background: rgba(9,15,27,.76); padding: 10px; display: grid; gap: 7px; }
-.tournament-player-rank-card__title { margin: 0; font-weight: 700; color: #edf5ff; }
-.tournament-player-rank-card__team { margin: 0; color: #b7c8e2; font-size: 13px; }
-.tournament-player-rank-card__line { margin: 0; color: #dce8f9; font-size: 13px; }
+.tournament-player-row__identity,
+.tournament-player-row__impact { display: grid; gap: 2px; }
+.tournament-player-row__impact { text-align: right; }
+.tournament-player-row__impact b { color: #9fe0ff; }
 
 .tournament-insight-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 10px; }
-.tournament-insight-card { border: 1px solid rgba(255,255,255,.12); background: rgba(9,15,27,.76); padding: 10px; }
-.tournament-insight-card h4 { margin: 0 0 8px; }
+.tournament-overview-card h4 { margin: 0 0 8px; }
 
-.tournament-empty-state { border: 1px solid rgba(255,255,255,.12); background: rgba(9,15,27,.76); padding: 10px; }
-.tournament-status__title { margin: 0; }
-.tournament-status__text { margin: 6px 0 0; color: #c8d7ee; }
+.home-tournaments-teaser__left { min-width: 0; }
+.home-tournaments-teaser__stats { display: block; color: #b4c3da; font-size: .72rem; margin-top: .12rem; }
+.home-tournaments-teaser__open { border: 1px solid rgba(49,208,255,.44); background: rgba(20,38,63,.65); font-size: .72rem; padding: .2rem .4rem; color: #9ddfff; white-space: nowrap; border-radius: var(--v2-radius-sm); }
 
 @media (max-width: 640px) {
-  .tournament-tabs { display: flex; overflow-x: auto; gap: 6px; }
-  .tournament-tab-content { width: 100%; max-width: 100%; }
-  .tournament-result-view { gap: 10px; }
+  .tournament-tabs { overflow-x: auto; display: flex; }
+  .tournament-tab { flex: 1 0 calc(25% - 6px); min-width: 86px; }
 }

--- a/v2/pages/home.js
+++ b/v2/pages/home.js
@@ -169,7 +169,7 @@ function renderHomeTournamentsCard(items = [], status = 'empty') {
       <div class="home-tournaments-teaser__left">
         <strong>${escapeHtml(item?.name || item?.tournamentId || 'Турнір')}</strong>
         <span class="home-tournaments-teaser__meta">${formatHomeTournamentMeta(item)}</span>
-        <span class="home-tournaments-teaser__stats">${Number(item?.teamsCount || 0)} команд · ${Number(item?.gamesCount || 0)} матчів · ${Number(item?.playersCount || 0)} гравців</span>
+        <span class="home-tournaments-teaser__stats">${Number(item?.teamsCount || 0)} команд · ${Number(item?.gamesCount || 0)} матчів</span>
       </div>
       <span class="home-tournaments-teaser__open">Відкрити</span>
     </a>`

--- a/v2/pages/tournaments.js
+++ b/v2/pages/tournaments.js
@@ -555,33 +555,30 @@ function renderTournamentDashboard(node, data) {
   clear(node);
 
   const dashboardCard = createElement('section', 'tournament-panel tournament-dashboard__shell');
-  const head = createElement('section', 'tournament-selected tournament-dashboard__head');
-  const top = createElement('div', 'tournament-selected__top');
-  const topInfo = createElement('div', '');
-  topInfo.append(
-    createElement('p', 'tournament-selected__kicker', 'ТУРНІР'),
-    createElement('h2', 'tournament-selected__title', title),
-    createElement('p', 'tournament-selected__sub', `${getTournamentFormatLabel(tournament, teams, players)} · ${statusLabel(tournament?.status || 'ACTIVE')} · ${formatTournamentDate(tournament?.dateStart || tournament?.startDate || tournament?.createdAt)}`)
+  const head = createElement('section', 'tournament-event');
+  const headWrap = createElement('header', 'tournament-event__header');
+  headWrap.append(
+    createElement('p', 'tournament-event__kicker', 'ТУРНІР'),
+    createElement('h1', 'tournament-event__title', title),
+    createElement('p', 'tournament-event__meta', `${getTournamentFormatLabel(tournament, teams, players)} · ${statusLabel(tournament?.status || 'ACTIVE')} · ${formatTournamentDate(tournament?.dateStart || tournament?.startDate || tournament?.createdAt)}`),
+    createElement('p', 'tournament-event__summary', `${teams.length} команд · ${games.length} матчів · ${players.length} гравців`)
   );
-  top.append(topInfo);
-  head.append(top);
+  head.append(headWrap);
 
-  const summaryStrip = createElement('p', 'tournament-selected__summary');
-  summaryStrip.textContent = `Команд: ${teams.length} · Матчів: ${games.length} · Гравців: ${players.length}`;
-  head.append(summaryStrip);
+  const scoreboard = renderScoreboardPreview(teams, games, players, teamMap);
 
   const tabsWrap = createElement('div', 'tournament-tabs');
   const contentWrap = createElement('div', 'tournament-tab-content');
 
   const tabs = [
-    { key: 'result', label: 'Результат' },
+    { key: 'table', label: 'Таблиця' },
     { key: 'games', label: 'Матчі' },
     { key: 'players', label: 'Гравці' },
     { key: 'overview', label: 'Огляд' }
   ];
 
   const renderers = {
-    result: () => renderTeamsTable(contentWrap, teams),
+    table: () => renderTeamsTable(contentWrap, teams),
     overview: () => renderOverview(contentWrap, teams, games, players, teamMap),
     games: () => renderGames(contentWrap, games, teamMap),
     players: () => renderPlayers(contentWrap, players, teamMap)
@@ -598,9 +595,52 @@ function renderTournamentDashboard(node, data) {
     tabsWrap.append(btn);
   });
 
-  dashboardCard.append(head, tabsWrap, contentWrap);
+  dashboardCard.append(head, scoreboard, tabsWrap, contentWrap);
   node.append(dashboardCard);
-  renderers.result();
+  renderers.table();
+}
+
+function renderScoreboardPreview(teams, games, players, teamMap) {
+  const board = createElement('section', 'tournament-scoreboard');
+  const sortedTeams = [...teams].sort((a, b) => toNumber(b.points) - toNumber(a.points) || toNumber(b.wins) - toNumber(a.wins));
+  const leader = sortedTeams[0] || null;
+  const latestGame = [...games].sort((a, b) => Date.parse(b?.timestamp || 0) - Date.parse(a?.timestamp || 0))[0] || null;
+
+  const leaderBlock = createElement('div', 'tournament-scoreboard__leader');
+  leaderBlock.append(createElement('span', '', 'Лідер турніру'));
+  if (leader) {
+    leaderBlock.append(
+      createElement('strong', '', toText(leader?.teamName, toText(leader?.teamId))),
+      createElement('b', '', formatPointsLabel(leader?.points)),
+      createElement('small', '', formatRecordLabel(leader))
+    );
+  } else {
+    leaderBlock.append(createElement('strong', '', 'Команди ще формуються'));
+  }
+
+  const topBlock = createElement('div', 'tournament-scoreboard__top');
+  const second = sortedTeams[1] || null;
+  const third = sortedTeams[2] || null;
+  if (second) topBlock.append(createElement('div', '', `#2 ${toText(second?.teamName, toText(second?.teamId))} — ${formatPointsLabel(second?.points)}`));
+  if (third) topBlock.append(createElement('div', '', `#3 ${toText(third?.teamName, toText(third?.teamId))} — ${formatPointsLabel(third?.points)}`));
+  if (!second && !third) topBlock.append(createElement('div', '', 'Топ-3 буде після старту матчів'));
+
+  const latestBlock = createElement('div', 'tournament-scoreboard__latest');
+  latestBlock.append(createElement('span', '', 'Останній матч'));
+  if (latestGame) {
+    const teamA = teamMap.get(String(latestGame?.teamAId || '')) || toText(latestGame?.teamAId);
+    const teamB = teamMap.get(String(latestGame?.teamBId || '')) || toText(latestGame?.teamBId);
+    const score = getMatchScoreLabel(latestGame) || '—';
+    latestBlock.append(
+      createElement('strong', '', `${teamA} ${score.replace(':', ' : ')} ${teamB}`),
+      createElement('small', '', `MVP: ${getMvpLabel(latestGame) || '—'}`)
+    );
+  } else {
+    latestBlock.append(createElement('strong', '', 'Матчі з’являться після першого результату'));
+  }
+
+  board.append(leaderBlock, topBlock, latestBlock);
+  return board;
 }
 
 function pluralizeUa(value, one, few, many) {
@@ -647,16 +687,17 @@ function renderTeamsTable(node, teams) {
   });
 
   const wrap = createElement('section', 'tournament-result-view');
-  const standings = createElement('div', 'tournament-standings-list');
+  const standings = createElement('div', 'tournament-table-list');
   sorted.forEach((team, index) => {
-    const card = createElement('article', `tournament-result-card${index === 0 ? ' is-leader' : ''}`);
-    card.append(
-      createElement('p', 'tournament-result-card__title', `#${index + 1} ${toText(team.teamName, toText(team.teamId))}`),
-      createElement('p', 'tournament-result-card__points', formatPointsLabel(team.points)),
-      createElement('p', 'tournament-result-card__line', formatRecordLabel(team)),
-      createElement('p', 'tournament-result-card__line', `MMR ${toNumber(team.mmrCurrent) || '—'}`)
+    const row = createElement('article', `tournament-table-row${index === 0 ? ' is-leader' : ''}`);
+    const topLine = createElement('div', 'tournament-table-row__top');
+    topLine.append(
+      createElement('span', 'place', `#${index + 1}`),
+      createElement('strong', '', toText(team.teamName, toText(team.teamId))),
+      createElement('span', 'points', String(toNumber(team.points)))
     );
-    standings.append(card);
+    row.append(topLine, createElement('p', 'tournament-table-row__meta', `${formatRecordLabel(team, true)} · MMR ${toNumber(team.mmrCurrent) || '—'}`));
+    standings.append(row);
   });
   wrap.append(standings);
   node.append(wrap);
@@ -669,23 +710,22 @@ function renderGames(node, games, teamMap) {
     return;
   }
 
-  const list = createElement('div', 'tournament-games-list');
+  const list = createElement('div', 'tournament-match-list');
   games.forEach((game, index) => {
     const teamA = getTeamName(game?.teamAId, teamMap);
     const teamB = getTeamName(game?.teamBId, teamMap);
-    const scoreLabel = getMatchScoreLabel(game) || getWinnerLabel(game, teamMap);
+    const scoreLabel = getMatchScoreLabel(game) || '—';
     const mvpLabel = getMvpLabel(game) || '—';
     const card = createElement('article', 'tournament-match-log');
-    const head = createElement('div', 'tournament-match-log__head');
-    const meta = createElement('div', 'tournament-match-log__meta');
-    meta.append(
-      createElement('span', 'tournament-match-log__kicker', `МАТЧ ${toText(game?.gameId, `G${index + 1}`)}`),
-      createElement('small', '', `${toText(game?.mode, 'Режим')} · ${formatTournamentDate(game?.timestamp)}`)
+    const head = createElement('div', 'tournament-match-log__top');
+    head.append(
+      createElement('span', '', `Матч ${toText(game?.gameId, `G${index + 1}`)}`),
+      createElement('strong', '', `${teamA} vs ${teamB}`),
+      createElement('b', '', scoreLabel.replace(':', ' : '))
     );
-    head.append(meta, createElement('strong', 'tournament-match-log__score', scoreLabel));
     card.append(
       head,
-      createElement('p', 'tournament-match-log__line', `${teamA} vs ${teamB}`),
+      createElement('p', 'tournament-match-log__line', `${toText(game?.mode, 'Режим')} · ${formatTournamentDate(game?.timestamp)}`),
       createElement('p', 'tournament-match-log__line', `MVP: ${mvpLabel}`),
       createElement('p', 'tournament-match-log__line', `ΔMMR: ${teamA} ${formatDelta(game?.teamAMmrDelta)} · ${teamB} ${formatDelta(game?.teamBMmrDelta)}`)
     );
@@ -714,16 +754,17 @@ function renderPlayers(node, players, teamMap) {
     return String(a?.playerNick || '').localeCompare(String(b?.playerNick || ''), 'uk');
   });
 
-  const list = createElement('div', 'tournament-players-list');
+  const list = createElement('div', 'tournament-player-list');
   sorted.forEach((player, index) => {
-    const row = createElement('article', `tournament-player-rank-card${index < 3 ? ` is-top-${index + 1}` : ''}`);
+    const row = createElement('article', `tournament-player-row${index === 0 ? ' is-leader' : ''}`);
     const teamName = teamMap.get(String(player?.teamId || '')) || toText(player?.teamId);
-    row.append(
-      createElement('p', 'tournament-player-rank-card__title', `#${index + 1} ${toText(player.playerNick, 'Гравець')}`),
-      createElement('p', 'tournament-player-rank-card__team', teamName),
-      createElement('p', 'tournament-player-rank-card__line', `${toNumber(player.games)} гри · ${toNumber(player.wins)} перемоги · MVP ${toNumber(player.mvpCount)}`),
-      createElement('p', 'tournament-player-rank-card__line', `Impact ${formatDelta(player.impactPoints)} · MMR ${formatDelta(player.mmrChange)}`)
-    );
+    const topLine = createElement('div', 'tournament-player-row__top');
+    const identity = createElement('div', 'tournament-player-row__identity');
+    identity.append(createElement('strong', '', toText(player.playerNick, 'Гравець')), createElement('small', '', teamName));
+    const impact = createElement('div', 'tournament-player-row__impact');
+    impact.append(createElement('b', '', formatDelta(player.impactPoints)), createElement('small', '', 'Impact'));
+    topLine.append(createElement('span', '', `#${index + 1}`), identity, impact);
+    row.append(topLine, createElement('p', 'tournament-player-row__meta', `${toNumber(player.games)} гри · ${toNumber(player.wins)} перемоги · ${toNumber(player.mvpCount)} MVP · MMR ${formatDelta(player.mmrChange)}`));
     list.append(row);
   });
   node.append(list);
@@ -738,7 +779,7 @@ function renderOverview(node, teams, games, players, teamMap) {
 
   const topPlayers = [...players].sort((a, b) => toNumber(b.mvpCount) - toNumber(a.mvpCount) || toNumber(b.impactPoints) - toNumber(a.impactPoints));
   const mvpLeader = topPlayers[0] || null;
-  const leaderCard = createElement('article', 'tournament-insight-card');
+  const leaderCard = createElement('article', 'tournament-overview-card');
   leaderCard.append(createElement('h4', '', 'Лідер турніру'));
   if (leader) {
     leaderCard.append(createSimpleLine(`${toText(leader.teamName, toText(leader.teamId))}`), createSimpleLine(`${toNumber(leader.points)} очок · ${toNumber(leader.wins)} перемог`));
@@ -746,7 +787,7 @@ function renderOverview(node, teams, games, players, teamMap) {
     leaderCard.append(createSimpleLine('Таблиця ще формується.'));
   }
 
-  const mvpCard = createElement('article', 'tournament-insight-card');
+  const mvpCard = createElement('article', 'tournament-overview-card');
   mvpCard.append(createElement('h4', '', 'MVP турніру'));
   if (mvpLeader) {
     mvpCard.append(createSimpleLine(toText(mvpLeader.playerNick, 'Гравець')), createSimpleLine(`${toNumber(mvpLeader.mvpCount)} MVP · Impact ${formatDelta(mvpLeader.impactPoints)}`));
@@ -754,7 +795,7 @@ function renderOverview(node, teams, games, players, teamMap) {
     mvpCard.append(createSimpleLine('Індивідуальний рейтинг ще формується.'));
   }
 
-  const statsCard = createElement('article', 'tournament-insight-card');
+  const statsCard = createElement('article', 'tournament-overview-card');
   statsCard.append(createElement('h4', '', 'Турнір у цифрах'));
   statsCard.append(createSimpleLine(`Команд: ${teams.length} · Матчів: ${games.length} · Гравців: ${players.length}`));
   if (latestGame) {


### PR DESCRIPTION
### Motivation
- The tournament UI used capsule/pill/meta-card patterns and was cluttered, hard to read on mobile, and not gameday-like, so the selected tournament view needed to be rebuilt to surface leader, top‑3 and latest match immediately. 
- The goal was a compact, mobile-first, scoreboard-first layout with no capsule/pill UI and minimal framed stat items.

### Description
- Replaced the selected tournament header and render flow in `v2/pages/tournaments.js` with a simple `tournament-event` header and a scoreboard preview (`tournament-scoreboard`) shown immediately under the header.  
- Converted tabs to a rectangular 4‑button layout with `Таблиця` as the default first tab and rewired renderers to `table`, `games`, `players`, `overview`.  
- Rebuilt lists: compact sports ranking rows (`tournament-table-list` / `tournament-table-row`), gameday-style match logs (`tournament-match-list` / `tournament-match-log`), and individual player ranking rows (`tournament-player-list` / `tournament-player-row`) with the required sorting logic preserved.  
- Removed use of capsule/meta components in the tournaments render path and added a CSS “hard guard” in `v2/assets/css/main.css` that hides `tournament-meta-item`, `t-rank-badge`, `chip`, `pill`, forces inner rows to zero radius, and applies mobile layout rules; updated `v2/pages/home.js` teaser to match the simplified style.

### Testing
- Ran `node --check v2/pages/tournaments.js` and `node --check v2/pages/home.js`, both completed without errors.  
- Verified absence of capsule generators in tournament render with ripgrep: `rg "createMetaItem|tournament-meta-item|t-rank-badge|pill|chip|px-card" v2/pages/tournaments.js` returned no matches.  
- Notes: no backend / save-flow / dataHub / router / profile/gameday/rating/Google‑Sheet schema changes were made and a 440px screenshot was not produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee6e83a2fc83219b32976cb24199f2)