### PR TITLE
Phase 6.2: School group matches generation, UI, results input and live standings

### DIFF
--- a/tests/schoolMode.test.mjs
+++ b/tests/schoolMode.test.mjs
@@ -6,6 +6,7 @@ import {
   generateRoundRobinMatches,
   calculateSchoolRoundRobinStandings,
   calculateSchoolGroupStandings,
+  getSchoolGroupProgress,
 } from '../v2/scripts/balance2/schoolMode.js';
 import { validateSchoolTournament } from '../v2/scripts/balance2/validation.js';
 import { buildSchoolEventPayload } from '../v2/scripts/balance2/schoolPayload.js';
@@ -78,6 +79,52 @@ test('group match generation gives 20 matches for 2x5 groups', () => {
   const groupA = generateRoundRobinMatches(['team1', 'team2', 'team3', 'team4', 'team5'], { stage: 'group', groupId: 'A' });
   const groupB = generateRoundRobinMatches(['team6', 'team7', 'team8', 'team9', 'team10'], { stage: 'group', groupId: 'B' });
   assert.equal(groupA.length + groupB.length, 20);
+});
+
+test('group A and B each have 10 matches', () => {
+  const groupA = generateRoundRobinMatches(['team1', 'team2', 'team3', 'team4', 'team5'], { stage: 'group', groupId: 'A' });
+  const groupB = generateRoundRobinMatches(['team6', 'team7', 'team8', 'team9', 'team10'], { stage: 'group', groupId: 'B' });
+  assert.equal(groupA.length, 10);
+  assert.equal(groupB.length, 10);
+});
+
+test('completed match sets winner and draw semantics', () => {
+  const match = generateRoundRobinMatches(['team1', 'team2'], { stage: 'group', groupId: 'A' })[0];
+  match.status = 'completed';
+  match.result.pointsA = 8;
+  match.result.pointsB = 5;
+  match.result.winnerTeamId = 'team1';
+  assert.equal(match.status, 'completed');
+  assert.equal(match.result.winnerTeamId, 'team1');
+  match.result.pointsA = 4;
+  match.result.pointsB = 4;
+  match.result.winnerTeamId = '';
+  match.result.isDraw = true;
+  assert.equal(match.result.isDraw, true);
+});
+
+test('invalid completed score is blocked by validation', () => {
+  const payload = {
+    eventMode: 'school', eventId: 'e1', title: 'x', players: [], format: 'school_groups_final', affectsPlayerRating: false,
+    teams: mkTeams(10),
+    groups: { A: { teamIds: ['team1', 'team2', 'team3', 'team4', 'team5'] }, B: { teamIds: ['team6', 'team7', 'team8', 'team9', 'team10'] } },
+    groupMatches: [{ title: 'Група A · Матч 1', teamAId: 'team1', teamBId: 'team2', status: 'completed', result: { pointsA: 11, pointsB: 3 } }],
+    finalGroup: { teamIds: ['team1', 'team2', 'team6', 'team7'], matches: [] },
+  };
+  const v = validateSchoolTournament(payload);
+  assert.equal(v.ok, false);
+  assert.equal(v.errors.some((e) => e.includes('Група A · Матч 1')), true);
+});
+
+test('group progress counts completed matches', () => {
+  const matches = [
+    { groupId: 'A', status: 'completed' }, { groupId: 'A', status: 'pending' },
+    { groupId: 'B', status: 'completed' }, { groupId: 'B', status: 'completed' },
+  ];
+  const progress = getSchoolGroupProgress(matches);
+  assert.equal(progress.completedTotal, 3);
+  assert.equal(progress.completedA, 1);
+  assert.equal(progress.completedB, 2);
 });
 
 test('final matches count for 4 and 5 teams', () => {

--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -29,7 +29,7 @@ import { saveLobby, restoreLobby, peekLobbyRestore, clearPlayersCache, saveLastS
 import { setStatus, lockSaveButton } from './status.js';
 import { validateSchoolEvent } from './validation.js';
 import { buildSchoolEventPayload } from './schoolPayload.js';
-import { balanceIntoSchoolTeams, generateSchoolGroups } from './schoolMode.js';
+import { balanceIntoSchoolTeams, generateSchoolGroups, generateRoundRobinMatches, normalizeManualPoints, calculateSchoolGroupStandings } from './schoolMode.js';
 import { debugLog } from '../../core/debug.js';
 
 const $ = (id) => document.getElementById(id);
@@ -474,6 +474,35 @@ function renderAndSync() {
 function saveSchoolDraftState() {
   if (state.app.eventMode !== 'school') return;
   saveSchoolDraft(buildSchoolEventPayload(state));
+}
+
+
+function refreshSchoolGroupStandings() {
+  const payload = buildSchoolEventPayload(state);
+  state.schoolState.groupStandings = payload.groupStandings || { A: [], B: [] };
+}
+
+function applySchoolGroupMatchPoints(matchId, pointsAValue, pointsBValue) {
+  const matches = Array.isArray(state.schoolState.groupMatches) ? state.schoolState.groupMatches : [];
+  const match = matches.find((item) => item.id === matchId);
+  if (!match) return { ok: false, error: 'Матч не знайдено.' };
+  const pointsA = pointsAValue === '' ? null : normalizeManualPoints(pointsAValue);
+  const pointsB = pointsBValue === '' ? null : normalizeManualPoints(pointsBValue);
+  if (pointsAValue !== '' && pointsA === null) return { ok: false, error: `Матч ${match.title || match.id} має некоректні бали.` };
+  if (pointsBValue !== '' && pointsB === null) return { ok: false, error: `Матч ${match.title || match.id} має некоректні бали.` };
+  match.result = { ...(match.result || {}), teamAId: match.teamAId, teamBId: match.teamBId, pointsA, pointsB };
+  if (Number.isInteger(pointsA) && Number.isInteger(pointsB)) {
+    match.status = 'completed';
+    match.result.isDraw = pointsA === pointsB;
+    match.result.winnerTeamId = pointsA > pointsB ? match.teamAId : (pointsB > pointsA ? match.teamBId : '');
+  } else {
+    match.result.isDraw = false;
+    match.result.winnerTeamId = '';
+    if (match.status === 'completed') match.status = 'pending';
+  }
+  match.updatedAt = new Date().toISOString();
+  refreshSchoolGroupStandings();
+  return { ok: true };
 }
 
 function buildPayload() {
@@ -1140,6 +1169,51 @@ async function init() {
       if (state.app.eventMode !== 'school') return;
       if ((state.schoolState?.groups?.A?.teamIds?.length || 0) + (state.schoolState?.groups?.B?.teamIds?.length || 0) > 0 && !window.confirm('Перегенерувати групи?')) return;
       state.schoolState.groups = generateSchoolGroups(TEAM_KEYS.slice(0, 10));
+      saveLobby(); saveSchoolDraftState(); renderAndSync();
+    },
+    onSchoolGenerateGroupMatches() {
+      if (state.app.eventMode !== 'school') return;
+      const groupA = state.schoolState?.groups?.A?.teamIds || [];
+      const groupB = state.schoolState?.groups?.B?.teamIds || [];
+      if (groupA.length !== 5 || groupB.length !== 5) return;
+      const hasResults = (state.schoolState.groupMatches || []).some((match) => Number.isInteger(match?.result?.pointsA) || Number.isInteger(match?.result?.pointsB));
+      if (hasResults && !window.confirm('Матчі груп уже створені. Перегенерація видалить введені результати.')) return;
+      const matchesA = generateRoundRobinMatches(groupA, { stage: 'group', groupId: 'A', titlePrefix: 'Група A' });
+      const matchesB = generateRoundRobinMatches(groupB, { stage: 'group', groupId: 'B', titlePrefix: 'Група B' });
+      state.schoolState.groupMatches = [...matchesA, ...matchesB];
+      refreshSchoolGroupStandings();
+      saveLobby(); saveSchoolDraftState(); renderAndSync();
+    },
+    onSchoolGroupMatchScoreChange(matchId, pointsAValue, pointsBValue) {
+      if (state.app.eventMode !== 'school') return;
+      const result = applySchoolGroupMatchPoints(matchId, pointsAValue, pointsBValue);
+      state.schoolState.lastError = result.ok ? '' : result.error;
+      if (!result.ok) setStatus({ state: 'error', text: result.error, retryVisible: false });
+      saveLobby(); saveSchoolDraftState(); renderAndSync();
+    },
+    onSchoolGroupMatchSetCurrent(matchId) {
+      const matches = Array.isArray(state.schoolState.groupMatches) ? state.schoolState.groupMatches : [];
+      const target = matches.find((m) => m.id === matchId);
+      if (!target) return;
+      if (target.status === 'completed') {
+        setStatus({ state: 'error', text: 'Завершений матч не можна зробити поточним.', retryVisible: false });
+        return;
+      }
+      matches.forEach((match) => {
+        if (match.status !== 'completed') match.status = match.id === matchId ? 'current' : 'pending';
+      });
+      target.updatedAt = new Date().toISOString();
+      saveLobby(); saveSchoolDraftState(); renderAndSync();
+    },
+    onSchoolGroupMatchClearResult(matchId) {
+      const matches = Array.isArray(state.schoolState.groupMatches) ? state.schoolState.groupMatches : [];
+      const target = matches.find((m) => m.id === matchId);
+      if (!target) return;
+      if (!window.confirm('Очистити результат цього матчу?')) return;
+      target.result = { ...(target.result || {}), teamAId: target.teamAId, teamBId: target.teamBId, pointsA: null, pointsB: null, winnerTeamId: '', isDraw: false };
+      target.status = 'pending';
+      target.updatedAt = new Date().toISOString();
+      refreshSchoolGroupStandings();
       saveLobby(); saveSchoolDraftState(); renderAndSync();
     },
     onSchoolMetaChange(teamKey, field, value) {

--- a/v2/scripts/balance2/schoolMode.js
+++ b/v2/scripts/balance2/schoolMode.js
@@ -189,3 +189,12 @@ export function calculateSchoolStandings(teams = [], battles = []) {
 
   return rows.map((row, index) => ({ ...row, place: index + 1 }));
 }
+
+
+export function getSchoolGroupProgress(groupMatches = []) {
+  const matches = Array.isArray(groupMatches) ? groupMatches : [];
+  const completedTotal = matches.filter((m) => m?.status === 'completed').length;
+  const completedA = matches.filter((m) => m?.groupId === 'A' && m?.status === 'completed').length;
+  const completedB = matches.filter((m) => m?.groupId === 'B' && m?.status === 'completed').length;
+  return { completedTotal, total: 20, completedA, totalA: 10, completedB, totalB: 10 };
+}

--- a/v2/scripts/balance2/ui.js
+++ b/v2/scripts/balance2/ui.js
@@ -16,6 +16,7 @@ import {
   getMaxLobbyPlayersForEventMode,
 } from './state.js';
 import { movePlayerToTeam } from './manual.js';
+import { formatSchoolDisplay, getSchoolGroupProgress } from './schoolMode.js';
 
 function escapeHtml(value = '') {
   return String(value ?? '')
@@ -515,6 +516,31 @@ function renderTournamentSchedule() {
   `;
 }
 
+function schoolTeamDisplay(teamId) {
+  const meta = state.schoolState?.teamMeta?.[teamId] || {};
+  const fallbackTeamName = state.teamsState.teamNames?.[teamId] || `Команда ${String(teamId || '').replace('team', '')}`;
+  const labels = formatSchoolDisplay(meta, fallbackTeamName);
+  return `${labels.schoolLabel} · ${labels.teamLabel}`;
+}
+
+function renderSchoolGroupMatches() {
+  if (state.app.eventMode !== 'school') return '';
+  const matches = Array.isArray(state.schoolState.groupMatches) ? state.schoolState.groupMatches : [];
+  const byGroup = (gid) => matches.filter((m) => m.groupId === gid);
+  const error = state.schoolState?.lastError ? `<div class="tag">${escapeHtml(state.schoolState.lastError)}</div>` : '';
+  const canGenerate = (state.schoolState?.groups?.A?.teamIds?.length || 0) === 5 && (state.schoolState?.groups?.B?.teamIds?.length || 0) === 5;
+  const groupBlock = (gid) => `<div class="team-card"><h4>Група ${gid} — матчі</h4>${byGroup(gid).map((match, idx) => {
+    const title = match.title || `Група ${gid} · Матч ${idx + 1}`;
+    return `<div class="tournament-schedule-row"><div><strong>${escapeHtml(title)}</strong><span>${escapeHtml(schoolTeamDisplay(match.teamAId))} vs ${escapeHtml(schoolTeamDisplay(match.teamBId))}</span></div><label>A <input type="number" min="0" max="10" step="1" data-school-group-score-a="${escapeAttr(match.id)}" value="${escapeAttr(match?.result?.pointsA ?? '')}"></label><label>B <input type="number" min="0" max="10" step="1" data-school-group-score-b="${escapeAttr(match.id)}" value="${escapeAttr(match?.result?.pointsB ?? '')}"></label><span class="tag">${escapeHtml(match.status || 'pending')}</span>${match.status === 'current' ? '<button class="chip" type="button" disabled>Поточний</button>' : `<button class="chip" type="button" data-school-group-current="${escapeAttr(match.id)}">Обрати як поточний</button>`}${(Number.isInteger(match?.result?.pointsA) || Number.isInteger(match?.result?.pointsB)) ? `<button class="chip" type="button" data-school-group-clear="${escapeAttr(match.id)}">Очистити результат</button>` : ''}</div>`;
+  }).join('') || '<div class="tag">Матчі ще не згенеровано.</div>'}</div>`;
+  const standingsTable = (gid) => {
+    const rows = state.schoolState?.groupStandings?.[gid] || [];
+    return `<div class="team-card"><h4>Таблиця Групи ${gid}</h4><table><thead><tr><th>Місце</th><th>Команда / школа</th><th>І</th><th>В</th><th>Н</th><th>П</th><th>Турнірні бали</th><th>Забито</th><th>Пропущено</th><th>Різниця</th></tr></thead><tbody>${rows.map((r) => `<tr><td>${r.place}</td><td>${escapeHtml(schoolTeamDisplay(r.teamId))}</td><td>${r.matchesPlayed}</td><td>${r.wins}</td><td>${r.draws}</td><td>${r.losses}</td><td>${r.tournamentPoints}</td><td>${r.pointsFor}</td><td>${r.pointsAgainst}</td><td>${r.pointsDiff}</td></tr>`).join('')}</tbody></table></div>`;
+  };
+  const progress = getSchoolGroupProgress(matches);
+  return `<div class="school-group-stage"><div class="team-settings-actions"><button class="chip" type="button" data-school-generate-group-matches="1" ${canGenerate ? '' : 'disabled'}>Згенерувати матчі груп</button></div><h4>Групові матчі</h4>${error}<div class="tag">Груповий етап: Зіграно ${progress.completedTotal} / ${progress.total} · Група A: ${progress.completedA} / ${progress.totalA} · Група B: ${progress.completedB} / ${progress.totalB}</div><div class="tag">${progress.completedTotal === 20 ? 'Груповий етап завершено. Можна формувати фінальну групу.' : 'Завершіть усі групові матчі, щоб сформувати фінальну групу.'}</div>${groupBlock('A')}${groupBlock('B')}${standingsTable('A')}${standingsTable('B')}<div class="tag">${progress.completedTotal === 20 ? '' : 'Фінальна група буде доступна після завершення групового етапу.'}</div></div>`;
+}
+
 export function renderTeams() {
   const grid = document.getElementById('teamsGrid');
   if (!grid) return;
@@ -543,6 +569,7 @@ export function renderTeams() {
     const groupA = state.schoolState?.groups?.A?.teamIds || [];
     const groupB = state.schoolState?.groups?.B?.teamIds || [];
     preview.innerHTML = `<div class="tag">Група A: ${groupA.length} команд</div><div class="tag">Група B: ${groupB.length} команд</div><div class="tag">${groupA.length === 5 && groupB.length === 5 ? '✅ 5/5' : '⚠️ Очікується 5/5'}</div>`;
+    preview.insertAdjacentHTML('beforeend', renderSchoolGroupMatches());
   }
 }
 
@@ -846,6 +873,9 @@ export function bindUiEvents(handlers) {
     const removeFromTeam = e.target.closest('[data-role="remove-player-from-team"]');
     const schoolBuildTeams = e.target.closest('[data-school-build-teams]');
     const schoolBuildGroups = e.target.closest('[data-school-build-groups]');
+    const schoolGenerateGroupMatches = e.target.closest('[data-school-generate-group-matches]');
+    const schoolCurrent = e.target.closest('[data-school-group-current]')?.dataset.schoolGroupCurrent;
+    const schoolClear = e.target.closest('[data-school-group-clear]')?.dataset.schoolGroupClear;
 
     if (toggle) {
       const alreadySelected = state.playersState.selectedMap.has(toggle);
@@ -909,6 +939,9 @@ export function bindUiEvents(handlers) {
     if (removeFromTeam) handlers.onRemovePlayerFromTeam(removeFromTeam.dataset.playerKey, removeFromTeam.dataset.teamId);
     if (schoolBuildTeams) handlers.onSchoolBuildTeams();
     if (schoolBuildGroups) handlers.onSchoolBuildGroups();
+    if (schoolGenerateGroupMatches) handlers.onSchoolGenerateGroupMatches();
+    if (schoolCurrent) handlers.onSchoolGroupMatchSetCurrent(schoolCurrent);
+    if (schoolClear) handlers.onSchoolGroupMatchClearResult(schoolClear);
   });
 
   document.addEventListener('input', (e) => {
@@ -920,6 +953,14 @@ export function bindUiEvents(handlers) {
     if (schoolDate) handlers.onSchoolDateChange(schoolDate.value);
     const schoolMetaInput = e.target.closest('[data-school-meta]');
     if (schoolMetaInput) handlers.onSchoolMetaChange(schoolMetaInput.dataset.schoolMeta, schoolMetaInput.dataset.schoolMetaField, schoolMetaInput.value);
+    const scoreA = e.target.closest('[data-school-group-score-a]');
+    const scoreB = e.target.closest('[data-school-group-score-b]');
+    if (scoreA || scoreB) {
+      const matchId = scoreA?.dataset.schoolGroupScoreA || scoreB?.dataset.schoolGroupScoreB;
+      const inputA = document.querySelector(`[data-school-group-score-a="${escapeAttr(matchId)}"]`);
+      const inputB = document.querySelector(`[data-school-group-score-b="${escapeAttr(matchId)}"]`);
+      handlers.onSchoolGroupMatchScoreChange(matchId, inputA?.value ?? '', inputB?.value ?? '');
+    }
   });
 
   document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
### Motivation
- Implement the group-stage workflow for `school` event mode so admins can generate round-robin group matches, enter results, and monitor live standings during Phase 6.2. 
- Provide safe UI and state handling without changing tournament mode, wildcard/final/champion/export flows, or reworking the balancer.

### Description
- Added group-match generation and handlers in `v2/scripts/balance2/app.js` including `onSchoolGenerateGroupMatches`, `onSchoolGroupMatchScoreChange`, `onSchoolGroupMatchSetCurrent`, and `onSchoolGroupMatchClearResult`, and utilities `applySchoolGroupMatchPoints` and `refreshSchoolGroupStandings` to normalize points, compute winner/draw and update `state.schoolState`. 
- Extended `v2/scripts/balance2/ui.js` to render the new “Групові матчі” section with a `Згенерувати матчі груп` button, per-match numeric inputs (`0..10`), current-match selection, clear-result button, live group standings tables, and an X/20 progress summary; all user-visible text is escaped to avoid unsafe HTML rendering. 
- Added `getSchoolGroupProgress` helper to `v2/scripts/balance2/schoolMode.js` and reused existing `generateRoundRobinMatches`, `normalizeManualPoints`, and standings calculators to avoid duplicating logic. 
- Updated tests in `tests/schoolMode.test.mjs` to cover generation of 20 matches (10 per group), completed match semantics (winner/draw), invalid score blocking, progress counting, and other school-specific expectations.

### Testing
- Ran `node --test tests/schoolMode.test.mjs` and all tests passed (11/11 subtests in that file passed). 
- Ran the full suite `node --test tests/*.test.mjs` and all repository tests passed (19/19 tests passed). 
- Validation ensures invalid manual scores (e.g. `11`) are blocked by `validateSchoolTournament` and do not mark matches as `completed` or corrupt payload building.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b46f882c83218c493e82301624fc)