### PR TITLE
Resolve merge conflict in balance2 save flow and restore school save hotfixes

### DIFF
--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -707,7 +707,7 @@ function markScheduledMatchPlayed(resultSummary) {
 }
 
 async function doSave(retry = false) {
-  const eventMode = state.app?.eventMode === 'school' ? 'school' : 'tournament';
+  const eventMode = state.app?.eventMode;
   debugLog('[balance2:save] mode', eventMode);
   const error = validateSave();
   if (error) {
@@ -723,12 +723,15 @@ async function doSave(retry = false) {
     return;
   }
 
-  if (eventMode === 'tournament') {
-    await handleSaveTournamentGame(retry);
-    return;
+  if (eventMode === 'school') {
+    return handleSaveSchoolEvent(retry);
   }
 
-  await handleSaveSchoolEvent(retry);
+  if (eventMode === 'tournament') {
+    return handleSaveTournamentGame(retry);
+  }
+
+  return handleSaveRegularGame(retry);
 }
 
 async function handleSaveTournamentGame(retry = false) {
@@ -878,9 +881,7 @@ async function handleSaveSchoolEvent(retry = false) {
   state.meta.lastPayload = payload;
   const valid = validateSchoolEvent(payload);
   if (!valid.ok) {
-    const message = `Некоректні дані шкільного турніру:
-- ${valid.errors.join('
-- ')}`;
+    const message = `Некоректні дані шкільного турніру:\n- ${valid.errors.join('\n- ')}`;
     setSaveFeedback('error', valid.errors[0] || 'Некоректні дані шкільного турніру', { renderNow: false });
     setStatus({ state: 'error', text: `❌ ${message}`, retryVisible: false });
     renderAndSync();


### PR DESCRIPTION
### Motivation
- Safely resolve a merge conflict in `v2/scripts/balance2/app.js` while preserving recent hotfixes that fixed critical school save behavior and a broken validation string. 
- Ensure save routing clearly separates `school`, `tournament`, and fallback legacy/regular save flows so each path uses its dedicated handler. 
- Keep school-related utilities and draft behavior intact (`handleSaveSchoolEvent`, `downloadSchoolPayloadJson`, `saveSchoolDraft`, `buildSchoolEventPayload` and restore/draft UI paths). 

### Description
- Rewrote `doSave` routing to use explicit branches based on `state.app?.eventMode` with clear returns: `school -> handleSaveSchoolEvent`, `tournament -> handleSaveTournamentGame`, and fallback -> `handleSaveRegularGame` (legacy/regular path). 
- Restored and kept `handleSaveSchoolEvent`, `downloadSchoolPayloadJson`, and draft clearing/restore interactions unchanged, and preserved `saveSchoolDraft`/`buildSchoolEventPayload` call sites. 
- Fixed the school validation message formatting to avoid the prior unterminated-string regression by building the message with `\n- ${valid.errors.join('\n- ')}`. 
- Removed conflict markers and adjusted `eventMode` extraction to `state.app?.eventMode` so branches behave correctly. 

### Testing
- Ran syntax/type checks: `node --check v2/scripts/balance2/app.js`, `node --check v2/scripts/balance2/ui.js`, `node --check v2/scripts/balance2/state.js`, `node --check v2/scripts/balance2/storage.js`, `node --check v2/scripts/balance2/schoolPayload.js`, `node --check v2/scripts/balance2/schoolMode.js`, and `node --check v2/scripts/balance2/validation.js`, all succeeded. 
- Ran unit tests with `node --test tests/*.test.mjs` and `node --test tests/schoolMode.test.mjs`, all executed tests passed (no failures). 
- Attempted to run `tests/balance2Import.test.mjs` as requested but the file does not exist in the repository, so that specific test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c4a70e408321a39adfe136c8743e)