### PR TITLE
Expandable team rosters in tournaments 'Table' tab

### DIFF
--- a/v2/assets/css/main.css
+++ b/v2/assets/css/main.css
@@ -8842,6 +8842,48 @@ body.theme-game :is(
 .tournament-player-row__meta,
 .tournament-match-log__line { margin: 6px 0 0; color: #d4e4f8; font-size: 13px; border: 0; background: transparent; }
 .tournament-table-row.is-leader { border-color: rgba(124,255,114,.44); }
+.tournament-standings-main {
+  width: 100%;
+  padding: 0;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.tournament-team-toggle {
+  color: #9fe0ff;
+  font-weight: 700;
+  min-width: 1ch;
+  text-align: center;
+}
+.tournament-team-roster {
+  display: none;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255,255,255,.12);
+}
+.tournament-standings-row.is-expanded { border-color: rgba(49,208,255,.42); background: rgba(14,26,45,.82); }
+.tournament-standings-row.is-expanded .tournament-team-roster { display: block; }
+.tournament-team-roster__head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: #d7e6f9;
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+.tournament-team-roster__list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 3px;
+  color: #edf5ff;
+  font-size: 13px;
+}
+.tournament-team-roster__empty {
+  margin: 0;
+  color: #b8cbe2;
+  font-size: 12px;
+}
 
 .tournament-player-row__identity,
 .tournament-player-row__impact { display: grid; gap: 2px; }

--- a/v2/pages/tournaments.js
+++ b/v2/pages/tournaments.js
@@ -28,20 +28,28 @@ function isEmptyStatus(value = '') {
   return String(value || '').trim() === '';
 }
 
-function parsePlayersList(value) {
+function parseTeamPlayers(value) {
   if (Array.isArray(value)) return value.map((item) => String(item || '').trim()).filter(Boolean);
-  if (typeof value !== 'string') return [];
+  if (value == null) return [];
+  if (typeof value !== 'string') return [String(value).trim()].filter(Boolean);
   const raw = value.trim();
   if (!raw) return [];
   if (raw.startsWith('[') || raw.startsWith('{')) {
     try {
       const parsed = JSON.parse(raw);
       if (Array.isArray(parsed)) return parsed.map((item) => String(item || '').trim()).filter(Boolean);
+      if (parsed && typeof parsed === 'object') {
+        const nested = Array.isArray(parsed.players) ? parsed.players : [];
+        if (nested.length) return nested.map((item) => String(item || '').trim()).filter(Boolean);
+      }
     } catch {
       // noop
     }
   }
-  return raw.split(',').map((item) => item.trim()).filter(Boolean);
+  return raw
+    .split(/[;,]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
 }
 
 function normalizeObjectRow(row = {}) {
@@ -150,7 +158,7 @@ function normalizeTournamentSheets({ tournamentsRows, teamsRows, gamesRows, play
       draws: toNumber(getCell(row, 'draws')),
       points: toNumber(getCell(row, 'points')),
       rank: toText(getCell(row, 'rank'), ''),
-      playersList: parsePlayersList(getCell(row, 'players'))
+      playersList: parseTeamPlayers(getCell(row, 'players'))
     });
   });
 
@@ -551,6 +559,7 @@ function renderTournamentDashboard(node, data) {
   const tournament = data?.tournament || data || {};
   const title = toText(tournament?.name, toText(tournament?.tournamentId, 'Турнір'));
   const teamMap = new Map(teams.map((team) => [String(team?.teamId || ''), toText(team?.teamName, String(team?.teamId || '—'))]));
+  const expandedTeams = new Set();
 
   clear(node);
 
@@ -578,7 +587,7 @@ function renderTournamentDashboard(node, data) {
   ];
 
   const renderers = {
-    table: () => renderTeamsTable(contentWrap, teams),
+    table: () => renderTeamsTable(contentWrap, teams, expandedTeams),
     overview: () => renderOverview(contentWrap, teams, games, players, teamMap),
     games: () => renderGames(contentWrap, games, teamMap),
     players: () => renderPlayers(contentWrap, players, teamMap)
@@ -669,7 +678,7 @@ function formatRecordLabel(record = {}, compact = false) {
   ].join(' · ');
 }
 
-function renderTeamsTable(node, teams) {
+function renderTeamsTable(node, teams, expandedTeams = new Set()) {
   clear(node);
   if (!teams.length) {
     node.append(stateCard('Команди ще формуються', 'Після збереження команд тут з’явиться результат турніру.'));
@@ -689,14 +698,56 @@ function renderTeamsTable(node, teams) {
   const wrap = createElement('section', 'tournament-result-view');
   const standings = createElement('div', 'tournament-table-list');
   sorted.forEach((team, index) => {
+    const teamKey = String(team?.teamId || team?.teamName || `team-${index}`);
+    const isExpanded = expandedTeams.has(teamKey);
     const row = createElement('article', `tournament-table-row${index === 0 ? ' is-leader' : ''}`);
-    const topLine = createElement('div', 'tournament-table-row__top');
+    row.classList.add('tournament-standings-row');
+    row.classList.toggle('is-expanded', isExpanded);
+
+    const topLine = createElement('button', 'tournament-table-row__top tournament-standings-main');
+    topLine.type = 'button';
+    topLine.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
     topLine.append(
       createElement('span', 'place', `#${index + 1}`),
       createElement('strong', '', toText(team.teamName, toText(team.teamId))),
-      createElement('span', 'points', String(toNumber(team.points)))
+      createElement('span', 'points', String(toNumber(team.points))),
+      createElement('span', 'tournament-team-toggle', isExpanded ? '−' : '+')
     );
-    row.append(topLine, createElement('p', 'tournament-table-row__meta', `${formatRecordLabel(team, true)} · MMR ${toNumber(team.mmrCurrent) || '—'}`));
+
+    const players = parseTeamPlayers(team?.playersList?.length ? team.playersList : team?.players);
+    const roster = createElement('div', 'tournament-team-roster');
+    const rosterHead = createElement('div', 'tournament-team-roster__head');
+    const playersCount = players.length;
+    rosterHead.append(
+      createElement('span', '', 'Склад'),
+      createElement('span', '', `${playersCount} ${pluralizeUa(playersCount, 'гравець', 'гравці', 'гравців')}`)
+    );
+    roster.append(rosterHead);
+
+    if (playersCount) {
+      const rosterList = createElement('ul', 'tournament-team-roster__list');
+      players.forEach((player) => {
+        rosterList.append(createElement('li', '', player));
+      });
+      roster.append(rosterList);
+    } else {
+      roster.append(createElement('p', 'tournament-team-roster__empty', 'Склад команди ще не збережено'));
+    }
+
+    topLine.addEventListener('click', () => {
+      if (expandedTeams.has(teamKey)) expandedTeams.delete(teamKey);
+      else expandedTeams.add(teamKey);
+      row.classList.toggle('is-expanded', expandedTeams.has(teamKey));
+      topLine.setAttribute('aria-expanded', expandedTeams.has(teamKey) ? 'true' : 'false');
+      const toggle = topLine.querySelector('.tournament-team-toggle');
+      if (toggle) toggle.textContent = expandedTeams.has(teamKey) ? '−' : '+';
+    });
+
+    row.append(
+      topLine,
+      createElement('p', 'tournament-table-row__meta', `${formatRecordLabel(team, true)} · MMR ${toNumber(team.mmrCurrent) || '—'}`),
+      roster
+    );
     standings.append(row);
   });
   wrap.append(standings);


### PR DESCRIPTION
### Motivation
- Users need to see team compositions directly from the `Таблиця` (Table) view without changing API or sheet structure.
- Provide a lightweight, accessible expand/collapse UI per team to reveal players while keeping the dashboard compact and mobile-friendly.

### Description
- Add `parseTeamPlayers(value)` helper to normalize `team.players` from arrays, JSON-like strings (including objects with `players`), comma- or semicolon-separated strings, `null` and other edge cases, returning an array of cleaned player names.
- Integrate parsed roster into data normalization by replacing `playersList: parsePlayersList(...)` with `playersList: parseTeamPlayers(...)` in tournament teams processing.
- Update teams table renderer: each team row header is now a full-width clickable `button` with `aria-expanded` and a `+ / −` toggle, and an inline `tournament-team-roster` block shows a compact list, a `Склад` heading and localized player count or the fallback `Склад команди ще не збережено` when empty; state of expanded rows is kept in a `Set` passed to `renderTeamsTable` so multiple teams can be open simultaneously.
- Add compact CSS rules in `v2/assets/css/main.css` for `.tournament-standings-main`, `.tournament-team-toggle`, `.tournament-team-roster`, `.tournament-standings-row.is-expanded`, and roster sub-elements, preserving the dashboard look and avoiding pill/oval styles.
- No unsafe `innerHTML` usage was introduced; all player names are inserted via text nodes (`textContent`) so output is escaped by default.
- Files changed: `v2/pages/tournaments.js`, `v2/assets/css/main.css`; APIs, Google Sheets structure and forbidden files/directories were not modified.

### Testing
- Ran `node --check v2/pages/tournaments.js` which completed successfully.
- Ran build command `npm run build:summer2025-og` which completed successfully producing the preview image.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef60ca28e08321b0dcb3e8df050e9c)