### PR TITLE
hotfix(balance2): recover startup crash after school mode changes

### DIFF
--- a/tests/balance2Import.test.mjs
+++ b/tests/balance2Import.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+class DummyEl {
+  constructor() {
+    this.value = '';
+    this.textContent = '';
+    this.innerHTML = '';
+    this.className = '';
+    this.dataset = {};
+    this.parentNode = this;
+    this.firstChild = null;
+    this.firstElementChild = null;
+    this.classList = { add() {}, remove() {}, toggle() {} };
+  }
+  addEventListener() {}
+  removeEventListener() {}
+  querySelector() { return new DummyEl(); }
+  querySelectorAll() { return []; }
+  closest() { return null; }
+  appendChild() { return new DummyEl(); }
+  insertBefore() { return new DummyEl(); }
+  insertAdjacentElement() { return new DummyEl(); }
+  insertAdjacentHTML() {}
+  setAttribute() {}
+  remove() {}
+  matches() { return false; }
+}
+
+const localStorageStub = {
+  map: new Map(),
+  getItem(k) { return this.map.has(k) ? this.map.get(k) : null; },
+  setItem(k, v) { this.map.set(k, String(v)); },
+  removeItem(k) { this.map.delete(k); },
+  clear() { this.map.clear(); },
+};
+
+test('balance2 modules import smoke test', async () => {
+  globalThis.window = globalThis;
+  globalThis.window.location = { search: '', hash: '' };
+  globalThis.localStorage = localStorageStub;
+  globalThis.alert = () => {};
+  globalThis.confirm = () => false;
+  globalThis.document = {
+    body: new DummyEl(),
+    createElement() { return new DummyEl(); },
+    getElementById() { return new DummyEl(); },
+    querySelector() { return new DummyEl(); },
+    querySelectorAll() { return []; },
+    addEventListener() {},
+  };
+
+  const modules = [
+    '../v2/scripts/balance2/app.js',
+    '../v2/scripts/balance2/ui.js',
+    '../v2/scripts/balance2/state.js',
+    '../v2/scripts/balance2/schoolPayload.js',
+    '../v2/scripts/balance2/validation.js',
+    '../v2/scripts/balance2/schoolMode.js',
+  ];
+
+  for (const mod of modules) {
+    await assert.doesNotReject(() => import(mod), `import failed: ${mod}`);
+  }
+});

--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -31,6 +31,7 @@ import { validateSchoolEvent } from './validation.js';
 import { buildSchoolEventPayload } from './schoolPayload.js';
 import {
   balanceIntoSchoolTeams,
+  createSchoolEventDraft,
   generateSchoolGroups,
   generateRoundRobinMatches,
   normalizeManualPoints,
@@ -111,6 +112,24 @@ function setTournamentDirty(message = 'Команди змінено — збе�
   state.tournamentState.teamsSaved = false;
   state.tournamentState.savedTournamentTeamIds = [];
   setTournamentStatus(message, 'warning');
+}
+
+function ensureSchoolState() {
+  if (!state.schoolState || typeof state.schoolState !== 'object') {
+    state.schoolState = createSchoolEventDraft();
+    return;
+  }
+  const fallback = createSchoolEventDraft();
+  state.schoolState = {
+    ...fallback,
+    ...state.schoolState,
+    groups: { ...fallback.groups, ...(state.schoolState.groups || {}) },
+    groupStandings: { ...fallback.groupStandings, ...(state.schoolState.groupStandings || {}) },
+    qualifiers: { ...fallback.qualifiers, ...(state.schoolState.qualifiers || {}) },
+    wildcard: { ...fallback.wildcard, ...(state.schoolState.wildcard || {}) },
+    finalGroup: { ...fallback.finalGroup, ...(state.schoolState.finalGroup || {}) },
+    teamMeta: state.schoolState.teamMeta && typeof state.schoolState.teamMeta === 'object' ? state.schoolState.teamMeta : {},
+  };
 }
 
 function generateRoundRobinSchedule(teamIds = []) {
@@ -706,7 +725,9 @@ function markScheduledMatchPlayed(resultSummary) {
 }
 
 async function doSave(retry = false) {
-  const eventMode = state.app?.eventMode === 'school' ? 'school' : 'tournament';
+  const eventMode = state.app?.eventMode === 'school'
+    ? 'school'
+    : (state.app?.eventMode === 'tournament' ? 'tournament' : 'default');
   debugLog('[balance2:save] mode', eventMode);
   const error = validateSave();
   if (error) {
@@ -722,12 +743,29 @@ async function doSave(retry = false) {
     return;
   }
 
+  if (eventMode === 'school') {
+    await handleSaveSchoolEvent(retry);
+    return;
+  }
+
   if (eventMode === 'tournament') {
     await handleSaveTournamentGame(retry);
     return;
   }
 
-  await handleSaveSchoolEvent(retry);
+  const payload = retry ? state.meta.lastPayload : buildPayload();
+  state.meta.lastPayload = payload;
+  const res = await saveMatch(payload);
+  if (!res?.ok) {
+    const msg = res?.message || 'Невідома помилка';
+    setSaveFeedback('error', msg, { renderNow: false });
+    setStatus({ state: 'error', text: `❌ ${msg}`, retryVisible: true });
+    renderAndSync();
+    return;
+  }
+  setSaveFeedback('success', 'Гру успішно збережено', { renderNow: false });
+  setStatus({ state: 'saved', text: '✅ Гру збережено', retryVisible: false });
+  renderAndSync();
 }
 
 async function handleSaveTournamentGame(retry = false) {
@@ -877,9 +915,7 @@ async function handleSaveSchoolEvent(retry = false) {
   state.meta.lastPayload = payload;
   const valid = validateSchoolEvent(payload);
   if (!valid.ok) {
-    const message = `Некоректні дані шкільного турніру:
-- ${valid.errors.join('
-- ')}`;
+    const message = `Некоректні дані шкільного турніру:\n- ${valid.errors.join('\n- ')}`;
     setSaveFeedback('error', valid.errors[0] || 'Некоректні дані шкільного турніру', { renderNow: false });
     setStatus({ state: 'error', text: `❌ ${message}`, retryVisible: false });
     renderAndSync();
@@ -1056,7 +1092,24 @@ async function init() {
   }
 
   $('restoreBtn')?.addEventListener('click', async () => {
-    if (!restoreLobby()) return;
+    const schoolDraft = peekSchoolDraft();
+    if ((schoolDraft?.eventMode === 'school' || schoolDraft?.type === 'school') && schoolDraft?.schoolState) {
+      if (!restoreLobby()) {
+        setStatus({ state: 'error', text: '❌ Не вдалося відновити lobby для school draft', retryVisible: false });
+        return;
+      }
+      try {
+        state.app.eventMode = 'school';
+        state.schoolState = schoolDraft.schoolState;
+        ensureSchoolState();
+      } catch {
+        setStatus({ state: 'error', text: '❌ Чернетка school пошкоджена. Видали чернетку та спробуй знову.', retryVisible: false });
+        return;
+      }
+    } else if (!restoreLobby()) {
+      return;
+    }
+    ensureSchoolState();
     normalizeEventAndSourceState(state.app.eventMode, state.app.playerSourceMode);
     $('sortMode').value = state.app.sortMode;
     await ensurePlayersLoaded();
@@ -1655,6 +1708,7 @@ async function init() {
   });
 
   normalizeEventAndSourceState(state.app.eventMode, localStorage.getItem(LEAGUE_KEY) || state.app.playerSourceMode);
+  ensureSchoolState();
   state.lastSavedGame = readLastSavedGame();
   $('sortMode').value = state.app.sortMode;
   syncSelectedMap();

--- a/v2/scripts/balance2/ui.js
+++ b/v2/scripts/balance2/ui.js
@@ -965,18 +965,18 @@ export function bindUiEvents(handlers) {
     if (createTournament) handlers.onCreateTournament();
     if (saveTeams) handlers.onSaveTournamentTeams();
     if (removeFromTeam) handlers.onRemovePlayerFromTeam(removeFromTeam.dataset.playerKey, removeFromTeam.dataset.teamId);
-    if (schoolBuildTeams) handlers.onSchoolBuildTeams();
-    if (schoolBuildGroups) handlers.onSchoolBuildGroups();
-    if (schoolGenerateGroupMatches) handlers.onSchoolGenerateGroupMatches();
-    if (schoolCurrent) handlers.onSchoolGroupMatchSetCurrent(schoolCurrent);
-    if (schoolClear) handlers.onSchoolGroupMatchClearResult(schoolClear);
-    if (schoolFormFinalGroup) handlers.onSchoolFormFinalGroup();
-    if (schoolSuggestWildcard) handlers.onSchoolSuggestWildcard();
-    if (schoolGenerateFinalMatches) handlers.onSchoolGenerateFinalMatches();
-    if (schoolFinalCurrent) handlers.onSchoolFinalMatchSetCurrent(schoolFinalCurrent);
-    if (schoolFinalClear) handlers.onSchoolFinalMatchClearResult(schoolFinalClear);
+    if (schoolBuildTeams) handlers.onSchoolBuildTeams?.();
+    if (schoolBuildGroups) handlers.onSchoolBuildGroups?.();
+    if (schoolGenerateGroupMatches) handlers.onSchoolGenerateGroupMatches?.();
+    if (schoolCurrent) handlers.onSchoolGroupMatchSetCurrent?.(schoolCurrent);
+    if (schoolClear) handlers.onSchoolGroupMatchClearResult?.(schoolClear);
+    if (schoolFormFinalGroup) handlers.onSchoolFormFinalGroup?.();
+    if (schoolSuggestWildcard) handlers.onSchoolSuggestWildcard?.();
+    if (schoolGenerateFinalMatches) handlers.onSchoolGenerateFinalMatches?.();
+    if (schoolFinalCurrent) handlers.onSchoolFinalMatchSetCurrent?.(schoolFinalCurrent);
+    if (schoolFinalClear) handlers.onSchoolFinalMatchClearResult?.(schoolFinalClear);
     const schoolExport = e.target.closest('[data-school-export-json]');
-    if (schoolExport) handlers.onSchoolExportJson();
+    if (schoolExport) handlers.onSchoolExportJson?.();
   });
 
   document.addEventListener('input', (e) => {
@@ -984,17 +984,17 @@ export function bindUiEvents(handlers) {
     if (tournamentNameInput) handlers.onTournamentName(tournamentNameInput.value);
     const schoolTitle = e.target.closest('[data-school-title]');
     const schoolDate = e.target.closest('[data-school-date]');
-    if (schoolTitle) handlers.onSchoolTitleChange(schoolTitle.value);
-    if (schoolDate) handlers.onSchoolDateChange(schoolDate.value);
+    if (schoolTitle) handlers.onSchoolTitleChange?.(schoolTitle.value);
+    if (schoolDate) handlers.onSchoolDateChange?.(schoolDate.value);
     const schoolMetaInput = e.target.closest('[data-school-meta]');
-    if (schoolMetaInput) handlers.onSchoolMetaChange(schoolMetaInput.dataset.schoolMeta, schoolMetaInput.dataset.schoolMetaField, schoolMetaInput.value);
+    if (schoolMetaInput) handlers.onSchoolMetaChange?.(schoolMetaInput.dataset.schoolMeta, schoolMetaInput.dataset.schoolMetaField, schoolMetaInput.value);
     const scoreA = e.target.closest('[data-school-group-score-a]');
     const scoreB = e.target.closest('[data-school-group-score-b]');
     if (scoreA || scoreB) {
       const matchId = scoreA?.dataset.schoolGroupScoreA || scoreB?.dataset.schoolGroupScoreB;
       const inputA = document.querySelector(`[data-school-group-score-a="${escapeAttr(matchId)}"]`);
       const inputB = document.querySelector(`[data-school-group-score-b="${escapeAttr(matchId)}"]`);
-      handlers.onSchoolGroupMatchScoreChange(matchId, inputA?.value ?? '', inputB?.value ?? '');
+      handlers.onSchoolGroupMatchScoreChange?.(matchId, inputA?.value ?? '', inputB?.value ?? '');
     }
     const finalA = e.target.closest('[data-school-final-score-a]');
     const finalB = e.target.closest('[data-school-final-score-b]');
@@ -1002,12 +1002,12 @@ export function bindUiEvents(handlers) {
       const matchId = finalA?.dataset.schoolFinalScoreA || finalB?.dataset.schoolFinalScoreB;
       const inputA = document.querySelector(`[data-school-final-score-a="${escapeAttr(matchId)}"]`);
       const inputB = document.querySelector(`[data-school-final-score-b="${escapeAttr(matchId)}"]`);
-      handlers.onSchoolFinalMatchScoreChange(matchId, inputA?.value ?? '', inputB?.value ?? '');
+      handlers.onSchoolFinalMatchScoreChange?.(matchId, inputA?.value ?? '', inputB?.value ?? '');
     }
     const wildcardSelect = e.target.closest('[data-school-wildcard-select]');
-    if (wildcardSelect) handlers.onSchoolWildcardSelect(wildcardSelect.value);
+    if (wildcardSelect) handlers.onSchoolWildcardSelect?.(wildcardSelect.value);
     const wildcardToggle = e.target.closest('[data-school-wildcard-enabled]');
-    if (wildcardToggle) handlers.onSchoolWildcardToggle(Boolean(wildcardToggle.checked));
+    if (wildcardToggle) handlers.onSchoolWildcardToggle?.(Boolean(wildcardToggle.checked));
   });
 
   document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
### Motivation
- Balance2 failed to start due to a runtime/parse error introduced with recent school-mode changes and that needed a minimal emergency fix to restore startup without adding features. 
- The goal was to make school-related code defensive so tournament mode always starts and corrupted/incomplete school draft/state cannot crash the page. 

### Description
- Fixed a fatal parse/runtime error in `handleSaveSchoolEvent` message formatting (unterminated string) to prevent module load failure in `v2/scripts/balance2/app.js`. 
- Added `ensureSchoolState()` in `v2/scripts/balance2/app.js` (and imported `createSchoolEventDraft`) to normalize and provide safe defaults for `state.schoolState` fields like `groups`, `groupStandings`, `qualifiers`, `wildcard`, `finalGroup`, and `teamMeta`. 
- Hardened school-draft restore flow in `v2/scripts/balance2/app.js` to detect a `school` draft, hydrate `state.schoolState`, set `state.app.eventMode = 'school'`, call `ensureSchoolState()`, and surface an error instead of crashing on corrupted drafts. 
- Made `doSave` routing explicit so `school` calls `handleSaveSchoolEvent`, `tournament` calls `handleSaveTournamentGame`, and other cases fall back to the legacy `saveMatch` flow. 
- Guarded school UI event handler calls in `v2/scripts/balance2/ui.js` using optional chaining (e.g. `handlers.onSchoolBuildTeams?.()`) so missing/undefined school handlers do not throw and do not break tournament flow. 
- Added a smoke import test `tests/balance2Import.test.mjs` that stubs a minimal browser environment and asserts that core balance2 modules (`app.js`, `ui.js`, `state.js`, `schoolPayload.js`, `validation.js`, `schoolMode.js`) import without errors. 

### Testing
- Ran `node --check` on the requested balance2 modules: `app.js`, `ui.js`, `state.js`, `storage.js`, `schoolPayload.js`, `schoolMode.js`, and `validation.js`, all succeeded. 
- Ran unit tests: `node --test tests/schoolMode.test.mjs` passed. 
- Ran the new smoke test `node --test tests/balance2Import.test.mjs` which passed under a browser-like stubbed environment. 
- Ran full test set `node --test tests/*.test.mjs` and observed all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c227dfa88321bcabd18e20a7d196)