### PR TITLE
Phase 6.1: school workflow shell (10 teams, teamMeta, groups preview)

### DIFF
--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -29,6 +29,7 @@ import { saveLobby, restoreLobby, peekLobbyRestore, clearPlayersCache, saveLastS
 import { setStatus, lockSaveButton } from './status.js';
 import { validateSchoolEvent } from './validation.js';
 import { buildSchoolEventPayload } from './schoolPayload.js';
+import { balanceIntoSchoolTeams, generateSchoolGroups } from './schoolMode.js';
 import { debugLog } from '../../core/debug.js';
 
 const $ = (id) => document.getElementById(id);
@@ -469,6 +470,10 @@ function renderAndSync() {
   syncSaveButtonState();
   render();
   syncSaveButtonState();
+}
+function saveSchoolDraftState() {
+  if (state.app.eventMode !== 'school') return;
+  saveSchoolDraft(buildSchoolEventPayload(state));
 }
 
 function buildPayload() {
@@ -1118,7 +1123,39 @@ async function init() {
       if (state.app.eventMode !== 'tournament') clearTournamentStatus();
       syncSaveButtonState();
       saveLobby();
+      saveSchoolDraftState();
       renderAndSync();
+    },
+    onSchoolBuildTeams() {
+      if (state.app.eventMode !== 'school') return;
+      const selected = getSelectedPlayers();
+      if (selected.length < 10) { setStatus({ state: 'error', text: 'Для school mode потрібно мінімум 10 гравців.', retryVisible: false }); return; }
+      if (selected.length > 50) { setStatus({ state: 'error', text: 'Для school mode максимум 50 гравців.', retryVisible: false }); return; }
+      const teams = balanceIntoSchoolTeams(selected);
+      TEAM_KEYS.forEach((key, idx) => { state.teamsState.teams[key] = idx < 10 ? (teams[key] || []).map((p) => getPlayerKey(p)) : []; });
+      state.teamsState.teamCount = 10;
+      saveLobby(); saveSchoolDraftState(); renderAndSync();
+    },
+    onSchoolBuildGroups() {
+      if (state.app.eventMode !== 'school') return;
+      if ((state.schoolState?.groups?.A?.teamIds?.length || 0) + (state.schoolState?.groups?.B?.teamIds?.length || 0) > 0 && !window.confirm('Перегенерувати групи?')) return;
+      state.schoolState.groups = generateSchoolGroups(TEAM_KEYS.slice(0, 10));
+      saveLobby(); saveSchoolDraftState(); renderAndSync();
+    },
+    onSchoolMetaChange(teamKey, field, value) {
+      if (state.app.eventMode !== 'school' || !TEAM_KEYS.includes(teamKey)) return;
+      if (!state.schoolState.teamMeta[teamKey]) state.schoolState.teamMeta[teamKey] = { schoolName: '', schoolNumber: '', teamName: '' };
+      if (['schoolName', 'schoolNumber', 'teamName'].includes(field)) state.schoolState.teamMeta[teamKey][field] = String(value || '').trimStart();
+      if (field === 'teamName') state.teamsState.teamNames[teamKey] = String(value || '').trim() || `Команда ${teamKey.replace('team', '')}`;
+      saveLobby(); saveSchoolDraftState();
+    },
+    onSchoolTitleChange(value) {
+      state.schoolState.title = String(value || '').trimStart() || 'Шкільний турнір';
+      saveLobby(); saveSchoolDraftState();
+    },
+    onSchoolDateChange(value) {
+      state.schoolState.date = String(value || '').trim() || new Date().toISOString().slice(0, 10);
+      saveLobby(); saveSchoolDraftState();
     },
     onPlayerSourceMode(sourceMode) {
       state.uiState.flowStarted = true;

--- a/v2/scripts/balance2/schoolMode.js
+++ b/v2/scripts/balance2/schoolMode.js
@@ -34,6 +34,31 @@ export function normalizeManualPoints(value) {
   return parsed;
 }
 
+export function balanceIntoSchoolTeams(players = []) {
+  const limits = getEventModeLimits('school');
+  const teamCount = limits.maxTeams;
+  const sorted = [...players].sort((a, b) => ((Number(b.pts ?? b.points) || 0) - (Number(a.pts ?? a.points) || 0)));
+  const teams = Object.fromEntries(Array.from({ length: teamCount }, (_, i) => [`team${i + 1}`, []]));
+  const targets = Array.from({ length: teamCount }, (_, i) => Math.floor(sorted.length / teamCount) + (i < sorted.length % teamCount ? 1 : 0));
+  const sum = (arr) => arr.reduce((acc, p) => acc + (Number(p.pts ?? p.points) || 0), 0);
+  sorted.forEach((player) => {
+    const idx = Array.from({ length: teamCount }, (_, i) => i)
+      .filter((i) => teams[`team${i + 1}`].length < targets[i])
+      .sort((a, b) => sum(teams[`team${a + 1}`]) - sum(teams[`team${b + 1}`]))[0] ?? 0;
+    teams[`team${idx + 1}`].push(player);
+  });
+  return teams;
+}
+
+export function generateSchoolGroups(teamKeys = []) {
+  const clean = [...new Set(teamKeys)].filter((k) => /^team([1-9]|10)$/.test(k));
+  const ordered = clean.sort((a, b) => Number(a.replace('team', '')) - Number(b.replace('team', '')));
+  return {
+    A: { id: 'A', name: 'Група A', teamIds: ordered.filter((_, idx) => idx % 2 === 0).slice(0, 5) },
+    B: { id: 'B', name: 'Група B', teamIds: ordered.filter((_, idx) => idx % 2 === 1).slice(0, 5) },
+  };
+}
+
 export function createSchoolEventDraft() {
   const now = nowIso();
   const stamp = now.replaceAll('-', '').replaceAll(':', '').replace('T', '_').slice(0, 15);

--- a/v2/scripts/balance2/ui.js
+++ b/v2/scripts/balance2/ui.js
@@ -409,6 +409,7 @@ export function renderTeamSettings() {
   const primaryActionLabel = state.app.mode === 'manual' ? 'Ручне формування' : 'Сформувати команди';
   const primaryActionMode = state.app.mode === 'manual' ? 'manual' : 'auto';
 
+  const isSchool = state.app.eventMode === 'school';
   settings.innerHTML = `
     <h3>3. Налаштування команд</h3>
     <p class="section-hint">Обери кількість команд і режим балансу до формування lobby.</p>
@@ -425,8 +426,10 @@ export function renderTeamSettings() {
       </div>
     </div>
     <div class="team-settings-actions">
-      <button class="chip balance-primary-action" type="button" data-role="balance-primary-action" data-balance-primary="${escapeAttr(primaryActionMode)}">${escapeHtml(primaryActionLabel)}</button>
+      ${isSchool ? '<button class="chip" type="button" data-school-build-teams="1">Сформувати 10 команд</button>' : `<button class="chip balance-primary-action" type="button" data-role="balance-primary-action" data-balance-primary="${escapeAttr(primaryActionMode)}">${escapeHtml(primaryActionLabel)}</button>`}
     </div>
+    ${isSchool ? '<div class="team-settings-actions"><button class="chip" type="button" data-school-build-groups="1">Сформувати групи</button></div><div id="schoolGroupsPreview"></div>' : ''}
+    ${isSchool ? `<div class="school-event-meta"><label>Назва турніру <input class="search-input" data-school-title="1" value="${escapeAttr(state.schoolState?.title || 'Шкільний турнір')}"></label><label>Дата турніру <input class="search-input" type="date" data-school-date="1" value="${escapeAttr(state.schoolState?.date || new Date().toISOString().slice(0, 10))}"></label></div>` : ''}
   `;
   settings.querySelector('[data-balance-mode-slot]')?.appendChild(modeControl);
 }
@@ -516,7 +519,7 @@ export function renderTeams() {
   const grid = document.getElementById('teamsGrid');
   if (!grid) return;
 
-  const keys = TEAM_KEYS.slice(0, state.teamsState.teamCount);
+  const keys = state.app.eventMode === 'school' ? TEAM_KEYS.slice(0, 10) : TEAM_KEYS.slice(0, state.teamsState.teamCount);
   const map = new Map(state.playersState.players.map((p) => [getPlayerKey(p), p]));
   const cards = keys.map((key) => {
     const playerKeys = state.teamsState.teams[key] || [];
@@ -525,10 +528,22 @@ export function renderTeams() {
       const player = map.get(playerKey) || { nick: playerKey, points: 0, rank: '—' };
       return `<div class="team-player">${playerMetaHtml(player)}<button class="team-player-remove" type="button" data-role="remove-player-from-team" data-player-key="${escapeAttr(playerKey)}" data-team-id="${escapeAttr(key)}">Прибрати</button></div>`;
     }).join('') || '<div class="team-empty-state">Додай гравців із lobby</div>';
-    return `<div class="team-card"><h4>${teamNameControl(key)} <span class="tag">Σ ${total}</span></h4>${members}</div>`;
+    const teamMeta = state.schoolState?.teamMeta?.[key] || {};
+    const schoolFields = state.app.eventMode === 'school' ? `<div class="school-meta-grid">
+      <input class="search-input" data-school-meta="${escapeAttr(key)}" data-school-meta-field="schoolName" placeholder="Назва школи" value="${escapeAttr(teamMeta.schoolName || '')}">
+      <input class="search-input" data-school-meta="${escapeAttr(key)}" data-school-meta-field="schoolNumber" placeholder="Номер школи" value="${escapeAttr(teamMeta.schoolNumber || '')}">
+      <input class="search-input" data-school-meta="${escapeAttr(key)}" data-school-meta-field="teamName" placeholder="Назва команди" value="${escapeAttr(teamMeta.teamName || `Команда ${key.replace('team', '')}`)}">
+    </div>` : '';
+    return `<div class="team-card"><h4>${teamNameControl(key)} <span class="tag">Σ ${total}</span></h4>${schoolFields}${members}</div>`;
   });
 
   grid.innerHTML = cards.join('');
+  const preview = document.getElementById('schoolGroupsPreview');
+  if (preview && state.app.eventMode === 'school') {
+    const groupA = state.schoolState?.groups?.A?.teamIds || [];
+    const groupB = state.schoolState?.groups?.B?.teamIds || [];
+    preview.innerHTML = `<div class="tag">Група A: ${groupA.length} команд</div><div class="tag">Група B: ${groupB.length} команд</div><div class="tag">${groupA.length === 5 && groupB.length === 5 ? '✅ 5/5' : '⚠️ Очікується 5/5'}</div>`;
+  }
 }
 
 export function renderMatchConfig() {
@@ -829,6 +844,8 @@ export function bindUiEvents(handlers) {
     const nextTournamentMatch = e.target.closest('[data-tournament-next-match]');
     const loadPlayers = e.target.closest('[data-load-players]');
     const removeFromTeam = e.target.closest('[data-role="remove-player-from-team"]');
+    const schoolBuildTeams = e.target.closest('[data-school-build-teams]');
+    const schoolBuildGroups = e.target.closest('[data-school-build-groups]');
 
     if (toggle) {
       const alreadySelected = state.playersState.selectedMap.has(toggle);
@@ -890,11 +907,19 @@ export function bindUiEvents(handlers) {
     if (createTournament) handlers.onCreateTournament();
     if (saveTeams) handlers.onSaveTournamentTeams();
     if (removeFromTeam) handlers.onRemovePlayerFromTeam(removeFromTeam.dataset.playerKey, removeFromTeam.dataset.teamId);
+    if (schoolBuildTeams) handlers.onSchoolBuildTeams();
+    if (schoolBuildGroups) handlers.onSchoolBuildGroups();
   });
 
   document.addEventListener('input', (e) => {
     const tournamentNameInput = e.target.closest('[data-tournament-name]');
     if (tournamentNameInput) handlers.onTournamentName(tournamentNameInput.value);
+    const schoolTitle = e.target.closest('[data-school-title]');
+    const schoolDate = e.target.closest('[data-school-date]');
+    if (schoolTitle) handlers.onSchoolTitleChange(schoolTitle.value);
+    if (schoolDate) handlers.onSchoolDateChange(schoolDate.value);
+    const schoolMetaInput = e.target.closest('[data-school-meta]');
+    if (schoolMetaInput) handlers.onSchoolMetaChange(schoolMetaInput.dataset.schoolMeta, schoolMetaInput.dataset.schoolMetaField, schoolMetaInput.value);
   });
 
   document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
### Motivation
- Додати базовий адмінський UI-каркас для school tournament у `balance2`, щоб адміністратор міг швидко створити подію в school mode з 10 командами і двома групами без зміни tournament flow. 

### Description
- Додано helpers у `v2/scripts/balance2/schoolMode.js`: `balanceIntoSchoolTeams(players)` для формування рівно 10 команд та `generateSchoolGroups(teamKeys)` для автогенерації груп A/B (таргет 5/5). 
- Розширено UI у `v2/scripts/balance2/ui.js`: поля для `title`/`date` (school), кнопки `Сформувати 10 команд` і `Сформувати групи`, інпут-поля team meta (`schoolName`, `schoolNumber`, `teamName`) для team1..team10 та простий preview груп з індикатором 5/5. 
- Додано обробники у `v2/scripts/balance2/app.js`: `onSchoolBuildTeams`, `onSchoolBuildGroups`, `onSchoolMetaChange`, `onSchoolTitleChange`, `onSchoolDateChange` та функцію збереження драфту `saveSchoolDraftState()` що викликає `saveSchoolDraft(buildSchoolEventPayload(state))`. 
- Інтеграція з існуючими механізмами: використовуються `TEAM_KEYS`, `getSelectedPlayers()`, `getPlayerKey()` та `buildSchoolEventPayload()`; tournament mode не змінений; ручне переміщення гравців (`movePlayerToTeam`) залишилось сумісним. 
- Безпека рендерингу: всі нові значення вставляються через value/attributes з екрануванням (`escapeAttr`/`escapeHtml`), без unsafe innerHTML вставок для school полів. 

### Testing
- Запущено модульні тести, зокрема: `node --test tests/schoolMode.test.mjs` та `node --test tests/*.test.mjs`; всі тести пройшли успішно. 
- Конкретно пройшли перевірки: ліміти school mode, генерація розкладу матчів, standings, build/validation payload для school tournament, нормалізація manual points, та підрахунок матчів для 2×5 груп.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14aba6f2648321ad1ec95787b7cc88)