### PR TITLE
[codex] fix balance2 tournament restore after reload

### DIFF
--- a/tests/balance2StorageRestore.test.mjs
+++ b/tests/balance2StorageRestore.test.mjs
@@ -1,0 +1,204 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  state,
+  TEAM_KEYS,
+  syncSelectedMap,
+} from '../v2/scripts/balance2/state.js';
+import { restoreLobby } from '../v2/scripts/balance2/storage.js';
+
+const LOBBY_KEY = 'balance2:lobby';
+
+class LocalStorageMock {
+  constructor() {
+    this.store = new Map();
+  }
+
+  getItem(key) {
+    return this.store.has(key) ? this.store.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.store.set(key, String(value));
+  }
+
+  removeItem(key) {
+    this.store.delete(key);
+  }
+
+  clear() {
+    this.store.clear();
+  }
+}
+
+globalThis.localStorage = new LocalStorageMock();
+
+const defaultTournamentState = structuredClone(state.tournamentState);
+
+function resetBalanceState() {
+  localStorage.clear();
+  state.app.league = 'kids';
+  state.app.playerSourceMode = 'kids';
+  state.app.mode = 'auto';
+  state.app.eventMode = 'tournament';
+  state.app.sortMode = 'points_desc';
+  state.app.query = '';
+  state.playersState.selected = [];
+  state.playersState.players = [];
+  state.playersState.playersLoaded = false;
+  syncSelectedMap();
+  state.teamsState.teamCount = 2;
+  state.teamsState.teams = Object.fromEntries(TEAM_KEYS.map((key) => [key, []]));
+  state.teamsState.teamNames = Object.fromEntries(TEAM_KEYS.map((key, idx) => [key, `Команда ${idx + 1}`]));
+  state.matchState.seriesCount = 3;
+  state.matchState.seriesRounds = Array(10).fill(null);
+  state.matchState.series = Array(10).fill('-');
+  state.matchState.match = { winner: '', series: '', mvp1: '', mvp2: '', mvp3: '', mvp1Key: '', mvp2Key: '', mvp3Key: '', penalties: {} };
+  state.tournamentState = structuredClone(defaultTournamentState);
+  state.activeTeamAId = 'team1';
+  state.activeTeamBId = 'team2';
+  state.uiState = { penaltiesCollapsed: true };
+}
+
+function writeLobbySnapshot(snapshot) {
+  localStorage.setItem(LOBBY_KEY, JSON.stringify(snapshot));
+}
+
+test('restoreLobby preserves mixed tournament source, tournament fields, MVP keys and 50/12 state', () => {
+  resetBalanceState();
+  const selected = Array.from({ length: 50 }, (_, idx) => `p${idx + 1}`);
+  const teams = Object.fromEntries(TEAM_KEYS.map((key, idx) => [key, [`p${idx + 1}`]]));
+  const teamNames = Object.fromEntries(TEAM_KEYS.map((key, idx) => [key, `Squad ${idx + 1}`]));
+  const tournamentSchedule = [
+    { gameId: 'G001', teamA: 'team1', teamB: 'team2', status: 'completed' },
+    { gameId: 'G002', teamA: 'team3', teamB: 'team4', status: 'pending' },
+  ];
+
+  writeLobbySnapshot({
+    app: {
+      league: 'kids',
+      mode: 'manual',
+      eventMode: 'tournament',
+      playerSourceMode: 'mixed',
+      sortMode: 'name_asc',
+    },
+    playersState: { selected },
+    teamsState: { teamCount: 12, teams, teamNames },
+    matchState: {
+      seriesCount: 10,
+      series: ['1', '2', '0'],
+      match: {
+        winner: 'team1',
+        series: '120',
+        mvp1: 'Alex',
+        mvp2: 'Sam',
+        mvp3: 'Kim',
+        mvp1Key: 'kids:alex',
+        mvp2Key: 'sg:sam',
+        mvp3Key: 'kids:kim',
+        penalties: { p1: 1 },
+      },
+    },
+    tournamentState: {
+      tournamentId: 'T-123',
+      tournamentName: 'May Cup',
+      tournamentTitle: 'May Cup title',
+      gameMode: 'TR',
+      teamsSaved: true,
+      savedTournamentTeamIds: TEAM_KEYS,
+      tournamentType: 'group',
+      tournamentSchedule,
+      games: [{ gameId: 'G001' }],
+      teams: [{ teamId: 'team1' }],
+      createdAt: '2026-05-25T20:00:00.000Z',
+      updatedAt: '2026-05-25T21:00:00.000Z',
+      currentScheduleGameId: 'G002',
+      gamesCreated: true,
+      currentGameId: 'G002',
+      nextGameNumber: 7,
+      isSaving: true,
+      status: { message: 'Ready', type: 'success' },
+      lastAction: 'saveTeams',
+      lastRequestStatus: 'OK',
+      lastErrorMessage: '',
+    },
+    activeTeamAId: 'team3',
+    activeTeamBId: 'team4',
+    uiState: { penaltiesCollapsed: false },
+  });
+
+  assert.equal(restoreLobby(), true);
+  assert.equal(state.app.playerSourceMode, 'mixed');
+  assert.equal(state.app.eventMode, 'tournament');
+  assert.equal(state.teamsState.teamCount, 12);
+  assert.equal(state.playersState.selected.length, 50);
+  assert.deepEqual(state.playersState.selected, selected);
+  assert.equal(Object.keys(state.teamsState.teams).length, 12);
+  assert.deepEqual(state.teamsState.teams.team12, ['p12']);
+  assert.equal(state.teamsState.teamNames.team12, 'Squad 12');
+  assert.equal(state.matchState.seriesCount, 10);
+  assert.equal(state.matchState.match.mvp1Key, 'kids:alex');
+  assert.equal(state.matchState.match.mvp2Key, 'sg:sam');
+  assert.equal(state.matchState.match.mvp3Key, 'kids:kim');
+  assert.equal(state.tournamentState.tournamentType, 'group');
+  assert.equal(state.tournamentState.tournamentTitle, 'May Cup title');
+  assert.deepEqual(state.tournamentState.savedTournamentTeamIds, TEAM_KEYS);
+  assert.deepEqual(state.tournamentState.tournamentSchedule, tournamentSchedule);
+  assert.deepEqual(state.tournamentState.games, [{ gameId: 'G001' }]);
+  assert.deepEqual(state.tournamentState.teams, [{ teamId: 'team1' }]);
+  assert.equal(state.tournamentState.createdAt, '2026-05-25T20:00:00.000Z');
+  assert.equal(state.tournamentState.updatedAt, '2026-05-25T21:00:00.000Z');
+  assert.equal(state.tournamentState.currentScheduleGameId, 'G002');
+  assert.equal(state.tournamentState.currentGameId, 'G002');
+  assert.deepEqual(state.tournamentState.status, { message: 'Ready', type: 'success' });
+  assert.equal(state.tournamentState.lastAction, 'saveTeams');
+  assert.equal(state.tournamentState.lastRequestStatus, 'OK');
+  assert.equal(state.tournamentState.isSaving, false);
+  assert.equal(state.activeTeamAId, 'team3');
+  assert.equal(state.activeTeamBId, 'team4');
+});
+
+test('restoreLobby keeps old snapshots backward compatible', () => {
+  resetBalanceState();
+  writeLobbySnapshot({
+    app: { eventMode: 'tournament' },
+    selected: ['p1', 'p2'],
+    teamCount: 6,
+    teams: { team1: ['p1'], team6: ['p2'] },
+    match: { mvp1: 'Old MVP' },
+    tournamentState: { tournamentId: 'OLD-1', teamsSaved: true },
+  });
+
+  assert.equal(restoreLobby(), true);
+  assert.equal(state.app.playerSourceMode, 'kids');
+  assert.equal(state.teamsState.teamCount, 6);
+  assert.deepEqual(state.teamsState.teams.team1, ['p1']);
+  assert.deepEqual(state.teamsState.teams.team6, ['p2']);
+  assert.deepEqual(state.teamsState.teams.team12, []);
+  assert.equal(state.matchState.match.mvp1, 'Old MVP');
+  assert.equal(state.matchState.match.mvp1Key, '');
+  assert.equal(state.tournamentState.tournamentId, 'OLD-1');
+  assert.equal(state.tournamentState.teamsSaved, true);
+  assert.equal(state.tournamentState.tournamentType, 'custom');
+  assert.deepEqual(state.tournamentState.savedTournamentTeamIds, []);
+});
+
+test('restoreLobby ignores corrupted tournamentState safely', () => {
+  resetBalanceState();
+  writeLobbySnapshot({
+    app: { eventMode: 'tournament', playerSourceMode: 'mixed' },
+    playersState: { selected: ['p1'] },
+    teamsState: { teamCount: 12, teams: { team12: ['p1'] } },
+    tournamentState: 'not an object',
+  });
+
+  assert.equal(restoreLobby(), true);
+  assert.equal(state.app.playerSourceMode, 'mixed');
+  assert.equal(state.teamsState.teamCount, 12);
+  assert.deepEqual(state.teamsState.teams.team12, ['p1']);
+  assert.equal(state.tournamentState.tournamentId, '');
+  assert.equal(state.tournamentState.tournamentType, 'custom');
+  assert.deepEqual(state.tournamentState.tournamentSchedule, []);
+  assert.deepEqual(state.tournamentState.status, { message: '', type: 'idle' });
+});

--- a/v2/scripts/balance2/app.js
+++ b/v2/scripts/balance2/app.js
@@ -49,6 +49,10 @@ const MVP_IDS = ['mvp1', 'mvp2', 'mvp3'];
 const MIXED_MVP_DUPLICATE_WARNING = 'Уточни MVP: є кілька гравців з таким ніком у різних лігах';
 const MIXED_MVP_SAVE_BLOCK = 'Уточни MVP: вибери гравця зі списку';
 let saveLocked = false;
+
+function isPlainObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
 let saveStatusResetTimer = 0;
 
 function escapeAttr(value = '') {
@@ -1077,7 +1081,11 @@ async function init() {
   $('restoreBtn')?.addEventListener('click', async () => {
     if (hasSchoolDraft) {
       const draft = peekSchoolDraft();
-      if (!draft) return;
+      if (!isPlainObject(draft)) {
+        setStatus({ state: 'error', text: 'Чернетка шкільного турніру пошкоджена. Видаліть чернетку або почніть заново.', retryVisible: false });
+        renderAndSync();
+        return;
+      }
       state.app.eventMode = 'school';
       state.schoolState = {
         ...state.schoolState,
@@ -1099,8 +1107,6 @@ async function init() {
     renderAndSync();
   });
 
-  $('balanceBtn')?.addEventListener('click', () => { runBalance(); renderAndSync(); });
-  $('manualBtn')?.addEventListener('click', () => { state.app.mode = 'manual'; ensureTeamsForManualAssignment(); syncSelectedFromTeamsAndBench(); ensureActiveMatchState(); setTournamentDirty(); saveLobby(); renderAndSync(); });
   $('clearLobbyBtn')?.addEventListener('click', () => { state.playersState.selected = []; syncSelectedMap(); clearAllTeams(); ensureActiveMatchState(); setTournamentDirty(); saveLobby(); renderAndSync(); });
 
   const debouncedSearch = (() => {

--- a/v2/scripts/balance2/storage.js
+++ b/v2/scripts/balance2/storage.js
@@ -1,6 +1,7 @@
 import {
   state,
   normalizeLeague,
+  normalizePlayerSourceMode,
   computeSeriesSummary,
   syncSelectedMap,
   getMaxLobbyPlayersForEventMode,
@@ -13,6 +14,70 @@ const KEY = 'balance2:lobby';
 const PLAYERS_KEY = 'balance2:playersCache';
 const LAST_GAME_KEY = 'balance2:lastSavedGame';
 export const SCHOOL_DRAFT_KEY = 'balance2_school_draft';
+
+function isPlainObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function pickString(value, fallback = '') {
+  return value === undefined || value === null ? fallback : String(value);
+}
+
+function pickBoolean(value, fallback = false) {
+  return value === undefined ? fallback : value === true;
+}
+
+function sanitizeTournamentStatus(value, fallback = { message: '', type: 'idle' }) {
+  if (!isPlainObject(value)) return { ...fallback };
+  return {
+    message: pickString(value.message, fallback.message || ''),
+    type: pickString(value.type, fallback.type || 'idle') || 'idle',
+  };
+}
+
+function pickCollection(value, fallback) {
+  if (Array.isArray(value)) return value;
+  if (isPlainObject(value)) return value;
+  if (Array.isArray(fallback) || isPlainObject(fallback)) return fallback;
+  return undefined;
+}
+
+function sanitizeTournamentState(restoredTournamentState) {
+  const fallback = isPlainObject(state.tournamentState) ? { ...state.tournamentState } : {};
+  const restored = isPlainObject(restoredTournamentState) ? restoredTournamentState : {};
+  const definedRestored = Object.fromEntries(Object.entries(restored).filter(([, value]) => value !== undefined));
+  const games = pickCollection(restored.games, fallback.games);
+  const teams = pickCollection(restored.teams, fallback.teams);
+
+  const next = {
+    ...fallback,
+    ...definedRestored,
+    tournamentId: pickString(restored.tournamentId, fallback.tournamentId || ''),
+    tournamentTitle: pickString(restored.tournamentTitle, fallback.tournamentTitle || restored.tournamentName || fallback.tournamentName || ''),
+    tournamentName: pickString(restored.tournamentName ?? restored.tournamentTitle, fallback.tournamentName || ''),
+    gameMode: ['DM', 'TR', 'KT'].includes(restored.gameMode) ? restored.gameMode : (fallback.gameMode || 'DM'),
+    teamsSaved: pickBoolean(restored.teamsSaved, fallback.teamsSaved === true),
+    savedTournamentTeamIds: Array.isArray(restored.savedTournamentTeamIds)
+      ? restored.savedTournamentTeamIds.filter((key) => TEAM_KEYS.includes(key))
+      : (Array.isArray(fallback.savedTournamentTeamIds) ? fallback.savedTournamentTeamIds : []),
+    tournamentType: restored.tournamentType === 'group' ? 'group' : (restored.tournamentType === 'custom' ? 'custom' : (fallback.tournamentType || 'custom')),
+    tournamentSchedule: Array.isArray(restored.tournamentSchedule) ? restored.tournamentSchedule : (Array.isArray(fallback.tournamentSchedule) ? fallback.tournamentSchedule : []),
+    currentScheduleGameId: pickString(restored.currentScheduleGameId, fallback.currentScheduleGameId || ''),
+    gamesCreated: pickBoolean(restored.gamesCreated, fallback.gamesCreated === true),
+    currentGameId: pickString(restored.currentGameId, fallback.currentGameId || ''),
+    nextGameNumber: Math.max(1, Number(restored.nextGameNumber ?? fallback.nextGameNumber) || 1),
+    isSaving: false,
+    status: sanitizeTournamentStatus(restored.status, fallback.status),
+    lastAction: pickString(restored.lastAction, fallback.lastAction || ''),
+    lastRequestStatus: pickString(restored.lastRequestStatus, fallback.lastRequestStatus || ''),
+    lastErrorMessage: pickString(restored.lastErrorMessage, fallback.lastErrorMessage || ''),
+    createdAt: pickString(restored.createdAt, fallback.createdAt || ''),
+    updatedAt: pickString(restored.updatedAt, fallback.updatedAt || ''),
+  };
+  if (games !== undefined) next.games = games;
+  if (teams !== undefined) next.teams = teams;
+  return next;
+}
 
 export function saveLobby() {
   const data = {
@@ -46,6 +111,7 @@ export function restoreLobby() {
     : 'points_desc';
   const restoredEventMode = data?.app?.eventMode;
   state.app.eventMode = (restoredEventMode === 'school' ? 'school' : 'tournament');
+  state.app.playerSourceMode = normalizePlayerSourceMode(data?.app?.playerSourceMode || data?.playerSourceMode || state.app.playerSourceMode, state.app.eventMode);
   state.app.query = '';
 
   state.playersState.selected = Array.isArray(data?.playersState?.selected || data?.selected)
@@ -74,6 +140,9 @@ export function restoreLobby() {
     mvp1: oldMatch.mvp1 || '',
     mvp2: oldMatch.mvp2 || '',
     mvp3: oldMatch.mvp3 || '',
+    mvp1Key: oldMatch.mvp1Key || '',
+    mvp2Key: oldMatch.mvp2Key || '',
+    mvp3Key: oldMatch.mvp3Key || '',
     penalties: oldMatch.penalties && typeof oldMatch.penalties === 'object' ? oldMatch.penalties : {},
   };
 
@@ -84,20 +153,15 @@ export function restoreLobby() {
     schedule: Array.isArray(data?.activeMatch?.schedule) ? data.activeMatch.schedule : [],
     selectedScheduleMatchId: data?.activeMatch?.selectedScheduleMatchId || '',
   };
-  const tournamentState = data?.tournamentState || {};
-  state.tournamentState = {
-    tournamentId: tournamentState.tournamentId || '',
-    tournamentName: tournamentState.tournamentName || '',
-    gameMode: ['DM', 'TR', 'KT'].includes(tournamentState.gameMode) ? tournamentState.gameMode : 'DM',
-    teamsSaved: tournamentState.teamsSaved === true,
-    gamesCreated: tournamentState.gamesCreated === true,
-    currentGameId: tournamentState.currentGameId || '',
-    nextGameNumber: Math.max(1, Number(tournamentState.nextGameNumber) || 1),
-  };
-  state.activeTeamAId = data?.activeTeamAId || 'team1';
-  state.activeTeamBId = data?.activeTeamBId || 'team2';
+  state.tournamentState = sanitizeTournamentState(data?.tournamentState);
+  state.activeTeamAId = TEAM_KEYS.includes(data?.activeTeamAId) ? data.activeTeamAId : 'team1';
+  state.activeTeamBId = TEAM_KEYS.includes(data?.activeTeamBId) ? data.activeTeamBId : 'team2';
 
-  state.uiState.penaltiesCollapsed = data?.uiState?.penaltiesCollapsed !== false;
+  state.uiState = {
+    ...state.uiState,
+    ...(isPlainObject(data?.uiState) ? data.uiState : {}),
+    penaltiesCollapsed: data?.uiState?.penaltiesCollapsed !== false,
+  };
 
   const summary = computeSeriesSummary();
   state.matchState.match.winner = summary.winner;


### PR DESCRIPTION
## Summary

This hotfix stabilizes Balance2 persistence/restore after tournament mode was expanded to 50 players and 12 teams.

What was fixed:
- restore `playerSourceMode`, including preserving mixed tournament mode after reload
- restore MVP key fields: `mvp1Key`, `mvp2Key`, `mvp3Key`
- add safe merge/default guards for `tournamentState`
- restore `tournamentType`, `status`, `tournamentSchedule`, `currentScheduleGameId`, `currentGameId`, and `savedTournamentTeamIds`
- preserve optional tournament fields such as `tournamentTitle`, `games`, `teams`, `createdAt`, and `updatedAt` when present
- restore 50 selected players without truncating to old limits
- restore `team1` through `team12` and team names
- keep old or corrupted snapshots from crashing Balance2
- guard corrupted school drafts without doing a school-mode refactor
- remove dead legacy `balanceBtn` / `manualBtn` listeners now that primary actions use delegated handlers

## Tests

Passing:
- `node --check v2/scripts/balance2/storage.js`
- `node --check v2/scripts/balance2/state.js`
- `node --check v2/scripts/balance2/app.js`
- `node --test tests\tournamentModeLimits.test.mjs tests\balance2PlayerSelection.test.mjs tests\schoolMode.test.mjs tests\balance2StorageRestore.test.mjs` — 34 pass
- `git diff --check`

Full suite note:
- `node --test tests/*.test.mjs` has one unrelated failure in `tests/gamedayParse.test.mjs`.
- The failure is caused by Node 24 rejecting assignment to `globalThis.navigator` because it is getter-only.
- This fail is not related to the Balance2 hotfix.
- Balance2-related tests pass: `tournamentModeLimits`, `balance2PlayerSelection`, `schoolMode`, and `balance2StorageRestore`.

## Manual QA

Browser manual QA was not executed due to environment/browser automation limitations around local file access. Restore behavior is covered by regression tests for mixed tournament source mode, full tournament state, MVP keys, 50 selected players, 12 teams, old snapshots, and corrupted tournament state.