### PR TITLE
Increase tournament limits: support up to 50 players and 12 teams

### DIFF
--- a/tests/schoolMode.test.mjs
+++ b/tests/schoolMode.test.mjs
@@ -240,5 +240,5 @@ test('getSchoolWorkflowStage resolves expected flow', () => {
 });
 
 test('tournament mode options unchanged', () => {
-  assert.deepEqual(getTeamCountOptionsForEventMode('tournament'), [2, 3, 4, 5, 6]);
+  assert.deepEqual(getTeamCountOptionsForEventMode('tournament'), [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 });

--- a/tests/tournamentModeLimits.test.mjs
+++ b/tests/tournamentModeLimits.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  TEAM_KEYS,
+  normalizeTeamCount,
+  getTeamCountOptionsForEventMode,
+  getMaxLobbyPlayersForEventMode,
+} from '../v2/scripts/balance2/state.js';
+import { balanceIntoNTeams } from '../v2/scripts/balance2/balance.js';
+
+test('tournament max players is 50', () => {
+  assert.equal(getMaxLobbyPlayersForEventMode('tournament'), 50);
+});
+
+test('tournament team options are 2..12', () => {
+  assert.deepEqual(getTeamCountOptionsForEventMode('tournament'), [2,3,4,5,6,7,8,9,10,11,12]);
+});
+
+test('team keys include team1..team12', () => {
+  assert.equal(TEAM_KEYS.length, 12);
+  assert.equal(TEAM_KEYS[0], 'team1');
+  assert.equal(TEAM_KEYS[11], 'team12');
+});
+
+test('normalizeTeamCount allows 12', () => {
+  assert.equal(normalizeTeamCount(12), 12);
+  assert.equal(normalizeTeamCount(99), 12);
+});
+
+test('balance 50 players into 12 teams without losing players or duplicates', () => {
+  const players = Array.from({ length: 50 }, (_, i) => ({ nick: `P${i + 1}`, points: 50 - i }));
+  const teams = balanceIntoNTeams(players, 12);
+  const activeTeams = TEAM_KEYS.slice(0, 12);
+  const assigned = activeTeams.flatMap((key) => teams[key] || []);
+  assert.equal(assigned.length, 50);
+
+  const nicks = assigned.map((p) => p.nick);
+  assert.equal(new Set(nicks).size, 50);
+  assert.deepEqual(new Set(nicks), new Set(players.map((p) => p.nick)));
+});

--- a/v2/scripts/balance2/balance.js
+++ b/v2/scripts/balance2/balance.js
@@ -35,9 +35,9 @@ export function autoBalance2(players) {
 }
 
 export function balanceIntoNTeams(players, n) {
-  const teamCount = Math.min(6, Math.max(2, Number(n) || 2));
+  const teamCount = Math.min(12, Math.max(2, Number(n) || 2));
   const sorted = [...players].sort((a, b) => ((Number(b.pts ?? b.points) || 0) - (Number(a.pts ?? a.points) || 0)) || a.nick.localeCompare(b.nick, 'uk'));
-  const teams = { team1: [], team2: [], team3: [], team4: [], team5: [], team6: [] };
+  const teams = Object.fromEntries(Array.from({ length: 12 }, (_, idx) => [`team${idx + 1}`, []]));
   const targets = Array.from({ length: teamCount }, (_, i) => Math.floor(players.length / teamCount) + (i < players.length % teamCount ? 1 : 0));
 
   for (const player of sorted) {

--- a/v2/scripts/balance2/manual.js
+++ b/v2/scripts/balance2/manual.js
@@ -1,10 +1,7 @@
-import { state, syncSelectedMap, MAX_LOBBY_PLAYERS } from './state.js';
+import { state, syncSelectedMap, getMaxLobbyPlayersForEventMode, TEAM_KEYS } from './state.js';
 
 export function clearTeams() {
-  state.teamsState.teams.team1 = [];
-  state.teamsState.teams.team2 = [];
-  state.teamsState.teams.team3 = [];
-  state.teamsState.teams.team4 = [];
+  TEAM_KEYS.forEach((teamKey) => { state.teamsState.teams[teamKey] = []; });
 }
 
 export function syncSelectedFromTeamsAndBench() {
@@ -13,7 +10,7 @@ export function syncSelectedFromTeamsAndBench() {
   for (const nick of state.playersState.selected) {
     if (!inTeams.has(nick)) withBench.push(nick);
   }
-  state.playersState.selected = [...new Set(withBench)].slice(0, MAX_LOBBY_PLAYERS);
+  state.playersState.selected = [...new Set(withBench)].slice(0, getMaxLobbyPlayersForEventMode(state.app.eventMode));
   syncSelectedMap();
 }
 

--- a/v2/scripts/balance2/state.js
+++ b/v2/scripts/balance2/state.js
@@ -1,13 +1,14 @@
 import { rankFromPoints } from '../../core/rankRules.js';
 
 export const MAX_SERIES_ROUNDS = 10;
-export const MAX_LOBBY_PLAYERS = 30;
+export const TOURNAMENT_MAX_PLAYERS = 50;
+export const MAX_LOBBY_PLAYERS = TOURNAMENT_MAX_PLAYERS;
 export const TEAM_KEYS = Array.from({ length: 12 }, (_, i) => `team${i + 1}`);
-export const TEAM_COUNT_OPTIONS = [2, 3, 4, 5, 6];
+export const TEAM_COUNT_OPTIONS = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 export const SCHOOL_TEAM_COUNT = 10;
 export const MIN_TEAM_COUNT = 2;
 export const MAX_TEAM_COUNT = 12;
-export const TOURNAMENT_MAX_TEAM_COUNT = 6;
+export const TOURNAMENT_MAX_TEAM_COUNT = 12;
 
 export const state = {
   app: {
@@ -120,7 +121,7 @@ export function getMaxTeamCountForCurrentMode() {
 }
 
 export function getMaxLobbyPlayersForEventMode(eventMode = state.app.eventMode) {
-  return eventMode === 'school' ? 50 : MAX_LOBBY_PLAYERS;
+  return eventMode === 'school' ? 50 : TOURNAMENT_MAX_PLAYERS;
 }
 
 export function sortByPointsDesc(a, b) {


### PR DESCRIPTION
### Motivation
- Restore and simplify tournament flow by avoiding a separate school workflow and making the existing tournament mode handle larger events. 
- Raise the tournament lobby cap so admins can select up to `50` players and increase the maximum team count to `12` to support larger tournaments. 
- Keep changes minimal and backward-compatible so school-specific code does not break the tournament flow.

### Description
- Raise player limit: introduced `TOURNAMENT_MAX_PLAYERS = 50` and made `getMaxLobbyPlayersForEventMode('tournament')` return `50` so UI/validation/restore use the new cap (`v2/scripts/balance2/state.js`).
- Expand teams to 12: updated `TEAM_KEYS` to `team1..team12`, `TEAM_COUNT_OPTIONS` to `[2..12]`, and `TOURNAMENT_MAX_TEAM_COUNT = 12` to allow 2–12 teams (`v2/scripts/balance2/state.js`).
- Balance & manual logic updated: `balanceIntoNTeams` now supports up to 12 teams and builds `team1..team12`, and manual helpers (`clearTeams`, `syncSelectedFromTeamsAndBench`) now use `TEAM_KEYS` and a mode-aware player cap helper (`v2/scripts/balance2/balance.js`, `v2/scripts/balance2/manual.js`).
- Tests & expectations: added `tests/tournamentModeLimits.test.mjs` covering max players, team options, team keys, normalizeTeamCount, and balancing 50 players into 12 teams; updated `tests/schoolMode.test.mjs` expectation for tournament options.

### Testing
- Static checks run: `node --check v2/scripts/balance2/app.js`, `node --check v2/scripts/balance2/ui.js`, `node --check v2/scripts/balance2/state.js`, `node --check v2/scripts/balance2/storage.js`, `node --check v2/scripts/balance2/balance.js`, `node --check v2/scripts/balance2/manual.js`, and `node --check v2/scripts/balance2/api.js` all completed without errors. 
- Unit tests run: `node --test tests/*.test.mjs` and the test suite passed (38 tests, 0 failures). 
- Files changed: `v2/scripts/balance2/state.js`, `v2/scripts/balance2/balance.js`, `v2/scripts/balance2/manual.js`, `tests/schoolMode.test.mjs`, and new `tests/tournamentModeLimits.test.mjs`, and all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14cc57eb8883219bb9f5160d3658cd)