### PR TITLE
hotfix(balance2): restore primary autobalance action and N-team balancing

### DIFF
--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -986,7 +986,7 @@ async function init() {
       const selected = state.playersState.selected.length;
       const teamCount = state.teamsState.teamCount;
       if (selected < teamCount) {
-        setStatus({ state: 'error', text: `Недостатньо гравців для ${teamCount} команд. Мінімум: ${teamCount}.`, retryVisible: false });
+        setStatus({ state: 'error', text: 'Недостатньо гравців для обраної кількості команд', retryVisible: false });
         renderAndSync();
         return;
       }

--- a/v2/scripts/balance2/balance.js
+++ b/v2/scripts/balance2/balance.js
@@ -1,5 +1,5 @@
 function sum(arr) {
-  return arr.reduce((s, p) => s + (Number(p.pts) || 0), 0);
+  return arr.reduce((s, p) => s + (Number(p.pts ?? p.points) || 0), 0);
 }
 
 export function autoBalance2(players) {
@@ -35,9 +35,9 @@ export function autoBalance2(players) {
 }
 
 export function balanceIntoNTeams(players, n) {
-  const teamCount = Math.min(4, Math.max(2, Number(n) || 2));
-  const sorted = [...players].sort((a, b) => ((b.pts || 0) - (a.pts || 0)) || a.nick.localeCompare(b.nick, 'uk'));
-  const teams = { team1: [], team2: [], team3: [], team4: [] };
+  const teamCount = Math.min(6, Math.max(2, Number(n) || 2));
+  const sorted = [...players].sort((a, b) => ((Number(b.pts ?? b.points) || 0) - (Number(a.pts ?? a.points) || 0)) || a.nick.localeCompare(b.nick, 'uk'));
+  const teams = { team1: [], team2: [], team3: [], team4: [], team5: [], team6: [] };
   const targets = Array.from({ length: teamCount }, (_, i) => Math.floor(players.length / teamCount) + (i < players.length % teamCount ? 1 : 0));
 
   for (const player of sorted) {

--- a/v2/scripts/balance2/ui.js
+++ b/v2/scripts/balance2/ui.js
@@ -818,7 +818,8 @@ export function bindUiEvents(handlers) {
     const penaltiesToggle = e.target.closest('[data-toggle-penalties]');
     const matchMode = e.target.closest('[data-match-mode]')?.dataset.matchMode;
     const balanceMode = e.target.closest('[data-balance-mode]')?.dataset.balanceMode;
-    const balancePrimary = e.target.closest('[data-balance-primary]')?.dataset.balancePrimary;
+    const balancePrimaryBtn = e.target.closest('[data-role="balance-primary-action"]');
+    const balancePrimary = balancePrimaryBtn?.dataset.balancePrimary;
     const eventMode = e.target.closest('[data-event-mode]')?.dataset.eventMode;
     const createTournament = e.target.closest('[data-tournament-create]');
     const saveTeams = e.target.closest('[data-tournament-save-teams]');
@@ -872,10 +873,11 @@ export function bindUiEvents(handlers) {
     if (penaltiesToggle) handlers.onTogglePenalties();
     if (matchMode) handlers.onMatchMode(matchMode);
     if (balanceMode) handlers.onBalanceMode(balanceMode);
-    if (balancePrimary) {
+    if (balancePrimaryBtn) {
       e.preventDefault();
       e.stopPropagation();
-      if (balancePrimary === 'manual') handlers.onManualBalance();
+      const mode = balancePrimary === 'manual' ? 'manual' : (balancePrimary === 'auto' ? 'auto' : (state.app.mode === 'manual' ? 'manual' : 'auto'));
+      if (mode === 'manual') handlers.onManualBalance();
       else handlers.onAutoBalance();
       return;
     }


### PR DESCRIPTION
### Motivation
- Виправити silent-failure при натисканні кнопки «Сформувати команди», яке перестало викликати автобаланс через змінений/відсутній dataset-атрибут. 
- Забезпечити коректну роботу автobalance для 2..6 команд і коректне зчитування полів очок гравців (`pts` або `points`).

### Description
- В `v2/scripts/balance2/ui.js` делегований клік тепер шукає кнопку за `data-role="balance-primary-action"` і безпечно резолвить режим дії (`auto`/`manual`) навіть якщо dataset не встановлено. 
- В `v2/scripts/balance2/app.js` у валідації автobalance уніфіковано повідомлення про недостатню кількість гравців на чіткий текст `Недостатньо гравців для обраної кількості команд`. 
- В `v2/scripts/balance2/balance.js` розширено підтримку до 6 команд замість 4, додано читання очок з `pts` або `points`, та додано додаткові команди у структуру результатів. 
- Змінено лише дозволені для хотфіксу файли: `ui.js`, `app.js`, `balance.js` без змін у бекенді, API payload, save-логіці чи алгоритмі балансу як таким (логіка розподілу збережена, розширено параметри). 

### Testing
- Запущено `git diff --check` і всі перевірки пройшли без помилок. 
- Запущено синтаксичну перевірку: `node --check v2/scripts/balance2/ui.js`, `node --check v2/scripts/balance2/app.js`, `node --check v2/scripts/balance2/balance.js`, всі перевірки пройшли успішно. 
- Ручне інтерактивне тестування потрібно виконати в браузері за `http://127.0.0.1:4190/v2/balance2.html` (перевірка flow описана в інструкції), автоматичні інтерактивні тести не були виконані у CI цього патчу.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7059b788883218318a50e3fe173f6)