### PR TITLE
Render full school tournament on #school page and extend school mode tests

### DIFF
--- a/tests/schoolMode.test.mjs
+++ b/tests/schoolMode.test.mjs
@@ -73,3 +73,14 @@ test('manual points normalization', () => {
   assert.equal(normalizeManualPoints(10), 10);
   assert.equal(normalizeManualPoints(11), null);
 });
+
+test('group match generation gives 20 matches for 2x5 groups', () => {
+  const groupA = generateRoundRobinMatches(['team1', 'team2', 'team3', 'team4', 'team5'], { stage: 'group', groupId: 'A' });
+  const groupB = generateRoundRobinMatches(['team6', 'team7', 'team8', 'team9', 'team10'], { stage: 'group', groupId: 'B' });
+  assert.equal(groupA.length + groupB.length, 20);
+});
+
+test('final matches count for 4 and 5 teams', () => {
+  assert.equal(generateRoundRobinMatches(['team1', 'team2', 'team3', 'team4'], { stage: 'final', groupId: 'FINAL' }).length, 6);
+  assert.equal(generateRoundRobinMatches(['team1', 'team2', 'team3', 'team4', 'team5'], { stage: 'final', groupId: 'FINAL' }).length, 10);
+});

--- a/v2/pages/school.js
+++ b/v2/pages/school.js
@@ -25,21 +25,48 @@ export async function initSchoolPage() {
     });
     root.append(list);
 
-    const standings = el('table', 'school-standings');
-    const thead = el('thead');
-    const headTr = el('tr');
-    ['Місце', 'Школа', 'Номер', 'Команда', 'І', 'В', 'Н', 'П', 'РМ', 'О'].forEach((h) => headTr.append(el('th', '', h)));
-    thead.append(headTr);
-    standings.append(thead);
-    const tbody = el('tbody');
-    ((latest.finalGroup?.standings || latest.standings || [])).forEach((row) => {
-      const tr = document.createElement('tr');
-      [row.place, row.schoolName || '—', row.schoolNumber || '—', row.teamName || '—', row.matchesPlayed || 0, row.wins || 0, row.draws || 0, row.losses || 0, row.pointsDiff || 0, row.tournamentPoints || 0]
-        .forEach((v) => tr.append(el('td', '', String(v))));
-      tbody.append(tr);
+    root.append(el('h3', '', `${latest.title || 'Шкільний турнір'} · ${latest.date || 'без дати'}`));
+
+    const teamsWrap = el('div', 'school-events-list');
+    (latest.teams || []).forEach((team, idx) => {
+      const row = el('div', 'school-event-item');
+      const schoolInfo = `${schoolLabel(team)} · ${team.schoolName || 'Без назви'} · ${team.teamName || `Команда ${idx + 1}`}`;
+      row.append(el('strong', '', schoolInfo));
+      row.append(el('div', '', `Гравців: ${(team.players || []).length} · Сила: ${Number(team.strengthPoints || 0)}`));
+      teamsWrap.append(row);
     });
-    standings.append(tbody);
-    root.append(standings);
+    root.append(teamsWrap);
+
+    const renderStandings = (title, rows = []) => {
+      root.append(el('h3', '', title));
+      const standings = el('table', 'school-standings');
+      const thead = el('thead');
+      const headTr = el('tr');
+      ['Місце', 'Школа', 'Номер', 'Команда', 'І', 'В', 'Н', 'П', 'РМ', 'О'].forEach((h) => headTr.append(el('th', '', h)));
+      thead.append(headTr);
+      standings.append(thead);
+      const tbody = el('tbody');
+      rows.forEach((row) => {
+        const tr = document.createElement('tr');
+        [row.place, row.schoolName || '—', row.schoolNumber || '—', row.teamName || '—', row.matchesPlayed || 0, row.wins || 0, row.draws || 0, row.losses || 0, row.pointsDiff || 0, row.tournamentPoints || 0]
+          .forEach((v) => tr.append(el('td', '', String(v))));
+        tbody.append(tr);
+      });
+      standings.append(tbody);
+      root.append(standings);
+    };
+
+    renderStandings('Group A', latest.groupStandings?.A || []);
+    renderStandings('Group B', latest.groupStandings?.B || []);
+    renderStandings('Фінальна таблиця', latest.finalGroup?.standings || latest.standings || []);
+
+    const qualifiers = el('div', 'school-event-item');
+    qualifiers.append(el('strong', '', 'Фіналісти'));
+    qualifiers.append(el('div', '', `Group A: ${(latest.qualifiers?.A || []).join(', ') || '—'} · Group B: ${(latest.qualifiers?.B || []).join(', ') || '—'}`));
+    if (latest.wildcard?.enabled && latest.wildcard?.teamId) {
+      qualifiers.append(el('div', '', `Wildcard: ${latest.wildcard.teamId}`));
+    }
+    root.append(qualifiers);
 
     root.append(el('h3', '', `Чемпіон: ${latest.championTeamId || latest.finalGroup?.championTeamId || '—'}`));
   } catch {


### PR DESCRIPTION
### Motivation
- Improve visibility of saved school tournaments on the public #school page so admins and viewers see title/date, teams and full standings instead of a minimal summary. 
- Add test coverage for key round-robin sizes (group and final) to guard tournament match-count logic.

### Description
- Enhanced `v2/pages/school.js` to render latest event details: event title/date, list of teams with school metadata and strength, Group A and Group B standings, final standings, qualifiers/wildcard block and champion hero. 
- Rendering uses DOM node creation (`createElement`/`textContent`) via helper `el(...)` to avoid unsafe `innerHTML` and prevent XSS. 
- Added two tests in `tests/schoolMode.test.mjs` to verify that group generation for two 5-team groups yields 20 matches and that final round-robin yields 6 matches for 4 teams and 10 matches for 5 teams. 

### Testing
- Ran `node --test tests/schoolMode.test.mjs` and all subtests passed. 
- Ran full suite `node --test tests/*.test.mjs` and all tests passed locally (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1499a94ef083218b04fc8c3e97ce8d)