### PR TITLE
Hotfix: cache-bust balance2 assets so updated School UI loads in production

### DIFF
--- a/v2/balance2.html
+++ b/v2/balance2.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LaserTag v2 · Балансер</title>
-  <script type="module" src="./pages/global-styles.js"></script>
-  <link rel="stylesheet" href="./assets/styles.css">
-  <link rel="stylesheet" href="./styles/balance2.css">
+  <script type="module" src="./pages/global-styles.js?v=20260525a"></script>
+  <link rel="stylesheet" href="./assets/styles.css?v=20260525a">
+  <link rel="stylesheet" href="./styles/balance2.css?v=20260525a">
 </head>
 <body>
   <main class="balance2-root">
@@ -115,6 +115,6 @@
     </section>
   </main>
 
-  <script type="module" src="./scripts/balance2/app.js"></script>
+  <script type="module" src="./scripts/balance2/app.js?v=20260525a"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Production was serving stale cached assets for the Balance2 page which prevented the updated School workflow and the Tournament/School switcher from appearing for users, so a cache-bust is required to force browsers/CDNs to fetch the new JS/CSS that already contains the school UI.

### Description
- Added version query parameters to asset references in `v2/balance2.html` for `./pages/global-styles.js`, `./assets/styles.css`, `./styles/balance2.css`, and `./scripts/balance2/app.js` to invalidate caches and ensure updated bundles are loaded.

### Testing
- Ran JavaScript syntax checks which succeeded: `node --check v2/scripts/balance2/app.js` and `node --check v2/scripts/balance2/ui.js` (OK). 
- Verified there are no merge conflict markers in the main school app file using `rg -n '<<<<<<<|=======|>>>>>>>' v2/scripts/balance2/app.js` (no matches). 
- Attempted an automated fetch of the production URL to validate the live page, but the request returned HTTP 403 from this environment so live production verification could not be completed here (network fetch failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c608145483218b287a5bc9c99d1a)